### PR TITLE
Adjust card layout to display more items per row

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
     .filters{display:grid;grid-template-columns:repeat(4,minmax(180px,1fr));gap:12px}
     @media (max-width:900px){.filters{grid-template-columns:1fr 1fr}}
     @media (max-width:560px){.filters{grid-template-columns:1fr}}
-    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:14px}
     .card{background:linear-gradient(180deg,var(--panel),#0e1626);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
-    .card img{width:100%;height:160px;object-fit:cover;background:#0b0b10}
-    .card .body{padding:14px}
-    .price{display:flex;gap:10px;align-items:baseline;margin:8px 0}
+    .card img{width:100%;height:140px;object-fit:cover;background:#0b0b10}
+    .card .body{padding:12px}
+    .price{display:flex;gap:10px;align-items:baseline;margin:6px 0}
     .price .old{text-decoration:line-through;color:var(--muted)}
     .badge{display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px}
     .section{padding:26px 0}


### PR DESCRIPTION
## Summary
- shrink the item grid min width and spacing to fit more cards in each row
- reduce card image height and padding so each item tile is more compact

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68dc850916ec832e9d8c328f7204f008