### PR TITLE
Add password-protected admin view for registrations

### DIFF
--- a/admin/inscriptions.html
+++ b/admin/inscriptions.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>EconoDeal — Accès aux inscriptions</title>
+  <style>
+    :root{
+      --bg:#0f172a; --panel:#111827; --panel-2:#1f2937; --text:#e5e7eb;
+      --muted:#9ca3af; --accent:#22c55e; --border:#2b3446; --radius:14px;
+      --danger:#f87171;
+    }
+    *{box-sizing:border-box}
+    body{
+      margin:0;
+      font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;
+      background:linear-gradient(180deg,var(--bg),#0b1020 50%,#0a0f1a);
+      color:var(--text);
+      min-height:100vh;
+      display:flex;
+      flex-direction:column;
+    }
+    header{
+      border-bottom:1px solid var(--border);
+      background:rgba(15,23,42,.85);
+      backdrop-filter:blur(8px);
+      position:sticky;
+      top:0;
+      z-index:10;
+    }
+    .container{max-width:1000px;margin:0 auto;padding:18px}
+    .breadcrumb{font-size:14px;color:var(--muted)}
+    h1{margin:12px 0;font-size:26px}
+    p{color:var(--muted);max-width:720px}
+    main{flex:1;width:100%}
+    table{width:100%;border-collapse:collapse;background:var(--panel-2);border-radius:var(--radius);overflow:hidden}
+    thead{background:rgba(34,197,94,.08)}
+    th,td{padding:12px 14px;text-align:left;border-bottom:1px solid var(--border);font-size:14px}
+    th{font-weight:600;color:#bbf7d0}
+    tbody tr:last-child td{border-bottom:none}
+    tbody tr:nth-child(even){background:rgba(15,23,42,.35)}
+    .badge{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(34,197,94,.18);color:#86efac;font-size:12px}
+    .actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0}
+    button{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 14px;font-size:14px;cursor:pointer;transition:background .2s ease,color .2s ease}
+    button:hover{background:var(--panel-2)}
+    .muted{color:var(--muted)}
+    .empty{margin:30px 0;padding:22px;border:1px dashed var(--border);border-radius:var(--radius);text-align:center;color:var(--muted)}
+    footer{border-top:1px solid var(--border);padding:18px 0;color:var(--muted);text-align:center;font-size:14px}
+
+    .overlay{position:fixed;inset:0;background:rgba(15,23,42,.96);display:flex;align-items:center;justify-content:center;padding:20px;z-index:200}
+    .overlay.hidden{display:none}
+    .overlay-card{background:linear-gradient(180deg,var(--panel),#0e1626);border:1px solid var(--border);border-radius:var(--radius);max-width:360px;width:100%;padding:26px;display:grid;gap:16px;box-shadow:0 24px 60px rgba(15,23,42,.45)}
+    .overlay h2{margin:0}
+    .overlay form{display:grid;gap:12px}
+    label{font-size:13px;color:var(--muted)}
+    input[type="password"]{width:100%;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;font-size:14px}
+    .error{color:var(--danger);font-size:13px;min-height:18px}
+  </style>
+</head>
+<body>
+  <div id="accessOverlay" class="overlay" role="dialog" aria-modal="true" aria-labelledby="overlayTitle">
+    <div class="overlay-card">
+      <h2 id="overlayTitle">Espace sécurisé</h2>
+      <p class="muted" style="margin:0">Entrez le mot de passe administrateur pour consulter la liste des inscriptions.</p>
+      <form id="accessForm">
+        <div>
+          <label for="adminPassword">Mot de passe</label>
+          <input id="adminPassword" name="password" type="password" autocomplete="current-password" required />
+        </div>
+        <div class="error" id="accessError" aria-live="assertive"></div>
+        <button type="submit">Déverrouiller</button>
+      </form>
+    </div>
+  </div>
+
+  <header>
+    <div class="container">
+      <div class="breadcrumb">🏠 <a href="../index.html" style="color:inherit;text-decoration:none">Retour à l'accueil</a> · Accès privé</div>
+      <h1>Inscriptions des membres</h1>
+      <p>Cette page affiche les contacts collectés via le formulaire d'inscription. Le contenu est stocké localement sur le navigateur utilisé. Pour une sécurité renforcée, changez le mot de passe dans ce fichier après chaque partage.</p>
+    </div>
+  </header>
+
+  <main>
+    <div class="container">
+      <div class="actions">
+        <span class="badge"><strong id="entryCount">0</strong>&nbsp;inscriptions</span>
+        <button id="btnRefresh" type="button">Actualiser</button>
+        <button id="btnExport" type="button">Exporter en CSV</button>
+      </div>
+      <div id="tableWrapper"></div>
+    </div>
+  </main>
+
+  <footer>
+    © <span id="year"></span> EconoDeal — Accès réservé
+  </footer>
+
+  <script>
+    const PASSWORD_HASH = '6136659243031c1b1d6c142aba3ee6b3ce0f2a1097a9e4a0b1bd11b54845e01c';
+
+    const overlay = document.getElementById('accessOverlay');
+    const form = document.getElementById('accessForm');
+    const passwordInput = document.getElementById('adminPassword');
+    const errorEl = document.getElementById('accessError');
+    const tableWrapper = document.getElementById('tableWrapper');
+    const countEl = document.getElementById('entryCount');
+    const btnRefresh = document.getElementById('btnRefresh');
+    const btnExport = document.getElementById('btnExport');
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    function safeRead(key){
+      try{
+        return localStorage.getItem(key);
+      }catch(err){
+        console.warn('Lecture impossible', err);
+        return null;
+      }
+    }
+
+    function parseJson(value){
+      if(!value) return null;
+      try{
+        return JSON.parse(value);
+      }catch(err){
+        console.warn('JSON invalide', err);
+        return null;
+      }
+    }
+
+    function formatDate(value){
+      if(!value) return '';
+      const date = new Date(value);
+      if(Number.isNaN(date.getTime())) return value;
+      return new Intl.DateTimeFormat('fr-CA', {
+        dateStyle:'medium',
+        timeStyle:'short'
+      }).format(date);
+    }
+
+    function splitNames(name){
+      const parts = (name || '')
+        .split(/\s+/)
+        .map(part => part.trim())
+        .filter(Boolean);
+      if(parts.length === 0){
+        return { firstName:'', lastName:'' };
+      }
+      const [firstName, ...rest] = parts;
+      return {
+        firstName,
+        lastName: rest.join(' ')
+      };
+    }
+
+    function sanitizeEntry(entry){
+      if(!entry || typeof entry !== 'object') return null;
+      const name = typeof entry.name === 'string' ? entry.name.trim() : '';
+      const email = typeof entry.email === 'string' ? entry.email.trim().toLowerCase() : '';
+      if(!email) return null;
+      return {
+        name,
+        email,
+        registeredAt: typeof entry.registeredAt === 'string' ? entry.registeredAt : ''
+      };
+    }
+
+    function getRegistrations(){
+      const parsed = parseJson(safeRead('econodealRegistrations'));
+      if(!Array.isArray(parsed)) return [];
+      return parsed
+        .map(sanitizeEntry)
+        .filter(Boolean)
+        .sort((a,b) => (a.registeredAt > b.registeredAt ? -1 : 1));
+    }
+
+    function renderTable(){
+      const entries = getRegistrations();
+      countEl.textContent = entries.length.toString();
+
+      if(entries.length === 0){
+        tableWrapper.innerHTML = '<div class="empty">Aucune inscription n\'est enregistrée sur ce navigateur.</div>';
+        return;
+      }
+
+      const rows = entries.map(entry => {
+        const parts = splitNames(entry.name);
+        const firstName = parts.firstName || '—';
+        const lastName = parts.lastName || '—';
+        const registered = formatDate(entry.registeredAt) || '—';
+        return `
+          <tr>
+            <td>${firstName}</td>
+            <td>${lastName}</td>
+            <td><a href="mailto:${entry.email}" style="color:inherit">${entry.email}</a></td>
+            <td>${registered}</td>
+          </tr>
+        `;
+      }).join('');
+
+      tableWrapper.innerHTML = `
+        <div style="overflow:auto;border-radius:var(--radius);border:1px solid var(--border)">
+          <table>
+            <thead>
+              <tr>
+                <th>Prénom</th>
+                <th>Nom</th>
+                <th>Courriel</th>
+                <th>Date d'inscription</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      `;
+    }
+
+    function toCSV(entries){
+      const header = ['prenom','nom','courriel','date_inscription'];
+      const lines = entries.map(entry => {
+        const parts = splitNames(entry.name);
+        const values = [parts.firstName, parts.lastName, entry.email, entry.registeredAt];
+        return values.map(value => {
+          const safe = (value || '').replace(/"/g,'""');
+          return `"${safe}"`;
+        }).join(',');
+      });
+      return [header.join(','), ...lines].join('\n');
+    }
+
+    function downloadCSV(){
+      const entries = getRegistrations();
+      if(entries.length === 0){
+        alert('Aucune inscription à exporter.');
+        return;
+      }
+      const blob = new Blob([toCSV(entries)], { type:'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `inscriptions-econodeal-${new Date().toISOString().slice(0,10)}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
+
+    async function hashValue(value){
+      const encoder = new TextEncoder();
+      const data = encoder.encode(value);
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      return hashArray.map(b => b.toString(16).padStart(2,'0')).join('');
+    }
+
+    async function verifyPassword(password){
+      const digest = await hashValue(password);
+      return digest === PASSWORD_HASH;
+    }
+
+    function unlock(){
+      overlay.classList.add('hidden');
+      document.body.classList.remove('locked');
+      renderTable();
+    }
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      errorEl.textContent = '';
+      const password = passwordInput.value.trim();
+      if(!password){
+        errorEl.textContent = 'Veuillez entrer le mot de passe.';
+        return;
+      }
+      form.querySelector('button[type="submit"]').disabled = true;
+      try{
+        const valid = await verifyPassword(password);
+        if(valid){
+          unlock();
+        }else{
+          errorEl.textContent = 'Mot de passe invalide.';
+          form.querySelector('button[type="submit"]').disabled = false;
+          passwordInput.value = '';
+          passwordInput.focus();
+        }
+      }catch(err){
+        console.error('Erreur de vérification', err);
+        errorEl.textContent = 'Une erreur est survenue. Réessayez.';
+        form.querySelector('button[type="submit"]').disabled = false;
+      }
+    });
+
+    btnRefresh.addEventListener('click', renderTable);
+    btnExport.addEventListener('click', downloadCSV);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -238,6 +238,16 @@
     const regulationCheckbox = document.getElementById('regulationCheckbox');
     const clientCountDisplays = Array.from(document.querySelectorAll('[data-client-count]'));
 
+    function parseJson(value){
+      if(!value) return null;
+      try{
+        return JSON.parse(value);
+      }catch(err){
+        console.warn('Impossible de lire les données existantes', err);
+        return null;
+      }
+    }
+
     function safeGet(key){
       try{
         return localStorage.getItem(key);
@@ -253,6 +263,51 @@
       }catch(err){
         console.warn('Impossible d\'enregistrer les données', err);
       }
+    }
+
+    function cleanText(value){
+      return typeof value === 'string' ? value.trim() : '';
+    }
+
+    function getRegistrations(){
+      const parsed = parseJson(safeGet('econodealRegistrations'));
+      if(!Array.isArray(parsed)) return [];
+      return parsed
+        .filter(item => item && typeof item === 'object')
+        .map(item => ({
+          name: cleanText(item.name),
+          email: cleanText(item.email).toLowerCase(),
+          registeredAt: cleanText(item.registeredAt)
+        }))
+        .filter(item => item.email);
+    }
+
+    function saveRegistrations(items){
+      safeSet('econodealRegistrations', JSON.stringify(items));
+    }
+
+    function upsertRegistration(entry){
+      const collection = getRegistrations();
+      const email = cleanText(entry.email).toLowerCase();
+      if(!email) return;
+
+      const normalized = {
+        name: cleanText(entry.name),
+        email,
+        registeredAt: cleanText(entry.registeredAt)
+      };
+
+      const existingIndex = collection.findIndex(item => item.email === email);
+      if(existingIndex >= 0){
+        collection[existingIndex] = {
+          ...collection[existingIndex],
+          ...normalized
+        };
+      }else{
+        collection.push(normalized);
+      }
+
+      saveRegistrations(collection);
     }
 
     function parseCount(value){
@@ -326,6 +381,7 @@
         };
 
         safeSet('econodealUser', JSON.stringify(payload));
+        upsertRegistration(payload);
         safeSet('econodealClientRegistered', 'true');
         updateClientCountDisplays();
         hideOverlay();


### PR DESCRIPTION
## Summary
- persist registration submissions in a local registry so they can be reviewed later
- add a password-protected admin page that lists member registrations and supports CSV export

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc90118308832eae02096bbe9e490a