### PR TITLE
Move country selector into the header

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     .nav-button:hover{background:var(--panel);color:#fff}
     .nav-button.current{background:linear-gradient(120deg,rgba(34,197,94,.25),rgba(59,130,246,.25));border-color:rgba(34,197,94,.6)}
     .country-toggle{display:inline-flex;align-items:center;gap:6px;background:var(--panel-2);padding:6px;border-radius:12px;border:1px solid var(--border)}
+    .country-toggle--header{background:rgba(15,23,42,.65);border-color:rgba(148,163,184,.4);box-shadow:0 6px 14px rgba(15,23,42,.35)}
+    .country-toggle--header .country-button{padding:8px 16px}
     .country-toggle .country-button{background:transparent;border:none;color:var(--muted);padding:8px 14px;border-radius:8px;font-weight:600;cursor:pointer;transition:background .2s ease,color .2s ease}
     .country-toggle .country-button:hover{color:#fff;background:rgba(59,130,246,.18)}
     .country-toggle .country-button.active,.country-toggle .country-button[aria-pressed="true"]{background:linear-gradient(120deg,rgba(34,197,94,.22),rgba(59,130,246,.18));color:#fff}
@@ -130,7 +132,7 @@
   </div>
   <header>
     <div class="container row" style="justify-content:space-between">
-      <div class="row" style="gap:10px;align-items:center">
+      <div class="row" style="gap:16px;align-items:center;flex-wrap:wrap">
         <a class="brand" href="index.html">
           <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs Amazon" />
           <span class="brand-text">
@@ -138,6 +140,11 @@
             <span class="brand-tagline">Votre hub Amazon</span>
           </span>
         </a>
+        <div class="country-toggle country-toggle--header" role="group" aria-label="Choisir le pays">
+          <button type="button" class="country-button active" data-country="canada" aria-pressed="true">Canada</button>
+          <button type="button" class="country-button" data-country="usa" aria-pressed="false">États-Unis</button>
+          <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europe</button>
+        </div>
       </div>
       <div class="row" style="gap:12px;align-items:center">
         <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>
@@ -158,11 +165,6 @@
       <!-- ✅ Les éléments requis existent et leurs IDs correspondent au script -->
       <div class="row" style="gap:12px;align-items:center;flex-wrap:wrap;margin-top:12px">
         <span class="muted" data-country-label>Pays couvert&nbsp;: Canada · Devise&nbsp;: CAD</span>
-        <div class="country-toggle" role="group" aria-label="Choisir le pays">
-          <button type="button" class="country-button active" data-country="canada" aria-pressed="true">Canada</button>
-          <button type="button" class="country-button" data-country="usa" aria-pressed="false">États-Unis</button>
-          <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europe</button>
-        </div>
       </div>
 
       <div class="filters" style="margin-top:12px">


### PR DESCRIPTION
## Summary
- move the country selector buttons next to the site logo in the header
- add header-specific styling so the selector blends with the navigation bar
- keep the country status label in the search filters without duplicating the selector

## Testing
- no automated tests were run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68ddadfb6bd4832e83527d75cecaacc5