### PR TITLE
Add registration gate with client counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     h1{margin:0;font-size:18px}
     label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
     select,input[type="range"],button{background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px}
+    input[type="text"],input[type="email"]{width:100%;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px}
     .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
     .nav-button:hover{background:var(--panel);color:#fff}
     .nav-button.current{background:linear-gradient(120deg,rgba(34,197,94,.25),rgba(59,130,246,.25));border-color:rgba(34,197,94,.6)}
@@ -55,9 +56,42 @@
     .roadmap-card ul{margin:0;padding-left:18px;display:grid;gap:6px;font-size:14px;color:var(--muted)}
     .roadmap-ai{border-left:3px solid var(--accent);padding-left:12px;background:rgba(34,197,94,.08);border-radius:8px}
     @media (max-width:600px){.roadmap::before{right:-120px}}
+    #registrationOverlay{position:fixed;inset:0;background:rgba(15,23,42,.95);display:flex;align-items:center;justify-content:center;padding:20px;z-index:2000}
+    #registrationOverlay.hidden{display:none}
+    .registration-card{background:linear-gradient(180deg,var(--panel),#0e1626);border:1px solid var(--border);border-radius:var(--radius);max-width:420px;width:100%;padding:26px;display:grid;gap:16px;box-shadow:0 24px 60px rgba(15,23,42,.5)}
+    .registration-card h2{margin:0}
+    .registration-card form{display:grid;gap:12px}
+    .checkbox-row{display:flex;gap:10px;align-items:flex-start;background:rgba(34,197,94,.05);border:1px solid rgba(34,197,94,.3);padding:12px;border-radius:10px}
+    .checkbox-row input[type="checkbox"]{margin-top:4px}
+    .registration-card button{background:linear-gradient(120deg,rgba(34,197,94,.9),rgba(59,130,246,.85));color:#fff;border:none;font-weight:600;cursor:pointer;transition:opacity .2s ease,transform .2s ease}
+    .registration-card button:hover:not(:disabled){opacity:.9;transform:translateY(-1px)}
+    .registration-card button:disabled{opacity:.45;cursor:not-allowed}
+    body.overlay-active{overflow:hidden}
+    body.overlay-active header,body.overlay-active main,body.overlay-active .footer{filter:blur(2px);pointer-events:none;user-select:none}
   </style>
 </head>
-<body>
+<body class="overlay-active">
+  <div id="registrationOverlay" role="dialog" aria-modal="true" aria-labelledby="registrationTitle">
+    <div class="registration-card">
+      <h2 id="registrationTitle">Accès réservé aux membres</h2>
+      <p class="muted" style="margin:0">Rejoignez <strong><span data-client-count>0</span></strong> chasseurs de rabais et accédez au catalogue complet.</p>
+      <form id="registrationForm">
+        <div>
+          <label for="fullName">Nom complet</label>
+          <input id="fullName" name="fullName" type="text" placeholder="Entrez votre nom" autocomplete="name" required />
+        </div>
+        <div>
+          <label for="email">Courriel</label>
+          <input id="email" name="email" type="email" placeholder="nom@exemple.com" autocomplete="email" required />
+        </div>
+        <div class="checkbox-row">
+          <input id="regulationCheckbox" name="regulation" type="checkbox" required />
+          <label for="regulationCheckbox" style="margin:0">Je confirme avoir lu et accepté les réglementations d'utilisation du site.</label>
+        </div>
+        <button id="registrationSubmit" type="submit" disabled>S'inscrire et accéder</button>
+      </form>
+    </div>
+  </div>
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
@@ -66,6 +100,7 @@
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
         <a class="nav-button" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
+        <div class="muted" style="white-space:nowrap">Clients inscrits&nbsp;: <span data-client-count>0</span></div>
         <div class="muted">© <span id="year"></span></div>
       </div>
     </div>
@@ -197,6 +232,106 @@
   <script>
   // === Initialisation sûre ===
   document.addEventListener('DOMContentLoaded', () => {
+    const overlay = document.getElementById('registrationOverlay');
+    const form = document.getElementById('registrationForm');
+    const submitBtn = document.getElementById('registrationSubmit');
+    const regulationCheckbox = document.getElementById('regulationCheckbox');
+    const clientCountDisplays = Array.from(document.querySelectorAll('[data-client-count]'));
+
+    function safeGet(key){
+      try{
+        return localStorage.getItem(key);
+      }catch(err){
+        console.warn('Stockage local indisponible', err);
+        return null;
+      }
+    }
+
+    function safeSet(key, value){
+      try{
+        localStorage.setItem(key, value);
+      }catch(err){
+        console.warn('Impossible d\'enregistrer les données', err);
+      }
+    }
+
+    function parseCount(value){
+      const parsed = parseInt(value ?? '0', 10);
+      return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    }
+
+    function getClientCount(){
+      return parseCount(safeGet('econodealClientCount'));
+    }
+
+    function setClientCount(value){
+      safeSet('econodealClientCount', String(Math.max(0, value)));
+    }
+
+    function updateClientCountDisplays(){
+      const formatter = new Intl.NumberFormat('fr-CA');
+      const count = getClientCount();
+      clientCountDisplays.forEach(el => {
+        el.textContent = formatter.format(count);
+      });
+    }
+
+    function hideOverlay(){
+      if(!overlay) return;
+      overlay.classList.add('hidden');
+      overlay.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('overlay-active');
+    }
+
+    function showOverlay(){
+      if(!overlay) return;
+      overlay.classList.remove('hidden');
+      overlay.removeAttribute('aria-hidden');
+      document.body.classList.add('overlay-active');
+      updateClientCountDisplays();
+    }
+
+    updateClientCountDisplays();
+
+    const alreadyRegistered = safeGet('econodealClientRegistered') === 'true';
+    if(alreadyRegistered){
+      hideOverlay();
+    }else{
+      showOverlay();
+    }
+
+    if(submitBtn && regulationCheckbox){
+      submitBtn.disabled = !regulationCheckbox.checked;
+      regulationCheckbox.addEventListener('change', () => {
+        submitBtn.disabled = !regulationCheckbox.checked;
+      });
+    }
+
+    if(form){
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        if(!form.reportValidity()) return;
+
+        const wasRegistered = safeGet('econodealClientRegistered') === 'true';
+        if(!wasRegistered){
+          const current = getClientCount();
+          setClientCount(current + 1);
+        }
+
+        const payload = {
+          name: (form.fullName?.value ?? '').trim(),
+          email: (form.email?.value ?? '').trim(),
+          consent: true,
+          registeredAt: new Date().toISOString()
+        };
+
+        safeSet('econodealUser', JSON.stringify(payload));
+        safeSet('econodealClientRegistered', 'true');
+        updateClientCountDisplays();
+        hideOverlay();
+      });
+    }
+
     const STORES = [
       {label:'Home Depot', slug:'home-depot'},
       {label:'Walmart', slug:'walmart'},


### PR DESCRIPTION
## Summary
- add a full-screen registration overlay that requires visitors to register and accept the regulations before accessing the catalogue
- persist registration information and maintain a local client counter displayed both in the overlay and the header navigation
- style the new registration flow and protect the main content while the overlay is active

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc8d0a1308832eb602d8e174afa24a