### PR TITLE
Add dedicated pricing and roadmap pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
     h1{margin:0;font-size:18px}
     label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
     select,input[type="range"],button{background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px}
-    select:focus,input[type="range"]:focus,button:focus{outline:2px solid var(--accent);outline-offset:1px}
+    .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
+    .nav-button:hover{background:var(--panel);color:#fff}
+    .nav-button.current{background:linear-gradient(120deg,rgba(34,197,94,.25),rgba(59,130,246,.25));border-color:rgba(34,197,94,.6)}
+    select:focus,input[type="range"]:focus,button:focus,.nav-button:focus{outline:2px solid var(--accent);outline-offset:1px}
     .filters{display:grid;grid-template-columns:repeat(4,minmax(180px,1fr));gap:12px}
     @media (max-width:900px){.filters{grid-template-columns:1fr 1fr}}
     @media (max-width:560px){.filters{grid-template-columns:1fr}}
@@ -61,7 +64,8 @@
         <h1>EconoDeal</h1>
       </div>
       <div class="row" style="gap:12px;align-items:center">
-        <button id="btnPricing" style="white-space:nowrap">Forfaits / prix</button>
+        <a class="nav-button" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
+        <a class="nav-button" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
         <div class="muted">© <span id="year"></span></div>
       </div>
     </div>
@@ -215,22 +219,11 @@
     const countEl     = document.getElementById('resultCount');
     const btnClear    = document.getElementById('btnClear');
     const devError    = document.getElementById('devError');
-    const btnPricing  = document.getElementById('btnPricing');
-    const pricingSection = document.getElementById('pricing');
 
     // Affiche l'année
     const y = new Date().getFullYear();
     document.getElementById('year').textContent = y;
     document.getElementById('yearFooter').textContent = y;
-
-    if(btnPricing && pricingSection){
-      btnPricing.addEventListener('click', () => {
-        pricingSection.scrollIntoView({behavior:'smooth', block:'start'});
-        pricingSection.classList.remove('pricing-pulse');
-        void pricingSection.offsetWidth;
-        pricingSection.classList.add('pricing-pulse');
-      });
-    }
 
     function toNumber(value){
       if(typeof value === 'number' && Number.isFinite(value)) return value;

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>EconoDeal — Forfaits</title>
+  <style>
+    :root{
+      --bg:#0f172a; --panel:#111827; --panel-2:#1f2937; --text:#e5e7eb;
+      --muted:#9ca3af; --accent:#22c55e; --border:#2b3446; --radius:14px;
+    }
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,var(--bg),#0b1020 50%,#0a0f1a);color:var(--text)}
+    header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
+    .container{max-width:1100px;margin:0 auto;padding:18px}
+    .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
+    h1{margin:0;font-size:18px}
+    .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
+    .nav-button:hover{background:var(--panel);color:#fff}
+    .nav-button:focus{outline:2px solid var(--accent);outline-offset:1px}
+    .nav-button.current{background:linear-gradient(120deg,rgba(34,197,94,.25),rgba(59,130,246,.25));border-color:rgba(34,197,94,.6)}
+    .section{padding:36px 0}
+    .muted{color:var(--muted)}
+    .pricing-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin-top:18px}
+    .pricing-card{background:linear-gradient(180deg,var(--panel),#111a2a);border:1px solid var(--border);border-radius:var(--radius);padding:18px;display:flex;flex-direction:column;gap:14px;position:relative;overflow:hidden}
+    .pricing-card::before{content:"";position:absolute;inset:0 0 auto 0;height:3px;background:linear-gradient(90deg,rgba(34,197,94,.6),rgba(59,130,246,.6));opacity:.6}
+    .pricing-card h4{margin:0;font-size:18px}
+    .pricing-price{font-size:26px;font-weight:700;color:#86efac}
+    .pricing-features{list-style:none;padding:0;margin:0;display:grid;gap:8px;font-size:14px;color:var(--muted)}
+    .pricing-tag{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .pricing-highlight{outline:2px solid rgba(34,197,94,.4);outline-offset:4px;transition:outline-color .3s ease}
+    .footer{border-top:1px solid var(--border);padding:20px 0;color:var(--muted);text-align:center}
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container row" style="justify-content:space-between">
+      <div class="row" style="gap:10px;align-items:center">
+        <a class="nav-button" href="index.html" style="padding:8px 12px">Accueil</a>
+        <h1>EconoDeal</h1>
+      </div>
+      <div class="row" style="gap:12px;align-items:center">
+        <a class="nav-button current" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
+        <a class="nav-button" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
+        <div class="muted">© <span id="year"></span></div>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="section">
+      <h2 style="margin:0 0 10px">Forfaits adaptés à vos besoins</h2>
+      <p class="muted" style="max-width:620px">Choisissez l'option qui correspond le mieux à votre façon de surveiller les rabais et liquidations au Canada. Chaque forfait inclut une période d'essai de 7 jours.</p>
+      <div class="pricing-grid">
+        <article class="pricing-card">
+          <div class="pricing-tag">Essentiel</div>
+          <h4>Accès de base</h4>
+          <div class="pricing-price">9,99&nbsp;$</div>
+          <ul class="pricing-features">
+            <li>Accès aux liquidations populaires</li>
+            <li>3 alertes courriel par semaine</li>
+            <li>Historique de prix sur 30 jours</li>
+          </ul>
+        </article>
+        <article class="pricing-card pricing-highlight">
+          <div class="pricing-tag">Le plus populaire</div>
+          <h4>Forfait Avancé</h4>
+          <div class="pricing-price">19,99&nbsp;$</div>
+          <ul class="pricing-features">
+            <li>Accès illimité au catalogue</li>
+            <li>Alertes personnalisées en temps réel</li>
+            <li>Listes partagées avec votre équipe</li>
+          </ul>
+        </article>
+        <article class="pricing-card">
+          <div class="pricing-tag">Premium</div>
+          <h4>Analyse IA complète</h4>
+          <div class="pricing-price">29,99&nbsp;$</div>
+          <ul class="pricing-features">
+            <li>Alertes illimitées multicanal</li>
+            <li>Analyse des prix assistée par IA</li>
+            <li>Prévisions de tendances du marché</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <div class="container footer">
+    © <span id="yearFooter"></span> EconoDeal · Tous droits réservés
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const y = new Date().getFullYear();
+      document.getElementById('year').textContent = y;
+      document.getElementById('yearFooter').textContent = y;
+    });
+  </script>
+</body>
+</html>

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>EconoDeal — Roadmap</title>
+  <style>
+    :root{
+      --bg:#0f172a; --panel:#111827; --panel-2:#1f2937; --text:#e5e7eb;
+      --muted:#9ca3af; --accent:#22c55e; --border:#2b3446; --radius:14px;
+    }
+    *{box-sizing:border-box}
+    body{margin:0;font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,var(--bg),#0b1020 50%,#0a0f1a);color:var(--text)}
+    header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
+    .container{max-width:1100px;margin:0 auto;padding:18px}
+    .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
+    h1{margin:0;font-size:18px}
+    .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
+    .nav-button:hover{background:var(--panel);color:#fff}
+    .nav-button:focus{outline:2px solid var(--accent);outline-offset:1px}
+    .nav-button.current{background:linear-gradient(120deg,rgba(34,197,94,.25),rgba(59,130,246,.25));border-color:rgba(34,197,94,.6)}
+    .section{padding:36px 0}
+    .muted{color:var(--muted)}
+    .roadmap{background:linear-gradient(180deg,var(--panel),#101b2d);border:1px solid var(--border);border-radius:var(--radius);padding:22px;display:grid;gap:18px;margin-top:22px;position:relative;overflow:hidden}
+    .roadmap::before{content:"Roadmap stratégique";position:absolute;top:16px;right:-80px;width:220px;text-align:center;transform:rotate(45deg);background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.35);color:#86efac;padding:6px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase}
+    .roadmap-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+    .roadmap-card{background:var(--panel-2);border:1px solid var(--border);border-radius:12px;padding:18px;display:flex;flex-direction:column;gap:12px;position:relative;overflow:hidden}
+    .roadmap-year{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+    .roadmap-year strong{display:block;font-size:20px;color:var(--text)}
+    .roadmap-card ul{margin:0;padding-left:18px;display:grid;gap:6px;font-size:14px;color:var(--muted)}
+    .roadmap-ai{border-left:3px solid var(--accent);padding-left:12px;background:rgba(34,197,94,.08);border-radius:8px}
+    .footer{border-top:1px solid var(--border);padding:20px 0;color:var(--muted);text-align:center}
+    @media (max-width:600px){.roadmap::before{right:-120px}}
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container row" style="justify-content:space-between">
+      <div class="row" style="gap:10px;align-items:center">
+        <a class="nav-button" href="index.html" style="padding:8px 12px">Accueil</a>
+        <h1>EconoDeal</h1>
+      </div>
+      <div class="row" style="gap:12px;align-items:center">
+        <a class="nav-button" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
+        <a class="nav-button current" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
+        <div class="muted">© <span id="year"></span></div>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="section">
+      <h2 style="margin:0 0 10px">Notre feuille de route</h2>
+      <p class="muted" style="max-width:640px">Une vision triennale pour propulser EconoDeal sur la scène internationale, avec une intégration progressive de l'intelligence artificielle au cœur de nos services.</p>
+      <div class="roadmap">
+        <div class="roadmap-grid">
+          <article class="roadmap-card">
+            <div class="roadmap-year"><strong>Année 1</strong> Canada</div>
+            <ul>
+              <li>Consolider la couverture des détaillants nationaux.</li>
+              <li>Optimiser les alertes de rabais en temps réel.</li>
+              <li>Lancer des tableaux de bord régionaux bilingues.</li>
+            </ul>
+          </article>
+          <article class="roadmap-card">
+            <div class="roadmap-year"><strong>Année 2</strong> États-Unis</div>
+            <ul>
+              <li>Élargir le catalogue aux grandes bannières américaines.</li>
+              <li>Déployer la surveillance des stocks multi-états.</li>
+              <li>Introduire l'analyse prédictive des tendances d'achat.</li>
+            </ul>
+          </article>
+          <article class="roadmap-card roadmap-ai">
+            <div class="roadmap-year"><strong>Année 3</strong> Europe</div>
+            <ul>
+              <li>Localiser l'expérience pour les principaux marchés européens.</li>
+              <li>Activer un moteur de recommandations IA multilingue.</li>
+              <li>Automatiser les stratégies de prix grâce à l'apprentissage continu.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="container footer">
+    © <span id="yearFooter"></span> EconoDeal · Tous droits réservés
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const y = new Date().getFullYear();
+      document.getElementById('year').textContent = y;
+      document.getElementById('yearFooter').textContent = y;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add navigation buttons in the main header that open dedicated pricing and roadmap pages
- create standalone pricing and roadmap views that reuse the existing styling and copy for consistency

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc8bc88144832e97bc04555cf5025a