### PR TITLE
Add continuous sidebar banner for store advertisements

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
     .roadmap-card ul{margin:0;padding-left:18px;display:grid;gap:6px;font-size:14px;color:rgba(226,232,240,.75)}
     .roadmap-ai{border-left:3px solid var(--accent);padding-left:12px;background:linear-gradient(160deg,rgba(34,197,94,.18),rgba(59,130,246,.15));border-radius:10px;box-shadow:0 14px 32px rgba(34,197,94,.18)}
     @media (max-width:600px){.roadmap::before{right:-120px}}
+    @media (max-width:1100px){.store-ads{display:none !important}}
     .notice-card{background:rgba(59,130,246,.08);border:1px solid rgba(59,130,246,.35);color:#bfdbfe;border-radius:12px;padding:18px;font-size:14px;line-height:1.55}
     .amazon-section{background:linear-gradient(200deg,rgba(9,16,28,.88),rgba(8,20,40,.92));border:1px solid rgba(59,130,246,.28);border-radius:var(--radius);padding:28px;display:grid;gap:24px;margin-top:32px;box-shadow:0 26px 60px rgba(2,6,23,.6)}
     .amazon-section h2{margin:0;font-size:28px;display:flex;align-items:center;gap:10px}
@@ -142,6 +143,15 @@
     .store-menu-item:hover{background:linear-gradient(160deg,rgba(59,130,246,.2),rgba(34,197,94,.18));box-shadow:0 16px 32px rgba(59,130,246,.28);transform:translateY(-4px)}
     .store-menu-label{font-size:15px;letter-spacing:-.01em}
     .store-menu-note{font-size:13px;color:var(--muted);font-weight:500}
+    .store-ads{position:fixed;top:120px;right:24px;width:240px;max-width:80vw;height:420px;padding:18px;border-radius:18px;border:1px solid rgba(59,130,246,.28);background:linear-gradient(200deg,rgba(6,12,24,.94),rgba(12,24,44,.9));box-shadow:0 24px 48px rgba(2,6,23,.65);display:flex;flex-direction:column;gap:14px;z-index:30;overflow:hidden}
+    .store-ads[aria-hidden="true"]{display:none}
+    .store-ads-header{font-size:13px;letter-spacing:.18em;text-transform:uppercase;color:rgba(148,163,184,.9);font-weight:700}
+    .store-ads-window{flex:1;overflow:hidden;mask-image:linear-gradient(180deg,transparent 0%,rgba(255,255,255,.9) 12%,rgba(255,255,255,.9) 88%,transparent 100%)}
+    .store-ads-track{display:flex;flex-direction:column;gap:12px;animation:storeAdsScroll 28s linear infinite;will-change:transform}
+    .store-ads-item{padding:14px;border-radius:12px;border:1px solid rgba(59,130,246,.24);background:linear-gradient(160deg,rgba(34,197,94,.18),rgba(59,130,246,.16));box-shadow:0 12px 30px rgba(15,23,42,.45);display:flex;flex-direction:column;gap:4px;color:var(--text)}
+    .store-ads-name{font-weight:700;letter-spacing:-.01em}
+    .store-ads-coverage{font-size:12px;color:var(--muted)}
+    @keyframes storeAdsScroll{0%{transform:translateY(0)}100%{transform:translateY(-50%)}}
   </style>
 </head>
 <body class="overlay-active">
@@ -172,6 +182,7 @@
       </form>
     </div>
   </div>
+  <aside id="storeAds" class="store-ads" aria-label="Publicités des magasins" aria-hidden="true"></aside>
   <header>
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:16px;align-items:center;flex-wrap:wrap">
@@ -380,6 +391,7 @@
     const submitBtn = document.getElementById('registrationSubmit');
     const regulationCheckbox = document.getElementById('regulationCheckbox');
     const clientCountDisplays = Array.from(document.querySelectorAll('[data-client-count]'));
+    const storeAdsContainer = document.getElementById('storeAds');
     function parseJson(value){
       if(!value) return null;
       try{
@@ -689,6 +701,40 @@
       {label:'Kohl’s', description:'Mode, maison et articles saisonniers'},
       {label:"BJ's Wholesale Club", description:'Inventaire régional à forte rotation'}
     ];
+
+    function renderStoreAds(){
+      if(!storeAdsContainer) return;
+      const items = STORES
+        .map(store => {
+          const label = store?.label;
+          if(!label) return null;
+          return {
+            label,
+            coverage: formatBranchCoverage(store?.branches)
+          };
+        })
+        .filter(Boolean);
+      if(items.length === 0){
+        storeAdsContainer.setAttribute('aria-hidden', 'true');
+        storeAdsContainer.innerHTML = '';
+        return;
+      }
+      const duplicates = items.concat(items);
+      const duration = Math.max(items.length * 4, 24);
+      const list = duplicates.map(item => {
+        const coverage = item.coverage ? `<span class="store-ads-coverage">${item.coverage}</span>` : '';
+        return `<div class="store-ads-item" role="text"><span class="store-ads-name">${item.label}</span>${coverage}</div>`;
+      }).join('');
+      storeAdsContainer.innerHTML = `
+        <div class="store-ads-header">Magasins en vedette</div>
+        <div class="store-ads-window">
+          <div class="store-ads-track" style="animation-duration:${duration}s">${list}</div>
+        </div>
+      `;
+      storeAdsContainer.removeAttribute('aria-hidden');
+    }
+
+    renderStoreAds();
 
     const POSTAL_DIRECTORY = [
       {
@@ -1523,6 +1569,7 @@
           seen.set(rawSlug, {...previous, label, slug: rawSlug, city, hasData});
         }
         store.branches = Array.from(seen.values()).sort((a,b)=>a.label.localeCompare(b.label,'fr'));
+        renderStoreAds();
       }catch(err){
         console.warn('Impossible de charger les succursales Canadian Tire', err);
       }


### PR DESCRIPTION
## Summary
- add a fixed sidebar banner that continuously scrolls the list of covered stores
- populate the banner from existing store metadata and refresh it after Canadian Tire branches load
- style the banner to match the site and hide it on narrower screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deb659d7ac832e870c0d172e40abc4