### PR TITLE
Restore Best Buy city list

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,6 @@
             <option>Rona</option>
             <option>Patrick Morin</option>
             <option>Sporting Life</option>
-            <option>Best Buy</option>
           </select>
         </div>
         <div>
@@ -451,19 +450,20 @@
       ];
     }
 
-    const DEFAULT_BRANCH_SLUGS = new Set(baseBranches().map(branch => branch.slug));
-
-    const baseBestBuyBranches = baseBranches().map(branch => ({...branch, hasData:false}));
+    const DEFAULT_BRANCH_SLUGS = new Set([
+      ...baseBranches().map(branch => branch.slug),
+      'montreal-best-buy',
+      'laval-best-buy'
+    ]);
 
     const STORES = [
-      {label:'Best Buy', slug:'best-buy', branches: baseBestBuyBranches},
+      {label:'Best Buy', slug:'best-buy', branches: fullBestBuyBranches()},
       {label:'Home Depot', slug:'home-depot', branches: baseBranches()},
       {label:'Walmart', slug:'walmart', branches: baseBranches()},
       {label:'Canadian Tire', slug:'canadian-tire', branches: baseBranches()},
       {label:'Rona', slug:'rona', branches: baseBranches()},
       {label:'Patrick Morin', slug:'patrick-morin', branches: baseBranches()},
-      {label:'Sporting Life', slug:'sporting-life', branches: baseBranches()},
-      {label:'Best Buy', slug:'best-buy', branches: fullBestBuyBranches()}
+      {label:'Sporting Life', slug:'sporting-life', branches: baseBranches()}
     ];
 
     const POSTAL_DIRECTORY = [


### PR DESCRIPTION
## Summary
- remove the duplicate Best Buy entry from the store selector
- ensure Best Buy uses the full branch directory while keeping Montréal/Laval defaults available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd474f64f4832e861204e7779dddf2