### PR TITLE
Expand Montreal postal code coverage for postal search

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,7 +420,8 @@
           'H1A','H1B','H1C','H1E','H1G','H1H','H1J','H1K','H1L','H1M','H1N','H1P','H1R','H1S','H1T','H1V','H1W','H1X','H1Y','H1Z',
           'H2A','H2B','H2C','H2E','H2G','H2H','H2J','H2K','H2L','H2M','H2N','H2P','H2R','H2S','H2T','H2V','H2W','H2X','H2Y','H2Z',
           'H3A','H3B','H3C','H3E','H3G','H3H','H3J','H3K','H3L','H3M','H3N','H3R','H3S','H3T','H3V','H3W','H3X','H3Y','H3Z',
-          'H4A','H4B','H4C','H4E','H4G','H4H','H4J','H4K','H4L','H4M','H4N','H4P','H4R','H4S','H4T','H4V','H4W','H4X'
+          'H4A','H4B','H4C','H4E','H4G','H4H','H4J','H4K','H4L','H4M','H4N','H4P','H4R','H4S','H4T','H4V','H4W','H4X',
+          'H8N','H8P','H8R','H8S','H8T','H8Y','H8Z','H9A','H9B','H9C','H9E','H9G','H9H','H9J','H9K','H9P','H9R','H9S','H9W','H9X'
         ]
       },
       {


### PR DESCRIPTION
## Summary
- include additional H8 and H9 prefixes in the Montréal postal directory so West Island codes such as H9H are recognized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd3be7a070832eb5b302aaeea32c7d