### PR TITLE
Add Best Buy option to store filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
           <label for="storeSelect">Magasin</label>
           <select id="storeSelect">
             <option value="">(Tous)</option>
+            <option>Best Buy</option>
             <option>Home Depot</option>
             <option>Walmart</option>
             <option>Canadian Tire</option>
@@ -403,7 +404,10 @@
 
     const DEFAULT_BRANCH_SLUGS = new Set(baseBranches().map(branch => branch.slug));
 
+    const bestBuyBranches = baseBranches().map(branch => ({...branch, hasData:false}));
+
     const STORES = [
+      {label:'Best Buy', slug:'best-buy', branches: bestBuyBranches},
       {label:'Home Depot', slug:'home-depot', branches: baseBranches()},
       {label:'Walmart', slug:'walmart', branches: baseBranches()},
       {label:'Canadian Tire', slug:'canadian-tire', branches: baseBranches()},


### PR DESCRIPTION
## Summary
- add Best Buy to the store selector dropdown on the landing page
- register Best Buy in the client-side store definitions with branches marked as coming soon

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68dd417968c4832ebfcf7343fd06d010