### PR TITLE
Add reseller-focused logo and branding badge

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,11 +1,28 @@
-<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72" role="img" aria-labelledby="title desc">
+  <title id="title">EconoDeal</title>
+  <desc id="desc">Logo lumineux illustrant une flèche de croissance et une poignée de main pour les revendeurs.</desc>
   <defs>
-    <linearGradient id='g' x1='0' x2='1' y1='0' y2='1'>
-      <stop offset='0%' stop-color='#22c55e'/>
-      <stop offset='100%' stop-color='#60a5fa'/>
+    <linearGradient id="badge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e" />
+      <stop offset="55%" stop-color="#34d399" />
+      <stop offset="100%" stop-color="#60a5fa" />
     </linearGradient>
+    <linearGradient id="spark" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#facc15" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="6" flood-color="#22c55e" flood-opacity="0.35" />
+    </filter>
   </defs>
-  <rect x='6' y='10' width='34' height='26' rx='6' stroke='url(#g)' stroke-width='3' fill='none'/>
-  <path d='M40 31l12 12' stroke='url(#g)' stroke-width='4' stroke-linecap='round'/>
-  <path d='M13 46h34l-2 8H15l-2-8z' stroke='url(#g)' stroke-width='3' fill='none'/>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 50a18 18 0 1 1-36 0 18 18 0 0 1 36 0Z" fill="rgba(15,23,42,0.92)" stroke="url(#badge)" stroke-width="3" filter="url(#glow)" />
+    <path d="M22 20h18a8 8 0 0 1 8 8v8" fill="rgba(15,23,42,0.8)" stroke="url(#badge)" stroke-width="3" />
+    <path d="M20 42 31 53c2.4 2.4 6.3 2.4 8.7 0l3.6-3.6a5 5 0 0 0 0-7l-4-4" stroke="url(#badge)" stroke-width="3.4" />
+    <path d="M24 38 34 48a3.5 3.5 0 0 0 5 0l3.2-3.2a3.5 3.5 0 0 0 0-5l-9-9" stroke="#c4f1f9" stroke-width="2.2" />
+    <path d="M38 22h12l-3.2-3.2" stroke="url(#badge)" stroke-width="3" />
+    <path d="m44 16 6-6" stroke="url(#spark)" stroke-width="3" />
+    <circle cx="50" cy="10" r="3" fill="#facc15" stroke="#fdf5d5" stroke-width="1.5" />
+    <path d="M17 30c-3-3-3-8 0-11l5.5-5.5" stroke="#38bdf8" stroke-width="2.5" />
+  </g>
 </svg>

--- a/best-deals.html
+++ b/best-deals.html
@@ -14,7 +14,12 @@
     header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
     .container{max-width:1100px;margin:0 auto;padding:18px}
     .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
-    h1{margin:0;font-size:18px}
+    .brand{display:inline-flex;align-items:center;gap:12px;padding:6px 14px;border-radius:14px;text-decoration:none;color:var(--text);background:rgba(34,197,94,.08);border:1px solid rgba(34,197,94,.35);transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+    .brand:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(34,197,94,.15);background:rgba(34,197,94,.12)}
+    .brand img{width:46px;height:46px;display:block}
+    .brand-text{display:flex;flex-direction:column;line-height:1.1}
+    .brand-title{margin:0;font-size:18px;font-weight:700;letter-spacing:-.01em}
+    .brand-tagline{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:#86efac;font-weight:600}
     h2{margin:0;font-size:24px}
     .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
     .nav-button:hover{background:var(--panel);color:#fff}
@@ -72,8 +77,13 @@
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
-        <a class="nav-button" href="index.html" style="padding:8px 12px">Accueil</a>
-        <h1>EconoDeal</h1>
+        <a class="brand" href="index.html">
+          <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs" />
+          <span class="brand-text">
+            <span class="brand-title">EconoDeal</span>
+            <span class="brand-tagline">Revendeur gagnant</span>
+          </span>
+        </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button current" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,12 @@
     header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter: blur(8px);border-bottom:1px solid var(--border)}
     .container{max-width:1100px;margin:0 auto;padding:18px}
     .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
-    h1{margin:0;font-size:18px}
+    .brand{display:inline-flex;align-items:center;gap:12px;padding:6px 14px;border-radius:14px;text-decoration:none;color:var(--text);background:rgba(34,197,94,.08);border:1px solid rgba(34,197,94,.35);transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+    .brand:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(34,197,94,.15);background:rgba(34,197,94,.12)}
+    .brand img{width:46px;height:46px;display:block}
+    .brand-text{display:flex;flex-direction:column;line-height:1.1}
+    .brand-title{margin:0;font-size:18px;font-weight:700;letter-spacing:-.01em}
+    .brand-tagline{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:#86efac;font-weight:600}
     label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
     select,input[type="range"],button{background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px}
     input[type="text"],input[type="email"]{width:100%;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px}
@@ -104,7 +109,13 @@
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
-        <h1>EconoDeal</h1>
+        <a class="brand" href="index.html">
+          <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs" />
+          <span class="brand-text">
+            <span class="brand-title">EconoDeal</span>
+            <span class="brand-tagline">Revendeur gagnant</span>
+          </span>
+        </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>

--- a/pricing.html
+++ b/pricing.html
@@ -14,7 +14,12 @@
     header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
     .container{max-width:1100px;margin:0 auto;padding:18px}
     .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
-    h1{margin:0;font-size:18px}
+    .brand{display:inline-flex;align-items:center;gap:12px;padding:6px 14px;border-radius:14px;text-decoration:none;color:var(--text);background:rgba(34,197,94,.08);border:1px solid rgba(34,197,94,.35);transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+    .brand:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(34,197,94,.15);background:rgba(34,197,94,.12)}
+    .brand img{width:46px;height:46px;display:block}
+    .brand-text{display:flex;flex-direction:column;line-height:1.1}
+    .brand-title{margin:0;font-size:18px;font-weight:700;letter-spacing:-.01em}
+    .brand-tagline{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:#86efac;font-weight:600}
     .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
     .nav-button:hover{background:var(--panel);color:#fff}
     .nav-button:focus{outline:2px solid var(--accent);outline-offset:1px}
@@ -36,8 +41,13 @@
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
-        <a class="nav-button" href="index.html" style="padding:8px 12px">Accueil</a>
-        <h1>EconoDeal</h1>
+        <a class="brand" href="index.html">
+          <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs" />
+          <span class="brand-text">
+            <span class="brand-title">EconoDeal</span>
+            <span class="brand-tagline">Revendeur gagnant</span>
+          </span>
+        </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>

--- a/roadmap.html
+++ b/roadmap.html
@@ -14,7 +14,12 @@
     header{position:sticky;top:0;z-index:20;background:rgba(15,23,42,.85);backdrop-filter:blur(8px);border-bottom:1px solid var(--border)}
     .container{max-width:1100px;margin:0 auto;padding:18px}
     .row{display:flex;gap:16px;flex-wrap:wrap;align-items:center}
-    h1{margin:0;font-size:18px}
+    .brand{display:inline-flex;align-items:center;gap:12px;padding:6px 14px;border-radius:14px;text-decoration:none;color:var(--text);background:rgba(34,197,94,.08);border:1px solid rgba(34,197,94,.35);transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+    .brand:hover{transform:translateY(-1px);box-shadow:0 12px 28px rgba(34,197,94,.15);background:rgba(34,197,94,.12)}
+    .brand img{width:46px;height:46px;display:block}
+    .brand-text{display:flex;flex-direction:column;line-height:1.1}
+    .brand-title{margin:0;font-size:18px;font-weight:700;letter-spacing:-.01em}
+    .brand-tagline{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:#86efac;font-weight:600}
     .nav-button{display:inline-flex;align-items:center;justify-content:center;background:var(--panel-2);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .2s ease,color .2s ease}
     .nav-button:hover{background:var(--panel);color:#fff}
     .nav-button:focus{outline:2px solid var(--accent);outline-offset:1px}
@@ -37,8 +42,13 @@
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
-        <a class="nav-button" href="index.html" style="padding:8px 12px">Accueil</a>
-        <h1>EconoDeal</h1>
+        <a class="brand" href="index.html">
+          <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs" />
+          <span class="brand-text">
+            <span class="brand-title">EconoDeal</span>
+            <span class="brand-tagline">Revendeur gagnant</span>
+          </span>
+        </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>


### PR DESCRIPTION
## Summary
- replace the static header title with a clickable brand block featuring a reseller-focused tagline across the main pages
- refresh the SVG logo with a vibrant gradient illustration evoking growth and partnerships for resellers

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd5f9e4378832e917bba2680deee76