### PR TITLE
Allow zero-dollar sale prices to count toward discounts

### DIFF
--- a/best-deals.html
+++ b/best-deals.html
@@ -348,8 +348,12 @@
         };
       }
       function discount(p,s){
-        if(!p || !s || !Number.isFinite(p) || !Number.isFinite(s) || p === 0) return 0;
-        const pct = Math.round((1 - (s / p)) * 100);
+        const price = Number(p);
+        const sale = Number(s);
+        if(!Number.isFinite(price) || price <= 0) return 0;
+        if(!Number.isFinite(sale)) return 0;
+        const clampedSale = Math.max(0, sale);
+        const pct = Math.round((1 - (clampedSale / price)) * 100);
         return Number.isFinite(pct) ? Math.max(pct, 0) : 0;
       }
       function currency(n){ return Number.isFinite(n) ? n.toLocaleString('fr-CA',{style:'currency',currency:'CAD'}) : '—'; }

--- a/index.html
+++ b/index.html
@@ -1085,8 +1085,12 @@
     }
 
     function discount(p,s){
-      if(!p || !s || !Number.isFinite(p) || !Number.isFinite(s) || p === 0) return 0;
-      const pct = Math.round((1 - (s / p)) * 100);
+      const price = Number(p);
+      const sale = Number(s);
+      if(!Number.isFinite(price) || price <= 0) return 0;
+      if(!Number.isFinite(sale)) return 0;
+      const clampedSale = Math.max(0, sale);
+      const pct = Math.round((1 - (clampedSale / price)) * 100);
       return Number.isFinite(pct) ? Math.max(pct, 0) : 0;
     }
     function currency(value){


### PR DESCRIPTION
## Summary
- update the discount helper on the home page to accept $0 sale prices while guarding against invalid inputs
- apply the same discount normalization to the best deals page so 0-priced offers remain ranked

## Testing
- browser_container.run_playwright_script (fixture forcing salePrice = 0 shows “-100% Rabais” on both pages)


------
https://chatgpt.com/codex/tasks/task_e_68dd97ec64f0832eb983389d2aef6394