### PR TITLE
Fix select styling for store and city filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
     .brand-title{margin:0;font-size:18px;font-weight:700;letter-spacing:-.01em}
     .brand-tagline{font-size:11px;text-transform:uppercase;letter-spacing:.14em;color:#86efac;font-weight:600}
     label{display:block;font-size:12px;color:var(--muted);margin-bottom:6px}
-    select,input[type="range"],button{background:linear-gradient(160deg,rgba(15,23,42,.95),rgba(30,41,59,.9));color:var(--text);border:1px solid rgba(148,163,184,.3);border-radius:10px;padding:10px 12px;box-shadow:0 0 0 1px rgba(2,6,23,.45) inset;transition:border-color .3s ease,box-shadow .3s ease,transform .2s ease}
+    select,input[type="range"],button{background:linear-gradient(160deg,rgba(15,23,42,.95),rgba(30,41,59,.9));background-color:#0f172a;color:var(--text);border:1px solid rgba(148,163,184,.3);border-radius:10px;padding:10px 12px;box-shadow:0 0 0 1px rgba(2,6,23,.45) inset;transition:border-color .3s ease,box-shadow .3s ease,transform .2s ease}
+    select option{color:#0f172a;background:#f8fafc}
     input[type="text"],input[type="email"]{width:100%;background:linear-gradient(170deg,rgba(17,24,39,.92),rgba(17,34,64,.9));color:var(--text);border:1px solid rgba(148,163,184,.3);border-radius:10px;padding:10px 12px;box-shadow:0 0 0 1px rgba(2,6,23,.35) inset;transition:border-color .3s ease,box-shadow .3s ease}
     input[type="text"]:focus,input[type="email"]:focus{border-color:rgba(59,130,246,.65);box-shadow:0 0 18px rgba(59,130,246,.25)}
     .nav-button{display:inline-flex;align-items:center;justify-content:center;background:linear-gradient(160deg,rgba(15,23,42,.94),rgba(20,33,54,.9));color:var(--text);border:1px solid rgba(59,130,246,.25);border-radius:10px;padding:10px 12px;text-decoration:none;transition:background .3s ease,color .3s ease,box-shadow .3s ease}


### PR DESCRIPTION
## Summary
- add a solid background fallback for the store and city selects
- ensure dropdown options render with dark text on a light background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde1ae1874832eb4e9ddf53c5c6a36