### PR TITLE
Filter Canadian Tire branches without data

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,6 +533,21 @@
       return `data/${s}/${c}.json`;
     }
 
+    async function canadianTireHasData(slug){
+      if(DEFAULT_BRANCH_SLUGS.has(slug)) return true;
+      const path = `data/canadian-tire/${slug}.json`;
+      try{
+        const head = await fetch(path, {method:'HEAD'});
+        if(head.ok) return true;
+      }catch(_err){ /* noop */ }
+      try{
+        const res = await fetch(path, {cache:'no-store'});
+        return res.ok;
+      }catch(_err){
+        return false;
+      }
+    }
+
     async function loadCanadianTireDirectory(){
       const store = STORES.find(entry => entry.slug === 'canadian-tire');
       if(!store) return;
@@ -545,6 +560,7 @@
         for(const entry of json){
           const rawSlug = typeof entry.slug === 'string' && entry.slug ? entry.slug : slugify(entry.nickname || entry.city || entry.label);
           if(!rawSlug || seen.has(rawSlug)) continue;
+          if(!await canadianTireHasData(rawSlug)) continue;
           const label = (entry.nickname || (entry.label || '').replace(/^Canadian Tire\s*/i, '') || entry.city || rawSlug).trim();
           const city = entry.city || label;
           seen.set(rawSlug, {label, slug: rawSlug, city});


### PR DESCRIPTION
## Summary
- skip Canadian Tire branches that do not have a corresponding data file when loading the directory
- avoid presenting empty city options by checking that each branch file exists before adding it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2ae5318c832e8b88d80c41f2f61e