### PR TITLE
Add Sporting Life preview pages for GitHub browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Site statique bilingue (FR/EN) avec filtres Magasin/Ville et barre de % de rabai
 - Dans `index.html`, remplace `render()` pour faire des `fetch('/data/ton_fichier.json')`,
   merger les tableaux, appliquer les filtres et générer les cartes.
 
+## Aperçus HTML rapides
+- Les jeux de données organisés génèrent un aperçu statique dans `previews/<magasin>/<ville>.html`.
+- Par exemple : `previews/sporting-life/montreal.html`, `previews/sporting-life/laval.html` et
+  `previews/sporting-life/saint-jerome.html` permettent de feuilleter les aubaines Sporting Life
+  directement depuis GitHub sans devoir lancer le site.
+
 © 2025 EconoDeal
 
 ## Automatisation du scraper Walmart

--- a/previews/sporting-life/laval.html
+++ b/previews/sporting-life/laval.html
@@ -1,0 +1,2807 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Sporting Life — Laval</title>
+<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#0f172a;color:#e5e7eb;margin:0;padding:24px">
+<h1 style="font-size:22px;margin:0 0 16px">Sporting Life — Laval (2790 articles, aperçu 200 premiers)</h1>
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px">
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772625_UTILITY-BROWN_0/Mens-Aconcagua-3-Jacket-UTILITY-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-32% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">183,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-aconcagua-3-pour-hommes/25772625.html?dwvar_25772625_color=UTILITY-BROWN&amp;dwvar_25772625_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772666_TNF-BLACK-NPF_0/Mens-Aconcagua-3-Vest-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">199,99 $</div>
+              <div style="font-weight:800">140,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-aconcagua-3-pour-hommes/25772666.html?dwvar_25772666_color=TNF-BLACK-NPF&amp;dwvar_25772666_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25885666_WHITE_0/Unisex-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">159,99 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25885666.html?dwvar_25885666_color=WHITE&amp;dwvar_25885666_size=10.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909847_LIGHT-HEATHER-GREY_0/Womens-Mayfield-Hoodie-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Mayfield pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Mayfield pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">105,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-mayfield-pour-femmes/25909847.html?dwvar_25909847_color=LIGHT-HEATHER-GREY&amp;dwvar_25909847_size=10%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25913930_BLUE_0/Womens-SL-72-OG-Shoe-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25913930.html?dwvar_25913930_color=BLUE&amp;dwvar_25913930_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25596362_BEIGE_0/Womens-327-Shoe-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 327 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 327 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-327-pour-femmes/25596362.html?dwvar_25596362_color=BEIGE&amp;dwvar_25596362_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902024_BLACK_0/Womens-Dalia-Crop-T-Shirt-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt court Dalia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-56% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt court Dalia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">42,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/t-shirts/t-shirt-court-dalia-pour-femmes/25902024.html?dwvar_25902024_color=BLACK&amp;dwvar_25902024_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25815960_BLACK_0/Womens-Kathleen-Slim-Boyfriend-Jean-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean coupe boyfriend ajustée Kathleen pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-55% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean coupe boyfriend ajustée Kathleen pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">65,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/denim/jean-coupe-boyfriend-ajustee-kathleen-pour-femmes/25815960.html?dwvar_25815960_color=BLACK&amp;dwvar_25815960_size=24&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768227_RED_0/Womens-Wink-Nylon-Waterproof-Boot-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Wink en nylon pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Wink en nylon pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-wink-en-nylon-pour-femmes/25768227.html?dwvar_25768227_color=RED&amp;dwvar_25768227_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887464_BLACK_0/Mens-Brooklin-2441-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Brooklin 2441 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Brooklin 2441 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">398,00 $</div>
+              <div style="font-weight:800">282,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-brooklin-2441-pour-hommes/25887464.html?dwvar_25887464_color=BLACK&amp;dwvar_25887464_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902719_LIGHT-HEATHER-GREY_0/Mens-Prep-Logo-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail Prep Logo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail Prep Logo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">175,00 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-prep-logo-pour-hommes/25902719.html?dwvar_25902719_color=LIGHT-HEATHER-GREY&amp;dwvar_25902719_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25299835_BLACK_0/Mens-Essential-Carn-Baffle-Zip-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à glissière Carn pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à glissière Carn pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">255,00 $</div>
+              <div style="font-weight:800">171,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-glissi%C3%A8re-carn-pour-hommes/25299835.html?dwvar_25299835_color=BLACK&amp;dwvar_25299835_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912288_WHITE_0/Mens-SL-72-RS-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 RS pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 RS pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-sl-72-rs-pour-hommes/25912288.html?dwvar_25912288_color=WHITE&amp;dwvar_25912288_size=7.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914599_WHITE-NAVY_0/Unisex-550-Shoe-WHITE-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">150,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25914599.html?dwvar_25914599_color=WHITE-NAVY&amp;dwvar_25914599_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25780842_BLACK_0/Womens-Multi-Logo-Scoop-Neck-Bikini-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut de bikini Multi Logo à encolure ronde pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut de bikini Multi Logo à encolure ronde pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">68,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-2-pi%C3%A8ces/haut-de-bikini-multi-logo-%C3%A0-encolure-ronde-pour-femmes/25780842.html?dwvar_25780842_color=BLACK&amp;dwvar_25780842_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862350_BLACK_0/Womens-Trail-Repel-Running-Vest-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet de course hydrofuge Trail pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-46% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet de course hydrofuge Trail pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">69,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/vestes-et-manteaux/vestes-de-course/gilet-de-course-hydrofuge-trail-pour-femmes/25862350.html?dwvar_25862350_color=BLACK&amp;dwvar_25862350_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25870346_TAN_0/Womens-Anacapa-2-Freedom-Hiking-Shoe-TAN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de randonnée Anacapa 2 Freedom pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de randonnée Anacapa 2 Freedom pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-randonnee/chaussures-de-randonnee-anacapa-2-freedom-pour-femmes/25870346.html?dwvar_25870346_color=TAN&amp;dwvar_25870346_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911868_WHITE_0/Womens-Adizero-Aruku-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911868.html?dwvar_25911868_color=WHITE&amp;dwvar_25911868_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25881525_BLACK_0/Sportswear-RPM-Tote-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac fourre-tout Sportswear RPM" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac fourre-tout Sportswear RPM</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">105,00 $</div>
+              <div style="font-weight:800">83,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-fourre-tout-sportswear-rpm/25881525.html?dwvar_25881525_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738618_IRON-GREY_0/Mens-Club-Therma-FIT-Puffer-Vest-IRON-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet bouffant Club Therma-FIT pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet bouffant Club Therma-FIT pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">125,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-bouffant-club-therma-fit-pour-hommes/25738618.html?dwvar_25738618_color=IRON-GREY&amp;dwvar_25738618_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25614751_BLUE_0/Undeniable-5.0-Duffel-Bag-Medium-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Undeniable 5.0 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Undeniable 5.0 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-undeniable-5.0-moyen/25614751.html?dwvar_25614751_color=BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25744657_BLACK_0/Unisex-480-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 480 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 480 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">89,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-480-unisexes/25744657.html?dwvar_25744657_color=BLACK&amp;dwvar_25744657_size=4%20%20%20%20%20%20Siz&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915657_WHITE-RED-BLUE_0/Womens-Cortez-Leather-Shoe-WHITE-RED-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-femmes/25915657.html?dwvar_25915657_color=WHITE-RED-BLUE&amp;dwvar_25915657_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25520644_BURGUNDY_0/Juniors-7-16-Knit-Beanie-BURGUNDY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Tuque en tricot pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-57% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Tuque en tricot pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">28,00 $</div>
+              <div style="font-weight:800">11,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/accessoires/chapeaux/winter-hats/tuque-en-tricot-pour-juniors-7-16/25520644.html?dwvar_25520644_color=BURGUNDY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893116_LIGHT-HEATHER-GREY_0/Junior-Boys-8-16-Logo-Crew-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras du cou Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras du cou Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-col-ras-du-cou-logo-pour-gar%C3%A7ons-juniors-8-16/25893116.html?dwvar_25893116_color=LIGHT-HEATHER-GREY&amp;dwvar_25893116_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893090_BLACK_0/Junior-Boys-8-16-Logo-Pullover-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-logo-pour-gar%C3%A7ons-juniors-8-16/25893090.html?dwvar_25893090_color=BLACK&amp;dwvar_25893090_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742305_BLACK_0/Kids-11-3-Gazelle-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour enfants [11-3]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour enfants [11-3]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/espadrilles-decontractees/chaussures-gazelle-pour-enfants-11-3/25742305.html?dwvar_25742305_color=BLACK&amp;dwvar_25742305_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878430_TNF-BLACK_0/Junior-Girls-7-20-Zaphira-Synthetic-Snow-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste de neige synthétique Zaphira pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste de neige synthétique Zaphira pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">190,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-de-neige-synthetique-zaphira-pour-filles-juniors-7-20/25878430.html?dwvar_25878430_color=TNF-BLACK&amp;dwvar_25878430_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878455_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-Wide-Leg-Pant-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon à jambe large en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon à jambe large en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-%C3%A0-jambe-large-en-molleton-camp-pour-filles-juniors-7-20/25878455.html?dwvar_25878455_color=TNF-BLACK&amp;dwvar_25878455_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903436_0/Juniors-Flair-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-flair-jr-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903436_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805490_0/Juniors-Experience-Pro-Ski--Kid-4-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-14% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-pro-%2B-fixations-kid-4-gw-pour-juniors-2025/25805490_000_104.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883489_BLUE_0/Mens-Arctic-Crest153-Down-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet Arctic Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet Arctic Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">369,99 $</div>
+              <div style="font-weight:800">209,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-en-duvet-arctic-crest-pour-hommes/25883489.html?dwvar_25883489_color=BLUE&amp;dwvar_25883489_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883471_BLACK_0/Mens-Slope-Style153-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Slope Style pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Slope Style pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">141,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-slope-style-pour-hommes/25883471.html?dwvar_25883471_color=BLACK&amp;dwvar_25883471_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805177_0/Experience-76-W-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 W + fixation Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 W + fixation Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">579,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-w-%2B-fixation-xpress-10-gw-2025/25805177_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25806597_0/Deacon-ST-Ski--vMotion-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Deacon ST + Fixations vMotion 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Deacon ST + Fixations vMotion 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,99 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-deacon-st-%2B-fixations-vmotion-10-gw-2025/25806597_000_161.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882184_0/S/View-Photochromic-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de sports de neige S/View à lentilles photochromiques" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de sports de neige S/View à lentilles photochromiques</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,95 $</div>
+              <div style="font-weight:800">79,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-sports-de-neige-s-view-%C3%A0-lentilles-photochromiques/25882184.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879255_0/Mens-S/Pro-Sport-MV-100-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Sport MV 100 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Sport MV 100 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">349,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-sport-mv-100-pour-hommes-2025/25879255_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916153_TNF-RED_0/Juniors-7-20-DryVent153-Mono-Mountain-Jacket-TNF-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste DryVent Mono Mountain pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste DryVent Mono Mountain pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">176,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-dryvent-mono-mountain-pour-juniors-7-20/25916153.html?dwvar_25916153_color=TNF-RED&amp;dwvar_25916153_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916173_BLACK_0/Juniors-11-6-Solid-Waterproof-Rain-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de pluie imperméables pour enfants [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de pluie imperméables pour enfants [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-et-chaussures-decontractees/bottes-de-pluie-impermeables-pour-enfants-11-6/25916173.html?dwvar_25916173_color=BLACK&amp;dwvar_25916173_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909797_MULTI_0/Womens-Helen-Knit-Sweater-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail en tricot Helene pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-48% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail en tricot Helene pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">235,00 $</div>
+              <div style="font-weight:800">122,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails/chandail-en-tricot-helene-pour-femmes/25909797.html?dwvar_25909797_color=MULTI&amp;dwvar_25909797_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911553_PINK_0/Womens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25911553.html?dwvar_25911553_color=PINK&amp;dwvar_25911553_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25823618_WHITE_0/Womens-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-550-pour-femmes/25823618.html?dwvar_25823618_color=WHITE&amp;dwvar_25823618_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25861865_BLACK_0/Junior-Girls-7-16-Sportswear-Varsity-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Varsity Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Varsity Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/styles/de-sport/vestes/veste-varsity-sportswear-pour-filles-juniors-7-16/25861865.html?dwvar_25861865_color=BLACK&amp;dwvar_25861865_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883109_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Pullover-Hoodie-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">70,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-doux-sportswear-pour-filles-7-16/25883109.html?dwvar_25883109_color=BOLD-BERRY&amp;dwvar_25883109_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822859_BLACK_0/Junior-Girls-7-16-Sportswear-Wide-Leg-Track-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">36,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-de-surv%C3%AAtement-%C3%A0-jambe-large-sportswear-pour-filles-juniors-7-16/25822859.html?dwvar_25822859_color=BLACK&amp;dwvar_25822859_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25754573_BLACK_0/Juniors-11-6-Shani-K-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Shani K pour juniors [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Shani K pour juniors [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-dhiver/bottes-impermeables-shani-k-pour-juniors-11-6/25754573.html?dwvar_25754573_color=BLACK&amp;dwvar_25754573_size=1&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876749_ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD_0/Mens-Yumiori-1/4-Zip-Top-ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 Yumiori pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 Yumiori pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">114,99 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-yumiori-pour-hommes/25876749.html?dwvar_25876749_color=ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD&amp;dwvar_25876749_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25904665_0/Experience-76-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 et fixations Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 et fixations Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-et-fixations-xpress-10-gw-2025/25904665_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763939_0/Mens-S/Pro-Alpha-120-EL-Ski-Boot-2024?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Alpha 120 EL pour hommes [2024]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Alpha 120 EL pour hommes [2024]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">419,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-alpha-120-el-pour-hommes-2024/25763939_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524638_TNF-BLACK-NPF_0/Mens-McMurdo-Parka-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Parka McMurdo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Parka McMurdo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">368,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/parkas/parka-mcmurdo-pour-hommes/25524638.html?dwvar_25524638_color=TNF-BLACK-NPF&amp;dwvar_25524638_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876400_TNF-BLK-TNF-BLK_0/Mens-Horizon-Performance-Fleece-Pullover-Hoodie-TNF-BLK-TNF-BLK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon molletonné Horizon Perfomance pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-45% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon molletonné Horizon Perfomance pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">104,99 $</div>
+              <div style="font-weight:800">57,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-molletonne-horizon-perfomance-pour-hommes/25876400.html?dwvar_25876400_color=TNF-BLK-TNF-BLK&amp;dwvar_25876400_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914532_WHITE-PINK-GOLD_0/Unisex-1906R-Shoe-WHITE-PINK-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 1906R unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 1906R unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">149,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-1906r-unisexes/25914532.html?dwvar_25914532_color=WHITE-PINK-GOLD&amp;dwvar_25914532_size=4.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912312_RED_0/Unisex-Adizero-Aruku-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Aruku Adizero unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Aruku Adizero unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-aruku-adizero-unisexes/25912312.html?dwvar_25912312_color=RED&amp;dwvar_25912312_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25781691_BLACK_0/Womens-All-SZN-Fleece-Graphic-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon ALL SZN Fleece Graphic pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon ALL SZN Fleece Graphic pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-all-szn-fleece-graphic-pour-femmes/25781691.html?dwvar_25781691_color=BLACK&amp;dwvar_25781691_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919220_WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE_0/Womens-Pacific-Shoe-WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-pacific-pour-femmes/25919220.html?dwvar_25919220_color=WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE&amp;dwvar_25919220_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911827_TURQUOISE_0/Womens-SL-72-OG-Shoe-TURQUOISE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25911827.html?dwvar_25911827_color=TURQUOISE&amp;dwvar_25911827_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915656_BLACK_0/Mens-Cortez-Leather-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-hommes/25915656.html?dwvar_25915656_color=BLACK&amp;dwvar_25915656_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900473_DARK-BLUE_0/Mens-Passerby-Long-Sleeve-Polo-DARK-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo manches longues Passerby pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo manches longues Passerby pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-manches-longues-passerby-pour-hommes/25900473.html?dwvar_25900473_color=DARK-BLUE&amp;dwvar_25900473_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918286_BLACK_0/Mens-Olmec-Bomber-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur Olmec pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur Olmec pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">458,00 $</div>
+              <div style="font-weight:800">259,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-olmec-pour-hommes/25918286.html?dwvar_25918286_color=BLACK&amp;dwvar_25918286_size=48&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901356_BLACK_0/Mens-Nallico-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Nallico pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Nallico pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">82,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-nallico-pour-hommes/25901356.html?dwvar_25901356_color=BLACK&amp;dwvar_25901356_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917641_BROWN_0/Mens-Samba-Shoe-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Samba pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Samba pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-samba-pour-hommes/25917641.html?dwvar_25917641_color=BROWN&amp;dwvar_25917641_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919214_BLACK_0/Mens-Pacific-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-pacific-pour-hommes/25919214.html?dwvar_25919214_color=BLACK&amp;dwvar_25919214_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901679_BLACK_0/Womens-Nelva-Sweatshirt-Dress-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe chandail Nelva pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe chandail Nelva pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-chandail-nelva-pour-femmes/25901679.html?dwvar_25901679_color=BLACK&amp;dwvar_25901679_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917095_OPEN-MISCELLANEOUS_0/Womens-Vantia-Skirt-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jupe Vantia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jupe Vantia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">288,00 $</div>
+              <div style="font-weight:800">120,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/jupes/jupe-vantia-pour-femmes/25917095.html?dwvar_25917095_color=OPEN-MISCELLANEOUS&amp;dwvar_25917095_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25489162_WHITE_0/Womens-Stan-Smith-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Stan Smith pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Stan Smith pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">103,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-stan-smith-pour-femmes/25489162.html?dwvar_25489162_color=WHITE&amp;dwvar_25489162_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742669_BLACK_0/Womens-Gazelle-Bold-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25742669.html?dwvar_25742669_color=BLACK&amp;dwvar_25742669_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878398_MUTED-PINE_0/Junior-Girls-7-20-Reversible-Shasta-Full-Zip-Jacket-MUTED-PINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon réversible Shasta pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon réversible Shasta pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">174,99 $</div>
+              <div style="font-weight:800">123,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-%C3%A0-capuchon-reversible-shasta-pour-filles-juniors-7-20/25878398.html?dwvar_25878398_color=MUTED-PINE&amp;dwvar_25878398_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878703_MAUVE_0/Juniors-7-20-Winter-Floral-Camp-Fleece-Pullover-Hoodie-MAUVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-dhiver-%C3%A0-capuchon-en-molleton-floral-camp-pour-juniors-7-20/25878703.html?dwvar_25878703_color=MAUVE&amp;dwvar_25878703_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883117_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Jogger-Pant-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de jogging doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de jogging doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalons-de-jogging-et-en-molleton/pantalon-de-jogging-doux-sportswear-pour-filles-7-16/25883117.html?dwvar_25883117_color=BOLD-BERRY&amp;dwvar_25883117_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903410_0/Juniors-Peregrine-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-peregrine-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903410_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882598_0/Mens-Evader-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Evader pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Evader pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">419,95 $</div>
+              <div style="font-weight:800">249,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-evader-pour-hommes-2025/25882598_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25771940_0/Mens-Ripcord-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Ripcord Flat Top pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Ripcord Flat Top pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,99 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-ripcord-flat-top-pour-hommes-2025/25771940_000_150.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902974_0/Mens-Moto-Boa-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Moto Boa® pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Moto Boa® pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">339,99 $</div>
+              <div style="font-weight:800">269,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-moto-boa-pour-hommes-2025/25902974_000_070.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902636_0/Mens-Mission-ReFlex-Snowboard-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Fixations de planche à neige Mission Re:Flex pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Fixations de planche à neige Mission Re:Flex pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">299,99 $</div>
+              <div style="font-weight:800">224,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/fixations-de-planche-%C3%A0-neige-mission-re%3Aflex-pour-hommes-2025/25902636_000_005.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876822_TNF-BLACK_0/Mens-Crest-1/4-Zip-Fleece-Pullover-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut en molleton à fermeture éclair 1/4 Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut en molleton à fermeture éclair 1/4 Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,99 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-en-molleton-%C3%A0-fermeture-eclair-1-4-crest-pour-hommes/25876822.html?dwvar_25876822_color=TNF-BLACK&amp;dwvar_25876822_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876186_TNF-BLACK_0/Mens-MTN-Range-Down-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet MTN Range pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet MTN Range pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">325,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-en-duvet-mtn-range-pour-hommes/25876186.html?dwvar_25876186_color=TNF-BLACK&amp;dwvar_25876186_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768490_GREY_0/Womens-Hannah-Zip-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes à glissière Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-61% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes à glissière Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-%C3%A0-glissi%C3%A8re-hannah-pour-femmes/25768490.html?dwvar_25768490_color=GREY&amp;dwvar_25768490_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25871476_CREAM_0/Womens-Steez-Waterproof-Sneaker-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Espadrilles imperméables Steez pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Espadrilles imperméables Steez pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/espadrilles-impermeables-steez-pour-femmes/25871476.html?dwvar_25871476_color=CREAM&amp;dwvar_25871476_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25761099_0/Radium-Prime-Sigma-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de ski Radium Prime Sigma" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de ski Radium Prime Sigma</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">194,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-ski-radium-prime-sigma/25761099.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25774779_0/Womens-Stylus-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Stylus Flat Top pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Stylus Flat Top pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">359,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-stylus-flat-top-pour-femmes-2025/25774779_000_147.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524380_0/Womens-Limelight-Step-On-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Limelight Step On® pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Limelight Step On® pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">344,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-limelight-step-on-pour-femmes-2025/25524380_000_060.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886045_YELLOW_0/Mens-GORE-TEX-2L-Pillowline-Jacket-YELLOW?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste GORE-TEX® 2L Pillowline pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-24% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste GORE-TEX® 2L Pillowline pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">394,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-planche-%C3%A0-neige/veste-gore-tex-2l-pillowline-pour-hommes/25886045.html?dwvar_25886045_color=YELLOW&amp;dwvar_25886045_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25890658_BLACK_0/Mens-Opside-Hoodie-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon Opside pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon Opside pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">350,00 $</div>
+              <div style="font-weight:800">247,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-capuchon-opside-pour-hommes/25890658.html?dwvar_25890658_color=BLACK&amp;dwvar_25890658_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886094_OLIVE_0/Mens-Oak-Crew-Neck-Fleece-Sweatshirt-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col rond en molleton Oak pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col rond en molleton Oak pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-rond-en-molleton-oak-pour-hommes/25886094.html?dwvar_25886094_color=OLIVE&amp;dwvar_25886094_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25767526_0/Stance-80-W-Ski--M-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Stance 80 + fixations M10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Stance 80 + fixations M10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,95 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-stance-80-%2B-fixations-m10-gw-2025/25767526_000_141.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763921_0/Mens-S/Pro-Supra-Boa-110-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Supra Boa 110 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Supra Boa 110 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">489,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-supra-boa-110-pour-hommes-2025/25763921_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25766650_0/Mens-S/Pro-Supra-Boa-120-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">799,95 $</div>
+              <div style="font-weight:800">559,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-ski-s-pro-supra-boa-120-pour-hommes-2025/25766650_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25743030_BLACK_0/Womens-Thermo-Fractal-Mid-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Thermo Fractal Mid pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-71% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Thermo Fractal Mid pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-thermo-fractal-mid-pour-femmes/25743030.html?dwvar_25743030_color=BLACK&amp;dwvar_25743030_size=5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25572520_BLACK_0/Womens-Hannah-Mid-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes mi-hautes Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes mi-hautes Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-mi-hautes-hannah-pour-femmes/25572520.html?dwvar_25572520_color=BLACK&amp;dwvar_25572520_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738600_FIR-GREEN_0/Mens-Sportswear-Club-Puffer-Jacket-FIR-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste bouffante Sportswear Club pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste bouffante Sportswear Club pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">158,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-bouffante-sportswear-club-pour-hommes/25738600.html?dwvar_25738600_color=FIR-GREEN&amp;dwvar_25738600_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25737784_GREY_0/Mens-Tech-Fleece-Crew-Sweatshirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras-du-cou Tech Fleece pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras-du-cou Tech Fleece pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">140,00 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-ras-du-cou-tech-fleece-pour-hommes/25737784.html?dwvar_25737784_color=GREY&amp;dwvar_25737784_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856188_AQUA_0/Womens-Gazelle-Shoe-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25856188.html?dwvar_25856188_color=AQUA&amp;dwvar_25856188_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856642_WHITE_0/Mens-Samba-OG-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chausssures Samba OG pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chausssures Samba OG pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chausssures-samba-og-pour-hommes/25856642.html?dwvar_25856642_color=WHITE&amp;dwvar_25856642_size=10&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911876_GREEN_0/Womens-Adizero-Aruku-Shoe-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911876.html?dwvar_25911876_color=GREEN&amp;dwvar_25911876_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840265_BLACK_0/Junior-Girls-7-16-Sportswear-Novelty-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Sportswear Novelty pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Sportswear Novelty pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-sportswear-novelty-pour-filles-juniors-7-16/25840265.html?dwvar_25840265_color=BLACK&amp;dwvar_25840265_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878448_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-1/4-Zip-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-en-molleton-camp-pour-filles-juniors-7-20/25878448.html?dwvar_25878448_color=TNF-BLACK&amp;dwvar_25878448_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883232_DARK-GREY-HEATHER_0/Juniors-7-16-Sportswear-Novelty-T-Shirt-DARK-GREY-HEATHER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Sportswear Novelty pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Sportswear Novelty pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">30,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/t-shirt-sportswear-novelty-pour-juniors-7-16/25883232.html?dwvar_25883232_color=DARK-GREY-HEATHER&amp;dwvar_25883232_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923019_SUPER-GREY_0/Kanken-Laptop-15-Backpack-SUPER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923019.html?dwvar_25923019_color=SUPER-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918035_BLACK_0/Mens-Ashton-Air-Down-Shirt-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Ashton Air en duvet pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Ashton Air en duvet pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">565,00 $</div>
+              <div style="font-weight:800">338,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-chemise-ashton-air-en-duvet-pour-hommes/25918035.html?dwvar_25918035_color=BLACK&amp;dwvar_25918035_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25889064_OLIVE_0/Mens-Granite-Hybrid-Bomber-Jacket-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur hybride Granite pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur hybride Granite pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">645,00 $</div>
+              <div style="font-weight:800">366,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-hybride-granite-pour-hommes/25889064.html?dwvar_25889064_color=OLIVE&amp;dwvar_25889064_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917322_BLACK_0/Mens-Hadiko-Rib-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon Hadiko Rib pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon Hadiko Rib pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-hadiko-rib-pour-hommes/25917322.html?dwvar_25917322_color=BLACK&amp;dwvar_25917322_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915666_HOT-MANGO-ANGORA-BLACK_0/Mens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-hommes/25915666.html?dwvar_25915666_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915666_size=8.5&amp;dwvar_25915666_style=D&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915665_HOT-MANGO-ANGORA-BLACK_0/Womens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-femmes/25915665.html?dwvar_25915665_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915665_size=6&amp;dwvar_25915665_style=B&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917096_OPEN-MISCELLANEOUS_0/Womens-Dantiana-Dress-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe Dantiana pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe Dantiana pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">298,00 $</div>
+              <div style="font-weight:800">124,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-dantiana-pour-femmes/25917096.html?dwvar_25917096_color=OPEN-MISCELLANEOUS&amp;dwvar_25917096_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902016_GREEN_0/Womens-Oversized-B1-Hoodie-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon surdimensionné B1 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon surdimensionné B1 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">178,00 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-surdimensionne-b1-pour-femmes/25902016.html?dwvar_25902016_color=GREEN&amp;dwvar_25902016_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779562_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779562.html?dwvar_25779562_color=WHITE&amp;dwvar_25779562_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779570_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779570.html?dwvar_25779570_color=WHITE&amp;dwvar_25779570_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789223_TOBACCO-BLURRED-OMBRE_0/Mens-Windward-II-Shirt-Jacket-TOBACCO-BLURRED-OMBRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Windward II pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Windward II pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">64,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/veste-chemise-windward-ii-pour-hommes/25789223.html?dwvar_25789223_color=TOBACCO-BLURRED-OMBRE&amp;dwvar_25789223_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840919_0/Recruit-V3-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Recruit V3" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Recruit V3</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-recruit-v3/25840919.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25625997_0/Composite-Stryker-4-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Stryker 4 en composite" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Stryker 4 en composite</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">71,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-stryker-4-en-composite/25625997.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916125_ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT_0/Junior-Girls-7-20-Cyclone-Wind-Jacket-ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste coupe-vent Cyclone pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste coupe-vent Cyclone pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-coupe-vent-cyclone-pour-filles-juniors-7-20/25916125.html?dwvar_25916125_color=ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT&amp;dwvar_25916125_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919618_TRUE-BLACK_0/Mens-Veridry-2L-Rain-Jacket-TRUE-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau de pluie Veridry 2L pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau de pluie Veridry 2L pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,99 $</div>
+              <div style="font-weight:800">108,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/v%C3%AAtements-techniques/manteau-de-pluie-veridry-2l-pour-hommes/25919618.html?dwvar_25919618_color=TRUE-BLACK&amp;dwvar_25919618_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879032_BROWN_0/Mens-Skateboarding-Quarter-Zip-Sweatshirt-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à glissière quart de longueur Skateboarding pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à glissière quart de longueur Skateboarding pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">48,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-glissi%C3%A8re-quart-de-longueur-skateboarding-pour-hommes/25879032.html?dwvar_25879032_color=BROWN&amp;dwvar_25879032_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25849977_KHAKI_0/Mens-511-Slim-Fit-Jean-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean 511 à coupe ajustée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean 511 à coupe ajustée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">118,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/denim/jean-511-%C3%A0-coupe-ajustee-pour-hommes/25849977.html?dwvar_25849977_color=KHAKI&amp;dwvar_25849977_size=29&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822073_AQUA_0/Juniors-1-7-Base-Camp-III-Slide-Sandal-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Base Camp III pour juniors [1-7]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Base Camp III pour juniors [1-7]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">44,99 $</div>
+              <div style="font-weight:800">21,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-base-camp-iii-pour-juniors-1-7/25822073.html?dwvar_25822073_color=AQUA&amp;dwvar_25822073_size=2&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25364399_BLUE_0/Juniors-1-6-Seacamp-II-CNX-Sandal-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Seacamp II CNX pour juniors [1-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Seacamp II CNX pour juniors [1-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-seacamp-ii-cnx-pour-juniors-1-6/25364399.html?dwvar_25364399_color=BLUE&amp;dwvar_25364399_size=4&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822883_BLACK_0/Junior-Girls-7-16-Sportswear-Oversized-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste surdimensionnée Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste surdimensionnée Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-surdimensionnee-sportswear-pour-filles-juniors-7-16/25822883.html?dwvar_25822883_color=BLACK&amp;dwvar_25822883_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25867490_0/IG-Radical-XCeed-Tennis-Racquet?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de tennis IG Radical XCeed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de tennis IG Radical XCeed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,95 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-tennis-ig-radical-xceed/25867490_000_004.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862830_0/Tempo-16-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Tempo 16" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Tempo 16</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">189,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-tempo-16/25862830.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763061_WHITE_0/Womens-Tennis-Essentials-Laser-Cut-Crossback-Tank-Top-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Camisole Tennis Essentials à sangles croisées au dos pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-69% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Camisole Tennis Essentials à sangles croisées au dos pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">80,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/camisole-tennis-essentials-%C3%A0-sangles-croisees-au-dos-pour-femmes/25763061.html?dwvar_25763061_color=WHITE&amp;dwvar_25763061_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25757485_MULTI_0/Womens-Dri-FIT-Slam-Tank-Top-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Débardeur NikeCourt Dri-FIT Slam pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Débardeur NikeCourt Dri-FIT Slam pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">95,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/debardeur-nikecourt-dri-fit-slam-pour-femmes/25757485.html?dwvar_25757485_color=MULTI&amp;dwvar_25757485_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25891730_BLACK_0/Mens-Gavin-Light-Down-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau léger en duvet Gavin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau léger en duvet Gavin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/manteau-leger-en-duvet-gavin-pour-hommes/25891730.html?dwvar_25891730_color=BLACK&amp;dwvar_25891730_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768243_GREY_0/Womens-V-Five-Suede-Shearling-Waterproof-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables V-Five Leather Shearling pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables V-Five Leather Shearling pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">71,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-v-five-leather-shearling-pour-femmes/25768243.html?dwvar_25768243_color=GREY&amp;dwvar_25768243_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866708_BLUE_0/Mens-5.75-Classic-Fit-Swim-Trunk-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain à coupe classique 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain à coupe classique 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">188,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-%C3%A0-coupe-classique-575-po-pour-hommes/25866708.html?dwvar_25866708_color=BLUE&amp;dwvar_25866708_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866690_MULTI_0/Mens-5.75-Traveler-Classic-Swim-Trunk-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain Traveler Classic de 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain Traveler Classic de 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">61,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-traveler-classic-de-575-po-pour-hommes/25866690.html?dwvar_25866690_color=MULTI&amp;dwvar_25866690_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25852237_BLACK_0/Womens-Smoothies-Sandbar-One-Piece-Swimsuit-Plus-Size-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">64,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-1-pi%C3%A8ce/maillot-de-bain-une-pi%C3%A8ce-smoothies-sandbar-pour-femmes-grandes-tailles/25852237.html?dwvar_25852237_color=BLACK&amp;dwvar_25852237_size=1%20%20%20Size%201&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887381_BLACK_0/Unisex-Lohja-Insulated-Coat-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau isolé Lohja unisexe" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau isolé Lohja unisexe</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">475,00 $</div>
+              <div style="font-weight:800">224,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/manteau-isole-lohja-unisexe/25887381.html?dwvar_25887381_color=BLACK&amp;dwvar_25887381_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25834771_STONE_0/Mens-Art-Jacket-STONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Art pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Art pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">89,00 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-art-pour-hommes/25834771.html?dwvar_25834771_color=STONE&amp;dwvar_25834771_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789207_KHAKI_0/Mens-Landroamer-Quilted-Shirt-Jacket-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise matelassée Landroamer pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise matelassée Landroamer pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">70,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/veste-chemise-matelassee-landroamer-pour-hommes/25789207.html?dwvar_25789207_color=KHAKI&amp;dwvar_25789207_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25775065_BLUE_0/Mens-Siz-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Siz pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Siz pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">425,00 $</div>
+              <div style="font-weight:800">200,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-siz-pour-hommes/25775065.html?dwvar_25775065_color=BLUE&amp;dwvar_25775065_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25407156_ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO_0/Mens-Arroyo-Flannel-Shirt-ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise en flanelle Arroyo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise en flanelle Arroyo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-en-flanelle-arroyo-pour-hommes/25407156.html?dwvar_25407156_color=ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO&amp;dwvar_25407156_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25638164_BLACK_0/Mens-Pump-Lightweight-Long-Sleeve-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à manches longues léger Pump pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-63% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à manches longues léger Pump pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">99,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/haut-%C3%A0-manches-longues-leger-pump-pour-hommes/25638164.html?dwvar_25638164_color=BLACK&amp;dwvar_25638164_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25534033_PINK_0/Junior-Girls-6-16-Mighty-Mogul-II-Jacket-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mighty Mogul pour filles juniors [6-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mighty Mogul pour filles juniors [6-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">169,99 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-mighty-mogul-pour-filles-juniors-6-16/25534033.html?dwvar_25534033_color=PINK&amp;dwvar_25534033_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25895988_NAVY_0/Junior-Boys-8-14-Mattan-Jacket-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mattan pour garçons juniors [8-14]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mattan pour garçons juniors [8-14]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">1 280,00 $</div>
+              <div style="font-weight:800">606,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-mattan-pour-gar%C3%A7ons-juniors-8-14/25895988.html?dwvar_25895988_color=NAVY&amp;dwvar_25895988_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920024_0/Mens-Crank-Laced-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Crank Laced pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Crank Laced pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,95 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-crank-laced-pour-hommes-2025/25920024-00158994.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920121_0/Unisex-Family-Tree-Hometown-Hero-Camber-Wide-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">879,99 $</div>
+              <div style="font-weight:800">659,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-family-tree-hometown-hero-camber-wide-unisexe-2025/25920121-00160476.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922487_GREY_0/Hustle-6.0-Backpack-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922487.html?dwvar_25922487_color=GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919212_BLACK_0/Mens-Field-General-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Field General pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Field General pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-field-general-pour-hommes/25919212.html?dwvar_25919212_color=BLACK&amp;dwvar_25919212_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924374_FLINTSTONE_0/Traverse-Light-20-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924374.html?dwvar_25924374_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924375_PETROL-BLUE_0/Traverse-Light-20-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924375.html?dwvar_25924375_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924372_PETROL-BLUE_0/Traverse-Light-15-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924372.html?dwvar_25924372_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924376_WINE-TASTING_0/Traverse-Light-20-Backpack-WINE-TASTING?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924376.html?dwvar_25924376_color=WINE-TASTING&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924370_DIRTY-DAISY_0/Traverse-Light-15-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924370.html?dwvar_25924370_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924373_DIRTY-DAISY_0/Traverse-Light-20-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924373.html?dwvar_25924373_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924371_FLINTSTONE_0/Traverse-Light-15-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924371.html?dwvar_25924371_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922476_BLUE-VOID-BLACK-MINT-FOAM_0/Brasilia-9.5-Duffel-Bag-Medium-BLUE-VOID-BLACK-MINT-FOAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Brasilia 9.5 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Brasilia 9.5 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-brasilia-9.5-moyen/25922476.html?dwvar_25922476_color=BLUE-VOID-BLACK-MINT-FOAM&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900135_BLACK_0/Hustle-6.0-Backpack-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25900135.html?dwvar_25900135_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25788407_BLACK_0/Square-Futura-Lunch-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à lunch Futura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à lunch Futura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-lunch-futura/25788407.html?dwvar_25788407_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922489_PINE-FOREST_0/Startle-Backpack-PINE-FOREST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Startle" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Startle</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-startle/25922489.html?dwvar_25922489_color=PINE-FOREST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922488_ROYAL-BLUE-SILVER_0/Hustle-6.0-Backpack-ROYAL-BLUE-SILVER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922488.html?dwvar_25922488_color=ROYAL-BLUE-SILVER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25551516_0/Recovery-Ball?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Balle de massage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Balle de massage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/balle-de-massage/25551516.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917802_POWDER-TEAL-BLISS-LILAC-PURE-TEAL_0/Womens-Gazelle-Bold-Shoe-POWDER-TEAL-BLISS-LILAC-PURE-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25917802.html?dwvar_25917802_color=POWDER-TEAL-BLISS-LILAC-PURE-TEAL&amp;dwvar_25917802_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923021_FOLIAGE-GREEN_0/Raven-28-Backpack-FOLIAGE-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Raven 28" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Raven 28</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">155,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-raven-28/25923021.html?dwvar_25923021_color=FOLIAGE-GREEN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923020_OX-RED_0/Kanken-Laptop-15-Backpack-OX-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923020.html?dwvar_25923020_color=OX-RED&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923017_ACORN_0/Kanken-Laptop-15-Backpack-ACORN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923017.html?dwvar_25923017_color=ACORN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25824715_GREY_0/Womens-GP-Challenge-Pro-Premium-Tennis-Shoe-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de tennis GP Challenge Pro Premium pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de tennis GP Challenge Pro Premium pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">170,00 $</div>
+              <div style="font-weight:800">126,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-tennis/chaussures-de-tennis-gp-challenge-pro-premium-pour-femmes/25824715.html?dwvar_25824715_color=GREY&amp;dwvar_25824715_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920787_DARK-SMOKE-WHITE_0/Icon-Air-Max-90-Card-Wallet-DARK-SMOKE-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920787.html?dwvar_25920787_color=DARK-SMOKE-WHITE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920892_BLACK_0/Fundamental-Speed-Rope-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Corde à sauter Fundamental Speed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-23% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Corde à sauter Fundamental Speed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">26,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/equipement-dentra%C3%AEnement/abdominaux-entra%C3%AEnement-et-exercice/corde-%C3%A0-sauter-fundamental-speed/25920892.html?dwvar_25920892_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920786_INFARED-COOL-GREY_0/Icon-Air-Max-90-Card-Wallet-INFARED-COOL-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920786.html?dwvar_25920786_color=INFARED-COOL-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923558_RUBBER_0/Split-Adventure-Backpack-38L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Split Adventure (38L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Split Adventure (38L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/sac-%C3%A0-dos-split-adventure-38l/25923558.html?dwvar_25923558_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923307_BLACKOUT_0/Enduro-25L-4.0-Backpack-BLACKOUT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923307.html?dwvar_25923307_color=BLACKOUT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923306_FORGED-IRON-REDLINE_0/Enduro-25L-4.0-Backpack-FORGED-IRON-REDLINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923306.html?dwvar_25923306_color=FORGED-IRON-REDLINE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923308_MIST_0/Enduro-25L-4.0-Backpack-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923308.html?dwvar_25923308_color=MIST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907007_RAZZLE-RASPBERRY_0/Aura-Crossbody-Bag-RAZZLE-RASPBERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-taille-et-sacs-ceinture/sac-%C3%A0-bandouli%C3%A8re-aura/25907007.html?dwvar_25907007_color=RAZZLE-RASPBERRY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917290_CLOUD-DANCER_0/Mens-Chris-Life-Short-Seeve-T-Shirt-CLOUD-DANCER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Chris Life pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Chris Life pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">15,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-chris-life-pour-hommes/25917290.html?dwvar_25917290_color=CLOUD-DANCER&amp;dwvar_25917290_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917916_RED_0/Womens-SL-72-OG-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25917916.html?dwvar_25917916_color=RED&amp;dwvar_25917916_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922692_0/WZRD-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball WZRD" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball WZRD</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-wzrd/25922692.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25464470_0/Patella-Knee-Strap?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sangle pour le genou" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sangle pour le genou</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">19,99 $</div>
+              <div style="font-weight:800">14,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/sangle-pour-le-genou/25464470.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912064_PINK_0/Mens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-hommes/25912064.html?dwvar_25912064_color=PINK&amp;dwvar_25912064_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922691_0/BALLR-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball BALLR+" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball BALLR+</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-ballr%2B/25922691.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916430_MULTI_0/Skills-Next-Nature-Mini-Basketball-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Mini-ballon de basketball Skills Next Nature" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-22% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Mini-ballon de basketball Skills Next Nature</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">18,00 $</div>
+              <div style="font-weight:800">13,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/loisirs-aquatiques/gilets-de-sauvetage-et-protection-contre-leau/mini-ballon-de-basketball-skills-next-nature/25916430.html?dwvar_25916430_color=MULTI&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921136_BLACK_0/Recharge-Stainless-Steel-Straw-Bottle-32-oz-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille en acier inoxydable Recharge avec paille (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille en acier inoxydable Recharge avec paille (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteilles-deau-et-gobelets/acier-inoxydable/bouteille-en-acier-inoxydable-recharge-avec-paille-32-oz/25921136.html?dwvar_25921136_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921827_TIGER-CAMO_0/Lunch-Box-5L-TIGER-CAMO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-5l/25921827.html?dwvar_25921827_color=TIGER-CAMO&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921828_BLACK-ONYX_0/Snacktime-Lunch-Box-5L-BLACK-ONYX?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921828.html?dwvar_25921828_color=BLACK-ONYX&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921826_RUBBER_0/Snacktime-Lunch-Box-5L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921826.html?dwvar_25921826_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921825_TRELLIS_0/Snacktime-Lunch-Box-5L-TRELLIS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921825.html?dwvar_25921825_color=TRELLIS&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922184_WHITE_0/Junior-Boys-8-20-Cotton-Seersucker-Short-Sleeve-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-35% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/chemise-%C3%A0-manches-courtes-en-coton-seersucker-pour-gar%C3%A7ons-juniors-8-20/25922184.html?dwvar_25922184_color=WHITE&amp;dwvar_25922184_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917289_DARK-SAPPHIRE_0/Mens-Kasper-Knit-Resort-Shirt-DARK-SAPPHIRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Kasper Resort en tricot pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Kasper Resort en tricot pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">52,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-kasper-resort-en-tricot-pour-hommes/25917289.html?dwvar_25917289_color=DARK-SAPPHIRE&amp;dwvar_25917289_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721226_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">250,00 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721226.html?dwvar_25721226_color=BLACK&amp;dwvar_25721226_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721234_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">260,00 $</div>
+              <div style="font-weight:800">194,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721234.html?dwvar_25721234_color=BLACK&amp;dwvar_25721234_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917111_GREY-MIST_0/Womens-Evida-Short-Dress-GREY-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe courte Evida pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe courte Evida pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-courte-evida-pour-femmes/25917111.html?dwvar_25917111_color=GREY-MIST&amp;dwvar_25917111_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917281_DARK-NAVY_0/Mens-Loc-Short-DARK-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short Loc pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-64% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short Loc pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">69,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/shorts/short-loc-pour-hommes/25917281.html?dwvar_25917281_color=DARK-NAVY&amp;dwvar_25917281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907031_PARACHUTE-BEIGE_0/Heritage-Crossbody-Bag-PARACHUTE-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac bandoulière Heritage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac bandoulière Heritage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-bandouli%C3%A8re-heritage/25907031.html?dwvar_25907031_color=PARACHUTE-BEIGE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25906991_BLACK_0/Aura-Crossbody-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-%C3%A0-bandouli%C3%A8re-aura/25906991.html?dwvar_25906991_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918278_DEEP-TEAL_0/Mens-Gills-Camp-Shirt-DEEP-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gills Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gills Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gills-camp-pour-hommes/25918278.html?dwvar_25918278_color=DEEP-TEAL&amp;dwvar_25918278_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918281_CHARCOAL_0/Mens-Trailer-Rider-2.0-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Trailer Rider 2.0 Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Trailer Rider 2.0 Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-trailer-rider-2.0-camp-pour-hommes/25918281.html?dwvar_25918281_color=CHARCOAL&amp;dwvar_25918281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918276_NAVY_0/Mens-Baywatch-Camp-Shirt-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Baywatch Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Baywatch Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-baywatch-camp-pour-hommes/25918276.html?dwvar_25918276_color=NAVY&amp;dwvar_25918276_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918279_CHARCOAL_0/Mens-Star-Gazer-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Star Gazer Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Star Gazer Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-star-gazer-camp--pour-hommes/25918279.html?dwvar_25918279_color=CHARCOAL&amp;dwvar_25918279_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918280_BUTTER-CREAM_0/Mens-Cottage-Country-Camp-Shirt-BUTTER-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Cottage Country Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Cottage Country Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-cottage-country-camp-pour-hommes/25918280.html?dwvar_25918280_color=BUTTER-CREAM&amp;dwvar_25918280_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918277_WHITE_0/Mens-Gear-Up-Camp-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gear Up Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gear Up Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gear-up-camp-pour-hommes/25918277.html?dwvar_25918277_color=WHITE&amp;dwvar_25918277_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921654_BLACK_0/Mens-Endorphin-Speed-4-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Endorphin Speed 4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Endorphin Speed 4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">220,00 $</div>
+              <div style="font-weight:800">164,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-de-stabilite/chaussures-de-course-endorphin-speed-4-pour-hommes/25921654.html?dwvar_25921654_color=BLACK&amp;dwvar_25921654_size=14&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917736_WHITE_0/Junior-Girls-7-16-Big-Pony-Logo-Terry-Dress-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/robes/robe-en-tissu-eponge-avec-logo-big-pony-pour-filles-juniors-7-16/25917736.html?dwvar_25917736_color=WHITE&amp;dwvar_25917736_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917380_CORAL_0/Mens-Allover-Print-Short-Sleeve-Shirt-CORAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes à motif intégral pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes à motif intégral pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-%C3%A0-motif-integral-pour-hommes/25917380.html?dwvar_25917380_color=CORAL&amp;dwvar_25917380_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917765_BLUE_0/Junior-Boys-8-20-Relaxed-Fit-Flex-Abrasion-Twill-Short-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,50 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/shorts/short-en-serge-flex-abrasion-relaxed-fit-pour-gar%C3%A7ons-juniors-8-20/25917765.html?dwvar_25917765_color=BLUE&amp;dwvar_25917765_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917383_BLUE_0/Mens-3-Button-Performance-Short-Sleeve-Polo-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo à manches courtes et 3 boutons pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-37% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo à manches courtes et 3 boutons pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">30,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-%C3%A0-manches-courtes-et-3-boutons-pour-hommes/25917383.html?dwvar_25917383_color=BLUE&amp;dwvar_25917383_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917224_NATURAL_0/Mens-Linen-Blend-Pant-NATURAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon en mélange de lin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon en mélange de lin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">53,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-en-melange-de-lin-pour-hommes/25917224.html?dwvar_25917224_color=NATURAL&amp;dwvar_25917224_size=XXL&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917379_OFF-WHITE_0/Mens-Striped-Short-Sleeve-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes rayée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes rayée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">34,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-rayee-pour-hommes/25917379.html?dwvar_25917379_color=OFF-WHITE&amp;dwvar_25917379_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917381_GREY_0/Mens-Camp-Short-Sleeve-Shirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">54,50 $</div>
+              <div style="font-weight:800">38,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-camp-pour-hommes/25917381.html?dwvar_25917381_color=GREY&amp;dwvar_25917381_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917375_OFF-WHITE_0/Mens-Expeditions-of-the-Obsessed-T-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Expeditions of the Obsessed pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Expeditions of the Obsessed pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-expeditions-of-the-obsessed-pour-hommes/25917375.html?dwvar_25917375_color=OFF-WHITE&amp;dwvar_25917375_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916161_BALTIC-BLUE-BLACK-IRIDESCENT_0/Refuel-Locking-Lid-Water-Bottle-32-oz-BALTIC-BLUE-BLACK-IRIDESCENT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Laval</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">24,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteille-deau-refuel-avec-couvercle-verrouillable-32-oz/25916161.html?dwvar_25916161_color=BALTIC-BLUE-BLACK-IRIDESCENT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        </div>
+</body>

--- a/previews/sporting-life/montreal.html
+++ b/previews/sporting-life/montreal.html
@@ -1,0 +1,2807 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Sporting Life — Montréal</title>
+<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#0f172a;color:#e5e7eb;margin:0;padding:24px">
+<h1 style="font-size:22px;margin:0 0 16px">Sporting Life — Montréal (2790 articles, aperçu 200 premiers)</h1>
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px">
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772625_UTILITY-BROWN_0/Mens-Aconcagua-3-Jacket-UTILITY-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-32% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">183,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-aconcagua-3-pour-hommes/25772625.html?dwvar_25772625_color=UTILITY-BROWN&amp;dwvar_25772625_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772666_TNF-BLACK-NPF_0/Mens-Aconcagua-3-Vest-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">199,99 $</div>
+              <div style="font-weight:800">140,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-aconcagua-3-pour-hommes/25772666.html?dwvar_25772666_color=TNF-BLACK-NPF&amp;dwvar_25772666_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25885666_WHITE_0/Unisex-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">159,99 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25885666.html?dwvar_25885666_color=WHITE&amp;dwvar_25885666_size=10.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909847_LIGHT-HEATHER-GREY_0/Womens-Mayfield-Hoodie-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Mayfield pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Mayfield pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">105,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-mayfield-pour-femmes/25909847.html?dwvar_25909847_color=LIGHT-HEATHER-GREY&amp;dwvar_25909847_size=10%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25913930_BLUE_0/Womens-SL-72-OG-Shoe-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25913930.html?dwvar_25913930_color=BLUE&amp;dwvar_25913930_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25596362_BEIGE_0/Womens-327-Shoe-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 327 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 327 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-327-pour-femmes/25596362.html?dwvar_25596362_color=BEIGE&amp;dwvar_25596362_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902024_BLACK_0/Womens-Dalia-Crop-T-Shirt-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt court Dalia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-56% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt court Dalia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">42,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/t-shirts/t-shirt-court-dalia-pour-femmes/25902024.html?dwvar_25902024_color=BLACK&amp;dwvar_25902024_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25815960_BLACK_0/Womens-Kathleen-Slim-Boyfriend-Jean-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean coupe boyfriend ajustée Kathleen pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-55% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean coupe boyfriend ajustée Kathleen pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">65,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/denim/jean-coupe-boyfriend-ajustee-kathleen-pour-femmes/25815960.html?dwvar_25815960_color=BLACK&amp;dwvar_25815960_size=24&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768227_RED_0/Womens-Wink-Nylon-Waterproof-Boot-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Wink en nylon pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Wink en nylon pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-wink-en-nylon-pour-femmes/25768227.html?dwvar_25768227_color=RED&amp;dwvar_25768227_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887464_BLACK_0/Mens-Brooklin-2441-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Brooklin 2441 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Brooklin 2441 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">398,00 $</div>
+              <div style="font-weight:800">282,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-brooklin-2441-pour-hommes/25887464.html?dwvar_25887464_color=BLACK&amp;dwvar_25887464_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902719_LIGHT-HEATHER-GREY_0/Mens-Prep-Logo-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail Prep Logo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail Prep Logo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">175,00 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-prep-logo-pour-hommes/25902719.html?dwvar_25902719_color=LIGHT-HEATHER-GREY&amp;dwvar_25902719_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25299835_BLACK_0/Mens-Essential-Carn-Baffle-Zip-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à glissière Carn pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à glissière Carn pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">255,00 $</div>
+              <div style="font-weight:800">171,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-glissi%C3%A8re-carn-pour-hommes/25299835.html?dwvar_25299835_color=BLACK&amp;dwvar_25299835_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912288_WHITE_0/Mens-SL-72-RS-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 RS pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 RS pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-sl-72-rs-pour-hommes/25912288.html?dwvar_25912288_color=WHITE&amp;dwvar_25912288_size=7.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914599_WHITE-NAVY_0/Unisex-550-Shoe-WHITE-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">150,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25914599.html?dwvar_25914599_color=WHITE-NAVY&amp;dwvar_25914599_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25780842_BLACK_0/Womens-Multi-Logo-Scoop-Neck-Bikini-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut de bikini Multi Logo à encolure ronde pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut de bikini Multi Logo à encolure ronde pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">68,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-2-pi%C3%A8ces/haut-de-bikini-multi-logo-%C3%A0-encolure-ronde-pour-femmes/25780842.html?dwvar_25780842_color=BLACK&amp;dwvar_25780842_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862350_BLACK_0/Womens-Trail-Repel-Running-Vest-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet de course hydrofuge Trail pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-46% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet de course hydrofuge Trail pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">69,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/vestes-et-manteaux/vestes-de-course/gilet-de-course-hydrofuge-trail-pour-femmes/25862350.html?dwvar_25862350_color=BLACK&amp;dwvar_25862350_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25870346_TAN_0/Womens-Anacapa-2-Freedom-Hiking-Shoe-TAN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de randonnée Anacapa 2 Freedom pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de randonnée Anacapa 2 Freedom pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-randonnee/chaussures-de-randonnee-anacapa-2-freedom-pour-femmes/25870346.html?dwvar_25870346_color=TAN&amp;dwvar_25870346_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911868_WHITE_0/Womens-Adizero-Aruku-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911868.html?dwvar_25911868_color=WHITE&amp;dwvar_25911868_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25881525_BLACK_0/Sportswear-RPM-Tote-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac fourre-tout Sportswear RPM" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac fourre-tout Sportswear RPM</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">105,00 $</div>
+              <div style="font-weight:800">83,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-fourre-tout-sportswear-rpm/25881525.html?dwvar_25881525_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738618_IRON-GREY_0/Mens-Club-Therma-FIT-Puffer-Vest-IRON-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet bouffant Club Therma-FIT pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet bouffant Club Therma-FIT pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">125,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-bouffant-club-therma-fit-pour-hommes/25738618.html?dwvar_25738618_color=IRON-GREY&amp;dwvar_25738618_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25614751_BLUE_0/Undeniable-5.0-Duffel-Bag-Medium-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Undeniable 5.0 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Undeniable 5.0 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-undeniable-5.0-moyen/25614751.html?dwvar_25614751_color=BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25744657_BLACK_0/Unisex-480-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 480 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 480 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">89,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-480-unisexes/25744657.html?dwvar_25744657_color=BLACK&amp;dwvar_25744657_size=4%20%20%20%20%20%20Siz&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915657_WHITE-RED-BLUE_0/Womens-Cortez-Leather-Shoe-WHITE-RED-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-femmes/25915657.html?dwvar_25915657_color=WHITE-RED-BLUE&amp;dwvar_25915657_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25520644_BURGUNDY_0/Juniors-7-16-Knit-Beanie-BURGUNDY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Tuque en tricot pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-57% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Tuque en tricot pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">28,00 $</div>
+              <div style="font-weight:800">11,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/accessoires/chapeaux/winter-hats/tuque-en-tricot-pour-juniors-7-16/25520644.html?dwvar_25520644_color=BURGUNDY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893116_LIGHT-HEATHER-GREY_0/Junior-Boys-8-16-Logo-Crew-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras du cou Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras du cou Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-col-ras-du-cou-logo-pour-gar%C3%A7ons-juniors-8-16/25893116.html?dwvar_25893116_color=LIGHT-HEATHER-GREY&amp;dwvar_25893116_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893090_BLACK_0/Junior-Boys-8-16-Logo-Pullover-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-logo-pour-gar%C3%A7ons-juniors-8-16/25893090.html?dwvar_25893090_color=BLACK&amp;dwvar_25893090_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742305_BLACK_0/Kids-11-3-Gazelle-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour enfants [11-3]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour enfants [11-3]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/espadrilles-decontractees/chaussures-gazelle-pour-enfants-11-3/25742305.html?dwvar_25742305_color=BLACK&amp;dwvar_25742305_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878430_TNF-BLACK_0/Junior-Girls-7-20-Zaphira-Synthetic-Snow-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste de neige synthétique Zaphira pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste de neige synthétique Zaphira pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">190,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-de-neige-synthetique-zaphira-pour-filles-juniors-7-20/25878430.html?dwvar_25878430_color=TNF-BLACK&amp;dwvar_25878430_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878455_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-Wide-Leg-Pant-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon à jambe large en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon à jambe large en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-%C3%A0-jambe-large-en-molleton-camp-pour-filles-juniors-7-20/25878455.html?dwvar_25878455_color=TNF-BLACK&amp;dwvar_25878455_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903436_0/Juniors-Flair-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-flair-jr-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903436_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805490_0/Juniors-Experience-Pro-Ski--Kid-4-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-14% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-pro-%2B-fixations-kid-4-gw-pour-juniors-2025/25805490_000_104.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883489_BLUE_0/Mens-Arctic-Crest153-Down-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet Arctic Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet Arctic Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">369,99 $</div>
+              <div style="font-weight:800">209,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-en-duvet-arctic-crest-pour-hommes/25883489.html?dwvar_25883489_color=BLUE&amp;dwvar_25883489_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883471_BLACK_0/Mens-Slope-Style153-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Slope Style pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Slope Style pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">141,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-slope-style-pour-hommes/25883471.html?dwvar_25883471_color=BLACK&amp;dwvar_25883471_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805177_0/Experience-76-W-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 W + fixation Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 W + fixation Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">579,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-w-%2B-fixation-xpress-10-gw-2025/25805177_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25806597_0/Deacon-ST-Ski--vMotion-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Deacon ST + Fixations vMotion 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Deacon ST + Fixations vMotion 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,99 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-deacon-st-%2B-fixations-vmotion-10-gw-2025/25806597_000_161.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882184_0/S/View-Photochromic-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de sports de neige S/View à lentilles photochromiques" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de sports de neige S/View à lentilles photochromiques</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,95 $</div>
+              <div style="font-weight:800">79,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-sports-de-neige-s-view-%C3%A0-lentilles-photochromiques/25882184.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879255_0/Mens-S/Pro-Sport-MV-100-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Sport MV 100 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Sport MV 100 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">349,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-sport-mv-100-pour-hommes-2025/25879255_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916153_TNF-RED_0/Juniors-7-20-DryVent153-Mono-Mountain-Jacket-TNF-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste DryVent Mono Mountain pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste DryVent Mono Mountain pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">176,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-dryvent-mono-mountain-pour-juniors-7-20/25916153.html?dwvar_25916153_color=TNF-RED&amp;dwvar_25916153_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916173_BLACK_0/Juniors-11-6-Solid-Waterproof-Rain-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de pluie imperméables pour enfants [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de pluie imperméables pour enfants [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-et-chaussures-decontractees/bottes-de-pluie-impermeables-pour-enfants-11-6/25916173.html?dwvar_25916173_color=BLACK&amp;dwvar_25916173_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909797_MULTI_0/Womens-Helen-Knit-Sweater-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail en tricot Helene pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-48% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail en tricot Helene pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">235,00 $</div>
+              <div style="font-weight:800">122,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails/chandail-en-tricot-helene-pour-femmes/25909797.html?dwvar_25909797_color=MULTI&amp;dwvar_25909797_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911553_PINK_0/Womens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25911553.html?dwvar_25911553_color=PINK&amp;dwvar_25911553_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25823618_WHITE_0/Womens-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-550-pour-femmes/25823618.html?dwvar_25823618_color=WHITE&amp;dwvar_25823618_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25861865_BLACK_0/Junior-Girls-7-16-Sportswear-Varsity-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Varsity Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Varsity Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/styles/de-sport/vestes/veste-varsity-sportswear-pour-filles-juniors-7-16/25861865.html?dwvar_25861865_color=BLACK&amp;dwvar_25861865_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883109_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Pullover-Hoodie-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">70,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-doux-sportswear-pour-filles-7-16/25883109.html?dwvar_25883109_color=BOLD-BERRY&amp;dwvar_25883109_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822859_BLACK_0/Junior-Girls-7-16-Sportswear-Wide-Leg-Track-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">36,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-de-surv%C3%AAtement-%C3%A0-jambe-large-sportswear-pour-filles-juniors-7-16/25822859.html?dwvar_25822859_color=BLACK&amp;dwvar_25822859_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25754573_BLACK_0/Juniors-11-6-Shani-K-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Shani K pour juniors [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Shani K pour juniors [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-dhiver/bottes-impermeables-shani-k-pour-juniors-11-6/25754573.html?dwvar_25754573_color=BLACK&amp;dwvar_25754573_size=1&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876749_ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD_0/Mens-Yumiori-1/4-Zip-Top-ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 Yumiori pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 Yumiori pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">114,99 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-yumiori-pour-hommes/25876749.html?dwvar_25876749_color=ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD&amp;dwvar_25876749_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25904665_0/Experience-76-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 et fixations Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 et fixations Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-et-fixations-xpress-10-gw-2025/25904665_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763939_0/Mens-S/Pro-Alpha-120-EL-Ski-Boot-2024?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Alpha 120 EL pour hommes [2024]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Alpha 120 EL pour hommes [2024]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">419,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-alpha-120-el-pour-hommes-2024/25763939_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524638_TNF-BLACK-NPF_0/Mens-McMurdo-Parka-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Parka McMurdo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Parka McMurdo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">368,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/parkas/parka-mcmurdo-pour-hommes/25524638.html?dwvar_25524638_color=TNF-BLACK-NPF&amp;dwvar_25524638_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876400_TNF-BLK-TNF-BLK_0/Mens-Horizon-Performance-Fleece-Pullover-Hoodie-TNF-BLK-TNF-BLK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon molletonné Horizon Perfomance pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-45% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon molletonné Horizon Perfomance pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">104,99 $</div>
+              <div style="font-weight:800">57,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-molletonne-horizon-perfomance-pour-hommes/25876400.html?dwvar_25876400_color=TNF-BLK-TNF-BLK&amp;dwvar_25876400_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914532_WHITE-PINK-GOLD_0/Unisex-1906R-Shoe-WHITE-PINK-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 1906R unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 1906R unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">149,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-1906r-unisexes/25914532.html?dwvar_25914532_color=WHITE-PINK-GOLD&amp;dwvar_25914532_size=4.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912312_RED_0/Unisex-Adizero-Aruku-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Aruku Adizero unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Aruku Adizero unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-aruku-adizero-unisexes/25912312.html?dwvar_25912312_color=RED&amp;dwvar_25912312_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25781691_BLACK_0/Womens-All-SZN-Fleece-Graphic-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon ALL SZN Fleece Graphic pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon ALL SZN Fleece Graphic pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-all-szn-fleece-graphic-pour-femmes/25781691.html?dwvar_25781691_color=BLACK&amp;dwvar_25781691_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919220_WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE_0/Womens-Pacific-Shoe-WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-pacific-pour-femmes/25919220.html?dwvar_25919220_color=WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE&amp;dwvar_25919220_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911827_TURQUOISE_0/Womens-SL-72-OG-Shoe-TURQUOISE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25911827.html?dwvar_25911827_color=TURQUOISE&amp;dwvar_25911827_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915656_BLACK_0/Mens-Cortez-Leather-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-hommes/25915656.html?dwvar_25915656_color=BLACK&amp;dwvar_25915656_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900473_DARK-BLUE_0/Mens-Passerby-Long-Sleeve-Polo-DARK-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo manches longues Passerby pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo manches longues Passerby pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-manches-longues-passerby-pour-hommes/25900473.html?dwvar_25900473_color=DARK-BLUE&amp;dwvar_25900473_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918286_BLACK_0/Mens-Olmec-Bomber-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur Olmec pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur Olmec pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">458,00 $</div>
+              <div style="font-weight:800">259,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-olmec-pour-hommes/25918286.html?dwvar_25918286_color=BLACK&amp;dwvar_25918286_size=48&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901356_BLACK_0/Mens-Nallico-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Nallico pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Nallico pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">82,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-nallico-pour-hommes/25901356.html?dwvar_25901356_color=BLACK&amp;dwvar_25901356_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917641_BROWN_0/Mens-Samba-Shoe-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Samba pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Samba pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-samba-pour-hommes/25917641.html?dwvar_25917641_color=BROWN&amp;dwvar_25917641_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919214_BLACK_0/Mens-Pacific-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-pacific-pour-hommes/25919214.html?dwvar_25919214_color=BLACK&amp;dwvar_25919214_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901679_BLACK_0/Womens-Nelva-Sweatshirt-Dress-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe chandail Nelva pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe chandail Nelva pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-chandail-nelva-pour-femmes/25901679.html?dwvar_25901679_color=BLACK&amp;dwvar_25901679_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917095_OPEN-MISCELLANEOUS_0/Womens-Vantia-Skirt-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jupe Vantia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jupe Vantia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">288,00 $</div>
+              <div style="font-weight:800">120,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/jupes/jupe-vantia-pour-femmes/25917095.html?dwvar_25917095_color=OPEN-MISCELLANEOUS&amp;dwvar_25917095_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25489162_WHITE_0/Womens-Stan-Smith-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Stan Smith pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Stan Smith pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">103,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-stan-smith-pour-femmes/25489162.html?dwvar_25489162_color=WHITE&amp;dwvar_25489162_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742669_BLACK_0/Womens-Gazelle-Bold-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25742669.html?dwvar_25742669_color=BLACK&amp;dwvar_25742669_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878398_MUTED-PINE_0/Junior-Girls-7-20-Reversible-Shasta-Full-Zip-Jacket-MUTED-PINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon réversible Shasta pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon réversible Shasta pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">174,99 $</div>
+              <div style="font-weight:800">123,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-%C3%A0-capuchon-reversible-shasta-pour-filles-juniors-7-20/25878398.html?dwvar_25878398_color=MUTED-PINE&amp;dwvar_25878398_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878703_MAUVE_0/Juniors-7-20-Winter-Floral-Camp-Fleece-Pullover-Hoodie-MAUVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-dhiver-%C3%A0-capuchon-en-molleton-floral-camp-pour-juniors-7-20/25878703.html?dwvar_25878703_color=MAUVE&amp;dwvar_25878703_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883117_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Jogger-Pant-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de jogging doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de jogging doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalons-de-jogging-et-en-molleton/pantalon-de-jogging-doux-sportswear-pour-filles-7-16/25883117.html?dwvar_25883117_color=BOLD-BERRY&amp;dwvar_25883117_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903410_0/Juniors-Peregrine-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-peregrine-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903410_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882598_0/Mens-Evader-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Evader pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Evader pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">419,95 $</div>
+              <div style="font-weight:800">249,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-evader-pour-hommes-2025/25882598_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25771940_0/Mens-Ripcord-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Ripcord Flat Top pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Ripcord Flat Top pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,99 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-ripcord-flat-top-pour-hommes-2025/25771940_000_150.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902974_0/Mens-Moto-Boa-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Moto Boa® pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Moto Boa® pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">339,99 $</div>
+              <div style="font-weight:800">269,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-moto-boa-pour-hommes-2025/25902974_000_070.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902636_0/Mens-Mission-ReFlex-Snowboard-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Fixations de planche à neige Mission Re:Flex pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Fixations de planche à neige Mission Re:Flex pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">299,99 $</div>
+              <div style="font-weight:800">224,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/fixations-de-planche-%C3%A0-neige-mission-re%3Aflex-pour-hommes-2025/25902636_000_005.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876822_TNF-BLACK_0/Mens-Crest-1/4-Zip-Fleece-Pullover-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut en molleton à fermeture éclair 1/4 Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut en molleton à fermeture éclair 1/4 Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,99 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-en-molleton-%C3%A0-fermeture-eclair-1-4-crest-pour-hommes/25876822.html?dwvar_25876822_color=TNF-BLACK&amp;dwvar_25876822_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876186_TNF-BLACK_0/Mens-MTN-Range-Down-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet MTN Range pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet MTN Range pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">325,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-en-duvet-mtn-range-pour-hommes/25876186.html?dwvar_25876186_color=TNF-BLACK&amp;dwvar_25876186_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768490_GREY_0/Womens-Hannah-Zip-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes à glissière Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-61% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes à glissière Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-%C3%A0-glissi%C3%A8re-hannah-pour-femmes/25768490.html?dwvar_25768490_color=GREY&amp;dwvar_25768490_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25871476_CREAM_0/Womens-Steez-Waterproof-Sneaker-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Espadrilles imperméables Steez pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Espadrilles imperméables Steez pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/espadrilles-impermeables-steez-pour-femmes/25871476.html?dwvar_25871476_color=CREAM&amp;dwvar_25871476_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25761099_0/Radium-Prime-Sigma-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de ski Radium Prime Sigma" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de ski Radium Prime Sigma</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">194,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-ski-radium-prime-sigma/25761099.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25774779_0/Womens-Stylus-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Stylus Flat Top pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Stylus Flat Top pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">359,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-stylus-flat-top-pour-femmes-2025/25774779_000_147.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524380_0/Womens-Limelight-Step-On-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Limelight Step On® pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Limelight Step On® pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">344,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-limelight-step-on-pour-femmes-2025/25524380_000_060.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886045_YELLOW_0/Mens-GORE-TEX-2L-Pillowline-Jacket-YELLOW?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste GORE-TEX® 2L Pillowline pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-24% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste GORE-TEX® 2L Pillowline pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">394,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-planche-%C3%A0-neige/veste-gore-tex-2l-pillowline-pour-hommes/25886045.html?dwvar_25886045_color=YELLOW&amp;dwvar_25886045_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25890658_BLACK_0/Mens-Opside-Hoodie-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon Opside pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon Opside pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">350,00 $</div>
+              <div style="font-weight:800">247,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-capuchon-opside-pour-hommes/25890658.html?dwvar_25890658_color=BLACK&amp;dwvar_25890658_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886094_OLIVE_0/Mens-Oak-Crew-Neck-Fleece-Sweatshirt-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col rond en molleton Oak pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col rond en molleton Oak pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-rond-en-molleton-oak-pour-hommes/25886094.html?dwvar_25886094_color=OLIVE&amp;dwvar_25886094_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25767526_0/Stance-80-W-Ski--M-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Stance 80 + fixations M10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Stance 80 + fixations M10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,95 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-stance-80-%2B-fixations-m10-gw-2025/25767526_000_141.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763921_0/Mens-S/Pro-Supra-Boa-110-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Supra Boa 110 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Supra Boa 110 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">489,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-supra-boa-110-pour-hommes-2025/25763921_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25766650_0/Mens-S/Pro-Supra-Boa-120-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">799,95 $</div>
+              <div style="font-weight:800">559,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-ski-s-pro-supra-boa-120-pour-hommes-2025/25766650_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25743030_BLACK_0/Womens-Thermo-Fractal-Mid-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Thermo Fractal Mid pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-71% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Thermo Fractal Mid pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-thermo-fractal-mid-pour-femmes/25743030.html?dwvar_25743030_color=BLACK&amp;dwvar_25743030_size=5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25572520_BLACK_0/Womens-Hannah-Mid-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes mi-hautes Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes mi-hautes Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-mi-hautes-hannah-pour-femmes/25572520.html?dwvar_25572520_color=BLACK&amp;dwvar_25572520_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738600_FIR-GREEN_0/Mens-Sportswear-Club-Puffer-Jacket-FIR-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste bouffante Sportswear Club pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste bouffante Sportswear Club pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">158,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-bouffante-sportswear-club-pour-hommes/25738600.html?dwvar_25738600_color=FIR-GREEN&amp;dwvar_25738600_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25737784_GREY_0/Mens-Tech-Fleece-Crew-Sweatshirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras-du-cou Tech Fleece pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras-du-cou Tech Fleece pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">140,00 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-ras-du-cou-tech-fleece-pour-hommes/25737784.html?dwvar_25737784_color=GREY&amp;dwvar_25737784_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856188_AQUA_0/Womens-Gazelle-Shoe-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25856188.html?dwvar_25856188_color=AQUA&amp;dwvar_25856188_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856642_WHITE_0/Mens-Samba-OG-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chausssures Samba OG pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chausssures Samba OG pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chausssures-samba-og-pour-hommes/25856642.html?dwvar_25856642_color=WHITE&amp;dwvar_25856642_size=10&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911876_GREEN_0/Womens-Adizero-Aruku-Shoe-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911876.html?dwvar_25911876_color=GREEN&amp;dwvar_25911876_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840265_BLACK_0/Junior-Girls-7-16-Sportswear-Novelty-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Sportswear Novelty pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Sportswear Novelty pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-sportswear-novelty-pour-filles-juniors-7-16/25840265.html?dwvar_25840265_color=BLACK&amp;dwvar_25840265_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878448_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-1/4-Zip-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-en-molleton-camp-pour-filles-juniors-7-20/25878448.html?dwvar_25878448_color=TNF-BLACK&amp;dwvar_25878448_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883232_DARK-GREY-HEATHER_0/Juniors-7-16-Sportswear-Novelty-T-Shirt-DARK-GREY-HEATHER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Sportswear Novelty pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Sportswear Novelty pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">30,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/t-shirt-sportswear-novelty-pour-juniors-7-16/25883232.html?dwvar_25883232_color=DARK-GREY-HEATHER&amp;dwvar_25883232_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923019_SUPER-GREY_0/Kanken-Laptop-15-Backpack-SUPER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923019.html?dwvar_25923019_color=SUPER-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918035_BLACK_0/Mens-Ashton-Air-Down-Shirt-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Ashton Air en duvet pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Ashton Air en duvet pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">565,00 $</div>
+              <div style="font-weight:800">338,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-chemise-ashton-air-en-duvet-pour-hommes/25918035.html?dwvar_25918035_color=BLACK&amp;dwvar_25918035_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25889064_OLIVE_0/Mens-Granite-Hybrid-Bomber-Jacket-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur hybride Granite pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur hybride Granite pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">645,00 $</div>
+              <div style="font-weight:800">366,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-hybride-granite-pour-hommes/25889064.html?dwvar_25889064_color=OLIVE&amp;dwvar_25889064_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917322_BLACK_0/Mens-Hadiko-Rib-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon Hadiko Rib pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon Hadiko Rib pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-hadiko-rib-pour-hommes/25917322.html?dwvar_25917322_color=BLACK&amp;dwvar_25917322_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915666_HOT-MANGO-ANGORA-BLACK_0/Mens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-hommes/25915666.html?dwvar_25915666_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915666_size=8.5&amp;dwvar_25915666_style=D&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915665_HOT-MANGO-ANGORA-BLACK_0/Womens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-femmes/25915665.html?dwvar_25915665_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915665_size=6&amp;dwvar_25915665_style=B&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917096_OPEN-MISCELLANEOUS_0/Womens-Dantiana-Dress-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe Dantiana pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe Dantiana pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">298,00 $</div>
+              <div style="font-weight:800">124,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-dantiana-pour-femmes/25917096.html?dwvar_25917096_color=OPEN-MISCELLANEOUS&amp;dwvar_25917096_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902016_GREEN_0/Womens-Oversized-B1-Hoodie-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon surdimensionné B1 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon surdimensionné B1 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">178,00 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-surdimensionne-b1-pour-femmes/25902016.html?dwvar_25902016_color=GREEN&amp;dwvar_25902016_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779562_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779562.html?dwvar_25779562_color=WHITE&amp;dwvar_25779562_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779570_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779570.html?dwvar_25779570_color=WHITE&amp;dwvar_25779570_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789223_TOBACCO-BLURRED-OMBRE_0/Mens-Windward-II-Shirt-Jacket-TOBACCO-BLURRED-OMBRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Windward II pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Windward II pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">64,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/veste-chemise-windward-ii-pour-hommes/25789223.html?dwvar_25789223_color=TOBACCO-BLURRED-OMBRE&amp;dwvar_25789223_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840919_0/Recruit-V3-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Recruit V3" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Recruit V3</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-recruit-v3/25840919.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25625997_0/Composite-Stryker-4-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Stryker 4 en composite" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Stryker 4 en composite</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">71,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-stryker-4-en-composite/25625997.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916125_ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT_0/Junior-Girls-7-20-Cyclone-Wind-Jacket-ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste coupe-vent Cyclone pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste coupe-vent Cyclone pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-coupe-vent-cyclone-pour-filles-juniors-7-20/25916125.html?dwvar_25916125_color=ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT&amp;dwvar_25916125_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919618_TRUE-BLACK_0/Mens-Veridry-2L-Rain-Jacket-TRUE-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau de pluie Veridry 2L pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau de pluie Veridry 2L pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,99 $</div>
+              <div style="font-weight:800">108,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/v%C3%AAtements-techniques/manteau-de-pluie-veridry-2l-pour-hommes/25919618.html?dwvar_25919618_color=TRUE-BLACK&amp;dwvar_25919618_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879032_BROWN_0/Mens-Skateboarding-Quarter-Zip-Sweatshirt-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à glissière quart de longueur Skateboarding pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à glissière quart de longueur Skateboarding pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">48,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-glissi%C3%A8re-quart-de-longueur-skateboarding-pour-hommes/25879032.html?dwvar_25879032_color=BROWN&amp;dwvar_25879032_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25849977_KHAKI_0/Mens-511-Slim-Fit-Jean-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean 511 à coupe ajustée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean 511 à coupe ajustée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">118,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/denim/jean-511-%C3%A0-coupe-ajustee-pour-hommes/25849977.html?dwvar_25849977_color=KHAKI&amp;dwvar_25849977_size=29&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822073_AQUA_0/Juniors-1-7-Base-Camp-III-Slide-Sandal-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Base Camp III pour juniors [1-7]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Base Camp III pour juniors [1-7]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">44,99 $</div>
+              <div style="font-weight:800">21,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-base-camp-iii-pour-juniors-1-7/25822073.html?dwvar_25822073_color=AQUA&amp;dwvar_25822073_size=2&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25364399_BLUE_0/Juniors-1-6-Seacamp-II-CNX-Sandal-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Seacamp II CNX pour juniors [1-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Seacamp II CNX pour juniors [1-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-seacamp-ii-cnx-pour-juniors-1-6/25364399.html?dwvar_25364399_color=BLUE&amp;dwvar_25364399_size=4&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822883_BLACK_0/Junior-Girls-7-16-Sportswear-Oversized-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste surdimensionnée Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste surdimensionnée Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-surdimensionnee-sportswear-pour-filles-juniors-7-16/25822883.html?dwvar_25822883_color=BLACK&amp;dwvar_25822883_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25867490_0/IG-Radical-XCeed-Tennis-Racquet?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de tennis IG Radical XCeed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de tennis IG Radical XCeed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,95 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-tennis-ig-radical-xceed/25867490_000_004.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862830_0/Tempo-16-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Tempo 16" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Tempo 16</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">189,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-tempo-16/25862830.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763061_WHITE_0/Womens-Tennis-Essentials-Laser-Cut-Crossback-Tank-Top-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Camisole Tennis Essentials à sangles croisées au dos pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-69% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Camisole Tennis Essentials à sangles croisées au dos pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">80,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/camisole-tennis-essentials-%C3%A0-sangles-croisees-au-dos-pour-femmes/25763061.html?dwvar_25763061_color=WHITE&amp;dwvar_25763061_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25757485_MULTI_0/Womens-Dri-FIT-Slam-Tank-Top-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Débardeur NikeCourt Dri-FIT Slam pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Débardeur NikeCourt Dri-FIT Slam pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">95,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/debardeur-nikecourt-dri-fit-slam-pour-femmes/25757485.html?dwvar_25757485_color=MULTI&amp;dwvar_25757485_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25891730_BLACK_0/Mens-Gavin-Light-Down-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau léger en duvet Gavin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau léger en duvet Gavin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/manteau-leger-en-duvet-gavin-pour-hommes/25891730.html?dwvar_25891730_color=BLACK&amp;dwvar_25891730_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768243_GREY_0/Womens-V-Five-Suede-Shearling-Waterproof-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables V-Five Leather Shearling pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables V-Five Leather Shearling pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">71,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-v-five-leather-shearling-pour-femmes/25768243.html?dwvar_25768243_color=GREY&amp;dwvar_25768243_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866708_BLUE_0/Mens-5.75-Classic-Fit-Swim-Trunk-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain à coupe classique 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain à coupe classique 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">188,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-%C3%A0-coupe-classique-575-po-pour-hommes/25866708.html?dwvar_25866708_color=BLUE&amp;dwvar_25866708_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866690_MULTI_0/Mens-5.75-Traveler-Classic-Swim-Trunk-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain Traveler Classic de 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain Traveler Classic de 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">61,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-traveler-classic-de-575-po-pour-hommes/25866690.html?dwvar_25866690_color=MULTI&amp;dwvar_25866690_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25852237_BLACK_0/Womens-Smoothies-Sandbar-One-Piece-Swimsuit-Plus-Size-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">64,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-1-pi%C3%A8ce/maillot-de-bain-une-pi%C3%A8ce-smoothies-sandbar-pour-femmes-grandes-tailles/25852237.html?dwvar_25852237_color=BLACK&amp;dwvar_25852237_size=1%20%20%20Size%201&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887381_BLACK_0/Unisex-Lohja-Insulated-Coat-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau isolé Lohja unisexe" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau isolé Lohja unisexe</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">475,00 $</div>
+              <div style="font-weight:800">224,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/manteau-isole-lohja-unisexe/25887381.html?dwvar_25887381_color=BLACK&amp;dwvar_25887381_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25834771_STONE_0/Mens-Art-Jacket-STONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Art pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Art pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">89,00 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-art-pour-hommes/25834771.html?dwvar_25834771_color=STONE&amp;dwvar_25834771_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789207_KHAKI_0/Mens-Landroamer-Quilted-Shirt-Jacket-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise matelassée Landroamer pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise matelassée Landroamer pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">70,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/veste-chemise-matelassee-landroamer-pour-hommes/25789207.html?dwvar_25789207_color=KHAKI&amp;dwvar_25789207_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25775065_BLUE_0/Mens-Siz-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Siz pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Siz pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">425,00 $</div>
+              <div style="font-weight:800">200,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-siz-pour-hommes/25775065.html?dwvar_25775065_color=BLUE&amp;dwvar_25775065_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25407156_ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO_0/Mens-Arroyo-Flannel-Shirt-ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise en flanelle Arroyo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise en flanelle Arroyo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-en-flanelle-arroyo-pour-hommes/25407156.html?dwvar_25407156_color=ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO&amp;dwvar_25407156_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25638164_BLACK_0/Mens-Pump-Lightweight-Long-Sleeve-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à manches longues léger Pump pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-63% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à manches longues léger Pump pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">99,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/haut-%C3%A0-manches-longues-leger-pump-pour-hommes/25638164.html?dwvar_25638164_color=BLACK&amp;dwvar_25638164_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25534033_PINK_0/Junior-Girls-6-16-Mighty-Mogul-II-Jacket-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mighty Mogul pour filles juniors [6-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mighty Mogul pour filles juniors [6-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">169,99 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-mighty-mogul-pour-filles-juniors-6-16/25534033.html?dwvar_25534033_color=PINK&amp;dwvar_25534033_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25895988_NAVY_0/Junior-Boys-8-14-Mattan-Jacket-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mattan pour garçons juniors [8-14]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mattan pour garçons juniors [8-14]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">1 280,00 $</div>
+              <div style="font-weight:800">606,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-mattan-pour-gar%C3%A7ons-juniors-8-14/25895988.html?dwvar_25895988_color=NAVY&amp;dwvar_25895988_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920024_0/Mens-Crank-Laced-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Crank Laced pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Crank Laced pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,95 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-crank-laced-pour-hommes-2025/25920024-00158994.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920121_0/Unisex-Family-Tree-Hometown-Hero-Camber-Wide-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">879,99 $</div>
+              <div style="font-weight:800">659,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-family-tree-hometown-hero-camber-wide-unisexe-2025/25920121-00160476.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922487_GREY_0/Hustle-6.0-Backpack-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922487.html?dwvar_25922487_color=GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919212_BLACK_0/Mens-Field-General-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Field General pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Field General pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-field-general-pour-hommes/25919212.html?dwvar_25919212_color=BLACK&amp;dwvar_25919212_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924374_FLINTSTONE_0/Traverse-Light-20-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924374.html?dwvar_25924374_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924375_PETROL-BLUE_0/Traverse-Light-20-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924375.html?dwvar_25924375_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924372_PETROL-BLUE_0/Traverse-Light-15-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924372.html?dwvar_25924372_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924376_WINE-TASTING_0/Traverse-Light-20-Backpack-WINE-TASTING?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924376.html?dwvar_25924376_color=WINE-TASTING&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924370_DIRTY-DAISY_0/Traverse-Light-15-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924370.html?dwvar_25924370_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924373_DIRTY-DAISY_0/Traverse-Light-20-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924373.html?dwvar_25924373_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924371_FLINTSTONE_0/Traverse-Light-15-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924371.html?dwvar_25924371_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922476_BLUE-VOID-BLACK-MINT-FOAM_0/Brasilia-9.5-Duffel-Bag-Medium-BLUE-VOID-BLACK-MINT-FOAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Brasilia 9.5 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Brasilia 9.5 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-brasilia-9.5-moyen/25922476.html?dwvar_25922476_color=BLUE-VOID-BLACK-MINT-FOAM&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900135_BLACK_0/Hustle-6.0-Backpack-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25900135.html?dwvar_25900135_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25788407_BLACK_0/Square-Futura-Lunch-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à lunch Futura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à lunch Futura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-lunch-futura/25788407.html?dwvar_25788407_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922489_PINE-FOREST_0/Startle-Backpack-PINE-FOREST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Startle" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Startle</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-startle/25922489.html?dwvar_25922489_color=PINE-FOREST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922488_ROYAL-BLUE-SILVER_0/Hustle-6.0-Backpack-ROYAL-BLUE-SILVER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922488.html?dwvar_25922488_color=ROYAL-BLUE-SILVER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25551516_0/Recovery-Ball?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Balle de massage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Balle de massage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/balle-de-massage/25551516.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917802_POWDER-TEAL-BLISS-LILAC-PURE-TEAL_0/Womens-Gazelle-Bold-Shoe-POWDER-TEAL-BLISS-LILAC-PURE-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25917802.html?dwvar_25917802_color=POWDER-TEAL-BLISS-LILAC-PURE-TEAL&amp;dwvar_25917802_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923021_FOLIAGE-GREEN_0/Raven-28-Backpack-FOLIAGE-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Raven 28" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Raven 28</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">155,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-raven-28/25923021.html?dwvar_25923021_color=FOLIAGE-GREEN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923020_OX-RED_0/Kanken-Laptop-15-Backpack-OX-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923020.html?dwvar_25923020_color=OX-RED&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923017_ACORN_0/Kanken-Laptop-15-Backpack-ACORN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923017.html?dwvar_25923017_color=ACORN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25824715_GREY_0/Womens-GP-Challenge-Pro-Premium-Tennis-Shoe-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de tennis GP Challenge Pro Premium pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de tennis GP Challenge Pro Premium pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">170,00 $</div>
+              <div style="font-weight:800">126,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-tennis/chaussures-de-tennis-gp-challenge-pro-premium-pour-femmes/25824715.html?dwvar_25824715_color=GREY&amp;dwvar_25824715_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920787_DARK-SMOKE-WHITE_0/Icon-Air-Max-90-Card-Wallet-DARK-SMOKE-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920787.html?dwvar_25920787_color=DARK-SMOKE-WHITE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920892_BLACK_0/Fundamental-Speed-Rope-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Corde à sauter Fundamental Speed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-23% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Corde à sauter Fundamental Speed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">26,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/equipement-dentra%C3%AEnement/abdominaux-entra%C3%AEnement-et-exercice/corde-%C3%A0-sauter-fundamental-speed/25920892.html?dwvar_25920892_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920786_INFARED-COOL-GREY_0/Icon-Air-Max-90-Card-Wallet-INFARED-COOL-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920786.html?dwvar_25920786_color=INFARED-COOL-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923558_RUBBER_0/Split-Adventure-Backpack-38L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Split Adventure (38L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Split Adventure (38L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/sac-%C3%A0-dos-split-adventure-38l/25923558.html?dwvar_25923558_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923307_BLACKOUT_0/Enduro-25L-4.0-Backpack-BLACKOUT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923307.html?dwvar_25923307_color=BLACKOUT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923306_FORGED-IRON-REDLINE_0/Enduro-25L-4.0-Backpack-FORGED-IRON-REDLINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923306.html?dwvar_25923306_color=FORGED-IRON-REDLINE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923308_MIST_0/Enduro-25L-4.0-Backpack-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923308.html?dwvar_25923308_color=MIST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907007_RAZZLE-RASPBERRY_0/Aura-Crossbody-Bag-RAZZLE-RASPBERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-taille-et-sacs-ceinture/sac-%C3%A0-bandouli%C3%A8re-aura/25907007.html?dwvar_25907007_color=RAZZLE-RASPBERRY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917290_CLOUD-DANCER_0/Mens-Chris-Life-Short-Seeve-T-Shirt-CLOUD-DANCER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Chris Life pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Chris Life pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">15,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-chris-life-pour-hommes/25917290.html?dwvar_25917290_color=CLOUD-DANCER&amp;dwvar_25917290_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917916_RED_0/Womens-SL-72-OG-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25917916.html?dwvar_25917916_color=RED&amp;dwvar_25917916_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922692_0/WZRD-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball WZRD" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball WZRD</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-wzrd/25922692.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25464470_0/Patella-Knee-Strap?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sangle pour le genou" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sangle pour le genou</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">19,99 $</div>
+              <div style="font-weight:800">14,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/sangle-pour-le-genou/25464470.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912064_PINK_0/Mens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-hommes/25912064.html?dwvar_25912064_color=PINK&amp;dwvar_25912064_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922691_0/BALLR-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball BALLR+" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball BALLR+</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-ballr%2B/25922691.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916430_MULTI_0/Skills-Next-Nature-Mini-Basketball-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Mini-ballon de basketball Skills Next Nature" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-22% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Mini-ballon de basketball Skills Next Nature</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">18,00 $</div>
+              <div style="font-weight:800">13,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/loisirs-aquatiques/gilets-de-sauvetage-et-protection-contre-leau/mini-ballon-de-basketball-skills-next-nature/25916430.html?dwvar_25916430_color=MULTI&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921136_BLACK_0/Recharge-Stainless-Steel-Straw-Bottle-32-oz-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille en acier inoxydable Recharge avec paille (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille en acier inoxydable Recharge avec paille (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteilles-deau-et-gobelets/acier-inoxydable/bouteille-en-acier-inoxydable-recharge-avec-paille-32-oz/25921136.html?dwvar_25921136_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921827_TIGER-CAMO_0/Lunch-Box-5L-TIGER-CAMO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-5l/25921827.html?dwvar_25921827_color=TIGER-CAMO&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921828_BLACK-ONYX_0/Snacktime-Lunch-Box-5L-BLACK-ONYX?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921828.html?dwvar_25921828_color=BLACK-ONYX&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921826_RUBBER_0/Snacktime-Lunch-Box-5L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921826.html?dwvar_25921826_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921825_TRELLIS_0/Snacktime-Lunch-Box-5L-TRELLIS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921825.html?dwvar_25921825_color=TRELLIS&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922184_WHITE_0/Junior-Boys-8-20-Cotton-Seersucker-Short-Sleeve-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-35% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/chemise-%C3%A0-manches-courtes-en-coton-seersucker-pour-gar%C3%A7ons-juniors-8-20/25922184.html?dwvar_25922184_color=WHITE&amp;dwvar_25922184_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917289_DARK-SAPPHIRE_0/Mens-Kasper-Knit-Resort-Shirt-DARK-SAPPHIRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Kasper Resort en tricot pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Kasper Resort en tricot pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">52,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-kasper-resort-en-tricot-pour-hommes/25917289.html?dwvar_25917289_color=DARK-SAPPHIRE&amp;dwvar_25917289_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721226_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">250,00 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721226.html?dwvar_25721226_color=BLACK&amp;dwvar_25721226_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721234_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">260,00 $</div>
+              <div style="font-weight:800">194,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721234.html?dwvar_25721234_color=BLACK&amp;dwvar_25721234_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917111_GREY-MIST_0/Womens-Evida-Short-Dress-GREY-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe courte Evida pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe courte Evida pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-courte-evida-pour-femmes/25917111.html?dwvar_25917111_color=GREY-MIST&amp;dwvar_25917111_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917281_DARK-NAVY_0/Mens-Loc-Short-DARK-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short Loc pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-64% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short Loc pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">69,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/shorts/short-loc-pour-hommes/25917281.html?dwvar_25917281_color=DARK-NAVY&amp;dwvar_25917281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907031_PARACHUTE-BEIGE_0/Heritage-Crossbody-Bag-PARACHUTE-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac bandoulière Heritage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac bandoulière Heritage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-bandouli%C3%A8re-heritage/25907031.html?dwvar_25907031_color=PARACHUTE-BEIGE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25906991_BLACK_0/Aura-Crossbody-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-%C3%A0-bandouli%C3%A8re-aura/25906991.html?dwvar_25906991_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918278_DEEP-TEAL_0/Mens-Gills-Camp-Shirt-DEEP-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gills Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gills Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gills-camp-pour-hommes/25918278.html?dwvar_25918278_color=DEEP-TEAL&amp;dwvar_25918278_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918281_CHARCOAL_0/Mens-Trailer-Rider-2.0-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Trailer Rider 2.0 Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Trailer Rider 2.0 Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-trailer-rider-2.0-camp-pour-hommes/25918281.html?dwvar_25918281_color=CHARCOAL&amp;dwvar_25918281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918276_NAVY_0/Mens-Baywatch-Camp-Shirt-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Baywatch Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Baywatch Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-baywatch-camp-pour-hommes/25918276.html?dwvar_25918276_color=NAVY&amp;dwvar_25918276_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918279_CHARCOAL_0/Mens-Star-Gazer-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Star Gazer Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Star Gazer Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-star-gazer-camp--pour-hommes/25918279.html?dwvar_25918279_color=CHARCOAL&amp;dwvar_25918279_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918280_BUTTER-CREAM_0/Mens-Cottage-Country-Camp-Shirt-BUTTER-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Cottage Country Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Cottage Country Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-cottage-country-camp-pour-hommes/25918280.html?dwvar_25918280_color=BUTTER-CREAM&amp;dwvar_25918280_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918277_WHITE_0/Mens-Gear-Up-Camp-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gear Up Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gear Up Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gear-up-camp-pour-hommes/25918277.html?dwvar_25918277_color=WHITE&amp;dwvar_25918277_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921654_BLACK_0/Mens-Endorphin-Speed-4-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Endorphin Speed 4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Endorphin Speed 4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">220,00 $</div>
+              <div style="font-weight:800">164,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-de-stabilite/chaussures-de-course-endorphin-speed-4-pour-hommes/25921654.html?dwvar_25921654_color=BLACK&amp;dwvar_25921654_size=14&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917736_WHITE_0/Junior-Girls-7-16-Big-Pony-Logo-Terry-Dress-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/robes/robe-en-tissu-eponge-avec-logo-big-pony-pour-filles-juniors-7-16/25917736.html?dwvar_25917736_color=WHITE&amp;dwvar_25917736_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917380_CORAL_0/Mens-Allover-Print-Short-Sleeve-Shirt-CORAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes à motif intégral pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes à motif intégral pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-%C3%A0-motif-integral-pour-hommes/25917380.html?dwvar_25917380_color=CORAL&amp;dwvar_25917380_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917765_BLUE_0/Junior-Boys-8-20-Relaxed-Fit-Flex-Abrasion-Twill-Short-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,50 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/shorts/short-en-serge-flex-abrasion-relaxed-fit-pour-gar%C3%A7ons-juniors-8-20/25917765.html?dwvar_25917765_color=BLUE&amp;dwvar_25917765_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917383_BLUE_0/Mens-3-Button-Performance-Short-Sleeve-Polo-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo à manches courtes et 3 boutons pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-37% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo à manches courtes et 3 boutons pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">30,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-%C3%A0-manches-courtes-et-3-boutons-pour-hommes/25917383.html?dwvar_25917383_color=BLUE&amp;dwvar_25917383_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917224_NATURAL_0/Mens-Linen-Blend-Pant-NATURAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon en mélange de lin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon en mélange de lin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">53,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-en-melange-de-lin-pour-hommes/25917224.html?dwvar_25917224_color=NATURAL&amp;dwvar_25917224_size=XXL&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917379_OFF-WHITE_0/Mens-Striped-Short-Sleeve-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes rayée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes rayée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">34,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-rayee-pour-hommes/25917379.html?dwvar_25917379_color=OFF-WHITE&amp;dwvar_25917379_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917381_GREY_0/Mens-Camp-Short-Sleeve-Shirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">54,50 $</div>
+              <div style="font-weight:800">38,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-camp-pour-hommes/25917381.html?dwvar_25917381_color=GREY&amp;dwvar_25917381_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917375_OFF-WHITE_0/Mens-Expeditions-of-the-Obsessed-T-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Expeditions of the Obsessed pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Expeditions of the Obsessed pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-expeditions-of-the-obsessed-pour-hommes/25917375.html?dwvar_25917375_color=OFF-WHITE&amp;dwvar_25917375_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916161_BALTIC-BLUE-BLACK-IRIDESCENT_0/Refuel-Locking-Lid-Water-Bottle-32-oz-BALTIC-BLUE-BLACK-IRIDESCENT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Montréal</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">24,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteille-deau-refuel-avec-couvercle-verrouillable-32-oz/25916161.html?dwvar_25916161_color=BALTIC-BLUE-BLACK-IRIDESCENT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        </div>
+</body>

--- a/previews/sporting-life/saint-jerome.html
+++ b/previews/sporting-life/saint-jerome.html
@@ -1,0 +1,2807 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Sporting Life — Saint-Jérôme</title>
+<body style="font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;background:#0f172a;color:#e5e7eb;margin:0;padding:24px">
+<h1 style="font-size:22px;margin:0 0 16px">Sporting Life — Saint-Jérôme (2790 articles, aperçu 200 premiers)</h1>
+<div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px">
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772625_UTILITY-BROWN_0/Mens-Aconcagua-3-Jacket-UTILITY-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-32% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">183,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-aconcagua-3-pour-hommes/25772625.html?dwvar_25772625_color=UTILITY-BROWN&amp;dwvar_25772625_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25772666_TNF-BLACK-NPF_0/Mens-Aconcagua-3-Vest-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet Aconcagua 3 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet Aconcagua 3 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">199,99 $</div>
+              <div style="font-weight:800">140,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-aconcagua-3-pour-hommes/25772666.html?dwvar_25772666_color=TNF-BLACK-NPF&amp;dwvar_25772666_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25885666_WHITE_0/Unisex-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">159,99 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25885666.html?dwvar_25885666_color=WHITE&amp;dwvar_25885666_size=10.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909847_LIGHT-HEATHER-GREY_0/Womens-Mayfield-Hoodie-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Mayfield pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Mayfield pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">105,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-mayfield-pour-femmes/25909847.html?dwvar_25909847_color=LIGHT-HEATHER-GREY&amp;dwvar_25909847_size=10%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25913930_BLUE_0/Womens-SL-72-OG-Shoe-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25913930.html?dwvar_25913930_color=BLUE&amp;dwvar_25913930_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25596362_BEIGE_0/Womens-327-Shoe-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 327 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 327 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-327-pour-femmes/25596362.html?dwvar_25596362_color=BEIGE&amp;dwvar_25596362_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902024_BLACK_0/Womens-Dalia-Crop-T-Shirt-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt court Dalia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-56% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt court Dalia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">42,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/t-shirts/t-shirt-court-dalia-pour-femmes/25902024.html?dwvar_25902024_color=BLACK&amp;dwvar_25902024_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25815960_BLACK_0/Womens-Kathleen-Slim-Boyfriend-Jean-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean coupe boyfriend ajustée Kathleen pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-55% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean coupe boyfriend ajustée Kathleen pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">65,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/denim/jean-coupe-boyfriend-ajustee-kathleen-pour-femmes/25815960.html?dwvar_25815960_color=BLACK&amp;dwvar_25815960_size=24&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768227_RED_0/Womens-Wink-Nylon-Waterproof-Boot-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Wink en nylon pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Wink en nylon pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-wink-en-nylon-pour-femmes/25768227.html?dwvar_25768227_color=RED&amp;dwvar_25768227_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887464_BLACK_0/Mens-Brooklin-2441-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Brooklin 2441 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Brooklin 2441 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">398,00 $</div>
+              <div style="font-weight:800">282,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-brooklin-2441-pour-hommes/25887464.html?dwvar_25887464_color=BLACK&amp;dwvar_25887464_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902719_LIGHT-HEATHER-GREY_0/Mens-Prep-Logo-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail Prep Logo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail Prep Logo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">175,00 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-prep-logo-pour-hommes/25902719.html?dwvar_25902719_color=LIGHT-HEATHER-GREY&amp;dwvar_25902719_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25299835_BLACK_0/Mens-Essential-Carn-Baffle-Zip-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à glissière Carn pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à glissière Carn pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">255,00 $</div>
+              <div style="font-weight:800">171,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-glissi%C3%A8re-carn-pour-hommes/25299835.html?dwvar_25299835_color=BLACK&amp;dwvar_25299835_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912288_WHITE_0/Mens-SL-72-RS-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 RS pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 RS pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-sl-72-rs-pour-hommes/25912288.html?dwvar_25912288_color=WHITE&amp;dwvar_25912288_size=7.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914599_WHITE-NAVY_0/Unisex-550-Shoe-WHITE-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">150,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-550-unisexes/25914599.html?dwvar_25914599_color=WHITE-NAVY&amp;dwvar_25914599_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25780842_BLACK_0/Womens-Multi-Logo-Scoop-Neck-Bikini-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut de bikini Multi Logo à encolure ronde pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut de bikini Multi Logo à encolure ronde pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">68,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-2-pi%C3%A8ces/haut-de-bikini-multi-logo-%C3%A0-encolure-ronde-pour-femmes/25780842.html?dwvar_25780842_color=BLACK&amp;dwvar_25780842_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862350_BLACK_0/Womens-Trail-Repel-Running-Vest-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet de course hydrofuge Trail pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-46% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet de course hydrofuge Trail pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">69,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/vestes-et-manteaux/vestes-de-course/gilet-de-course-hydrofuge-trail-pour-femmes/25862350.html?dwvar_25862350_color=BLACK&amp;dwvar_25862350_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25870346_TAN_0/Womens-Anacapa-2-Freedom-Hiking-Shoe-TAN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de randonnée Anacapa 2 Freedom pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de randonnée Anacapa 2 Freedom pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-randonnee/chaussures-de-randonnee-anacapa-2-freedom-pour-femmes/25870346.html?dwvar_25870346_color=TAN&amp;dwvar_25870346_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911868_WHITE_0/Womens-Adizero-Aruku-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911868.html?dwvar_25911868_color=WHITE&amp;dwvar_25911868_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25881525_BLACK_0/Sportswear-RPM-Tote-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac fourre-tout Sportswear RPM" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac fourre-tout Sportswear RPM</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">105,00 $</div>
+              <div style="font-weight:800">83,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-fourre-tout-sportswear-rpm/25881525.html?dwvar_25881525_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738618_IRON-GREY_0/Mens-Club-Therma-FIT-Puffer-Vest-IRON-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Gilet bouffant Club Therma-FIT pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Gilet bouffant Club Therma-FIT pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">125,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes/gilet-bouffant-club-therma-fit-pour-hommes/25738618.html?dwvar_25738618_color=IRON-GREY&amp;dwvar_25738618_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25614751_BLUE_0/Undeniable-5.0-Duffel-Bag-Medium-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Undeniable 5.0 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Undeniable 5.0 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-undeniable-5.0-moyen/25614751.html?dwvar_25614751_color=BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25744657_BLACK_0/Unisex-480-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 480 unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 480 unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">89,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-480-unisexes/25744657.html?dwvar_25744657_color=BLACK&amp;dwvar_25744657_size=4%20%20%20%20%20%20Siz&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915657_WHITE-RED-BLUE_0/Womens-Cortez-Leather-Shoe-WHITE-RED-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-femmes/25915657.html?dwvar_25915657_color=WHITE-RED-BLUE&amp;dwvar_25915657_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25520644_BURGUNDY_0/Juniors-7-16-Knit-Beanie-BURGUNDY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Tuque en tricot pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-57% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Tuque en tricot pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">28,00 $</div>
+              <div style="font-weight:800">11,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/accessoires/chapeaux/winter-hats/tuque-en-tricot-pour-juniors-7-16/25520644.html?dwvar_25520644_color=BURGUNDY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893116_LIGHT-HEATHER-GREY_0/Junior-Boys-8-16-Logo-Crew-Sweatshirt-LIGHT-HEATHER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras du cou Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras du cou Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-col-ras-du-cou-logo-pour-gar%C3%A7ons-juniors-8-16/25893116.html?dwvar_25893116_color=LIGHT-HEATHER-GREY&amp;dwvar_25893116_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25893090_BLACK_0/Junior-Boys-8-16-Logo-Pullover-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Logo pour garçons juniors [8-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Logo pour garçons juniors [8-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">111,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-logo-pour-gar%C3%A7ons-juniors-8-16/25893090.html?dwvar_25893090_color=BLACK&amp;dwvar_25893090_size=12%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742305_BLACK_0/Kids-11-3-Gazelle-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour enfants [11-3]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour enfants [11-3]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/espadrilles-decontractees/chaussures-gazelle-pour-enfants-11-3/25742305.html?dwvar_25742305_color=BLACK&amp;dwvar_25742305_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878430_TNF-BLACK_0/Junior-Girls-7-20-Zaphira-Synthetic-Snow-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste de neige synthétique Zaphira pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste de neige synthétique Zaphira pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">269,99 $</div>
+              <div style="font-weight:800">190,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-de-neige-synthetique-zaphira-pour-filles-juniors-7-20/25878430.html?dwvar_25878430_color=TNF-BLACK&amp;dwvar_25878430_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878455_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-Wide-Leg-Pant-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon à jambe large en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon à jambe large en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-%C3%A0-jambe-large-en-molleton-camp-pour-filles-juniors-7-20/25878455.html?dwvar_25878455_color=TNF-BLACK&amp;dwvar_25878455_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903436_0/Juniors-Flair-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Flair Jr + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-flair-jr-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903436_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805490_0/Juniors-Experience-Pro-Ski--Kid-4-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-14% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience Pro + Fixations Kid 4 GW pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-pro-%2B-fixations-kid-4-gw-pour-juniors-2025/25805490_000_104.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883489_BLUE_0/Mens-Arctic-Crest153-Down-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet Arctic Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet Arctic Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">369,99 $</div>
+              <div style="font-weight:800">209,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-en-duvet-arctic-crest-pour-hommes/25883489.html?dwvar_25883489_color=BLUE&amp;dwvar_25883489_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883471_BLACK_0/Mens-Slope-Style153-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Slope Style pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Slope Style pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">141,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-slope-style-pour-hommes/25883471.html?dwvar_25883471_color=BLACK&amp;dwvar_25883471_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25805177_0/Experience-76-W-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 W + fixation Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 W + fixation Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">579,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-w-%2B-fixation-xpress-10-gw-2025/25805177_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25806597_0/Deacon-ST-Ski--vMotion-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Deacon ST + Fixations vMotion 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Deacon ST + Fixations vMotion 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,99 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-deacon-st-%2B-fixations-vmotion-10-gw-2025/25806597_000_161.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882184_0/S/View-Photochromic-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de sports de neige S/View à lentilles photochromiques" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de sports de neige S/View à lentilles photochromiques</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,95 $</div>
+              <div style="font-weight:800">79,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-sports-de-neige-s-view-%C3%A0-lentilles-photochromiques/25882184.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879255_0/Mens-S/Pro-Sport-MV-100-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Sport MV 100 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Sport MV 100 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">349,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-sport-mv-100-pour-hommes-2025/25879255_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916153_TNF-RED_0/Juniors-7-20-DryVent153-Mono-Mountain-Jacket-TNF-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste DryVent Mono Mountain pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste DryVent Mono Mountain pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,99 $</div>
+              <div style="font-weight:800">176,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-dryvent-mono-mountain-pour-juniors-7-20/25916153.html?dwvar_25916153_color=TNF-RED&amp;dwvar_25916153_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916173_BLACK_0/Juniors-11-6-Solid-Waterproof-Rain-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de pluie imperméables pour enfants [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de pluie imperméables pour enfants [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-et-chaussures-decontractees/bottes-de-pluie-impermeables-pour-enfants-11-6/25916173.html?dwvar_25916173_color=BLACK&amp;dwvar_25916173_size=11&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25909797_MULTI_0/Womens-Helen-Knit-Sweater-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail en tricot Helene pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-48% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail en tricot Helene pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">235,00 $</div>
+              <div style="font-weight:800">122,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails/chandail-en-tricot-helene-pour-femmes/25909797.html?dwvar_25909797_color=MULTI&amp;dwvar_25909797_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911553_PINK_0/Womens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25911553.html?dwvar_25911553_color=PINK&amp;dwvar_25911553_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25823618_WHITE_0/Womens-550-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 550 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 550 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-550-pour-femmes/25823618.html?dwvar_25823618_color=WHITE&amp;dwvar_25823618_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25861865_BLACK_0/Junior-Girls-7-16-Sportswear-Varsity-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Varsity Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Varsity Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/styles/de-sport/vestes/veste-varsity-sportswear-pour-filles-juniors-7-16/25861865.html?dwvar_25861865_color=BLACK&amp;dwvar_25861865_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883109_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Pullover-Hoodie-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">70,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-%C3%A0-capuchon-doux-sportswear-pour-filles-7-16/25883109.html?dwvar_25883109_color=BOLD-BERRY&amp;dwvar_25883109_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822859_BLACK_0/Junior-Girls-7-16-Sportswear-Wide-Leg-Track-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de survêtement à jambe large Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">36,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalon-de-surv%C3%AAtement-%C3%A0-jambe-large-sportswear-pour-filles-juniors-7-16/25822859.html?dwvar_25822859_color=BLACK&amp;dwvar_25822859_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25754573_BLACK_0/Juniors-11-6-Shani-K-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Shani K pour juniors [11-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Shani K pour juniors [11-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/bottes-dhiver/bottes-impermeables-shani-k-pour-juniors-11-6/25754573.html?dwvar_25754573_color=BLACK&amp;dwvar_25754573_size=1&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876749_ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD_0/Mens-Yumiori-1/4-Zip-Top-ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 Yumiori pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 Yumiori pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">114,99 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-yumiori-pour-hommes/25876749.html?dwvar_25876749_color=ASPHALT-GREY-BURNT-UMBER-SUMMIT-GOLD&amp;dwvar_25876749_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25904665_0/Experience-76-Ski--Xpress-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Experience 76 et fixations Xpress 10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Experience 76 et fixations Xpress 10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,95 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-experience-76-et-fixations-xpress-10-gw-2025/25904665_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763939_0/Mens-S/Pro-Alpha-120-EL-Ski-Boot-2024?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Alpha 120 EL pour hommes [2024]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Alpha 120 EL pour hommes [2024]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">419,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-alpha-120-el-pour-hommes-2024/25763939_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524638_TNF-BLACK-NPF_0/Mens-McMurdo-Parka-TNF-BLACK-NPF?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Parka McMurdo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Parka McMurdo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">368,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/parkas/parka-mcmurdo-pour-hommes/25524638.html?dwvar_25524638_color=TNF-BLACK-NPF&amp;dwvar_25524638_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876400_TNF-BLK-TNF-BLK_0/Mens-Horizon-Performance-Fleece-Pullover-Hoodie-TNF-BLK-TNF-BLK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon molletonné Horizon Perfomance pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-45% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon molletonné Horizon Perfomance pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">104,99 $</div>
+              <div style="font-weight:800">57,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-molletonne-horizon-perfomance-pour-hommes/25876400.html?dwvar_25876400_color=TNF-BLK-TNF-BLK&amp;dwvar_25876400_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25914532_WHITE-PINK-GOLD_0/Unisex-1906R-Shoe-WHITE-PINK-GOLD?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures 1906R unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures 1906R unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">149,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-1906r-unisexes/25914532.html?dwvar_25914532_color=WHITE-PINK-GOLD&amp;dwvar_25914532_size=4.5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912312_RED_0/Unisex-Adizero-Aruku-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Aruku Adizero unisexes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Aruku Adizero unisexes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-aruku-adizero-unisexes/25912312.html?dwvar_25912312_color=RED&amp;dwvar_25912312_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25781691_BLACK_0/Womens-All-SZN-Fleece-Graphic-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon ALL SZN Fleece Graphic pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-59% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon ALL SZN Fleece Graphic pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-all-szn-fleece-graphic-pour-femmes/25781691.html?dwvar_25781691_color=BLACK&amp;dwvar_25781691_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919220_WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE_0/Womens-Pacific-Shoe-WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-pacific-pour-femmes/25919220.html?dwvar_25919220_color=WHITE-BLACK-PLATINUM-TINT-SAFETY-ORANGE&amp;dwvar_25919220_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911827_TURQUOISE_0/Womens-SL-72-OG-Shoe-TURQUOISE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25911827.html?dwvar_25911827_color=TURQUOISE&amp;dwvar_25911827_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915656_BLACK_0/Mens-Cortez-Leather-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Cortez en cuir pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Cortez en cuir pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">95,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-cortez-en-cuir-pour-hommes/25915656.html?dwvar_25915656_color=BLACK&amp;dwvar_25915656_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900473_DARK-BLUE_0/Mens-Passerby-Long-Sleeve-Polo-DARK-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo manches longues Passerby pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-36% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo manches longues Passerby pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">148,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-manches-longues-passerby-pour-hommes/25900473.html?dwvar_25900473_color=DARK-BLUE&amp;dwvar_25900473_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918286_BLACK_0/Mens-Olmec-Bomber-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur Olmec pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur Olmec pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">458,00 $</div>
+              <div style="font-weight:800">259,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-olmec-pour-hommes/25918286.html?dwvar_25918286_color=BLACK&amp;dwvar_25918286_size=48&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901356_BLACK_0/Mens-Nallico-Hoodie-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon Nallico pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-47% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon Nallico pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">158,00 $</div>
+              <div style="font-weight:800">82,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-nallico-pour-hommes/25901356.html?dwvar_25901356_color=BLACK&amp;dwvar_25901356_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917641_BROWN_0/Mens-Samba-Shoe-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Samba pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Samba pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-samba-pour-hommes/25917641.html?dwvar_25917641_color=BROWN&amp;dwvar_25917641_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919214_BLACK_0/Mens-Pacific-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Pacific pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Pacific pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">100,00 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-pacific-pour-hommes/25919214.html?dwvar_25919214_color=BLACK&amp;dwvar_25919214_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25901679_BLACK_0/Womens-Nelva-Sweatshirt-Dress-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe chandail Nelva pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe chandail Nelva pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">198,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-chandail-nelva-pour-femmes/25901679.html?dwvar_25901679_color=BLACK&amp;dwvar_25901679_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917095_OPEN-MISCELLANEOUS_0/Womens-Vantia-Skirt-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jupe Vantia pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jupe Vantia pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">288,00 $</div>
+              <div style="font-weight:800">120,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/jupes/jupe-vantia-pour-femmes/25917095.html?dwvar_25917095_color=OPEN-MISCELLANEOUS&amp;dwvar_25917095_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25489162_WHITE_0/Womens-Stan-Smith-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Stan Smith pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Stan Smith pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">103,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-stan-smith-pour-femmes/25489162.html?dwvar_25489162_color=WHITE&amp;dwvar_25489162_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25742669_BLACK_0/Womens-Gazelle-Bold-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25742669.html?dwvar_25742669_color=BLACK&amp;dwvar_25742669_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878398_MUTED-PINE_0/Junior-Girls-7-20-Reversible-Shasta-Full-Zip-Jacket-MUTED-PINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon réversible Shasta pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon réversible Shasta pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">174,99 $</div>
+              <div style="font-weight:800">123,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-%C3%A0-capuchon-reversible-shasta-pour-filles-juniors-7-20/25878398.html?dwvar_25878398_color=MUTED-PINE&amp;dwvar_25878398_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878703_MAUVE_0/Juniors-7-20-Winter-Floral-Camp-Fleece-Pullover-Hoodie-MAUVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail d&#x27;hiver à capuchon en molleton Floral Camp pour juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/chandail-dhiver-%C3%A0-capuchon-en-molleton-floral-camp-pour-juniors-7-20/25878703.html?dwvar_25878703_color=MAUVE&amp;dwvar_25878703_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883117_BOLD-BERRY_0/Junior-Girls-7-16-Sportswear-Soft-Jogger-Pant-BOLD-BERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon de jogging doux Sportswear pour filles [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon de jogging doux Sportswear pour filles [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/pantalons/pantalons-de-jogging-et-en-molleton/pantalon-de-jogging-doux-sportswear-pour-filles-7-16/25883117.html?dwvar_25883117_color=BOLD-BERRY&amp;dwvar_25883117_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25903410_0/Juniors-Peregrine-Jr-Ski--vMotion-7.0-Jr-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-17% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Peregrine + fixations vMotion 7.0 Jr pour juniors [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">239,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-peregrine-%2B-fixations-vmotion-7.0-jr-pour-juniors-2025/25903410_000_080.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25882598_0/Mens-Evader-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Evader pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Evader pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">419,95 $</div>
+              <div style="font-weight:800">249,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-evader-pour-hommes-2025/25882598_000_144.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25771940_0/Mens-Ripcord-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Ripcord Flat Top pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Ripcord Flat Top pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">549,99 $</div>
+              <div style="font-weight:800">329,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-ripcord-flat-top-pour-hommes-2025/25771940_000_150.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902974_0/Mens-Moto-Boa-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Moto Boa® pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Moto Boa® pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">339,99 $</div>
+              <div style="font-weight:800">269,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-moto-boa-pour-hommes-2025/25902974_000_070.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902636_0/Mens-Mission-ReFlex-Snowboard-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Fixations de planche à neige Mission Re:Flex pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Fixations de planche à neige Mission Re:Flex pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">299,99 $</div>
+              <div style="font-weight:800">224,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/fixations-de-planche-%C3%A0-neige-mission-re%3Aflex-pour-hommes-2025/25902636_000_005.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876822_TNF-BLACK_0/Mens-Crest-1/4-Zip-Fleece-Pullover-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut en molleton à fermeture éclair 1/4 Crest pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut en molleton à fermeture éclair 1/4 Crest pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,99 $</div>
+              <div style="font-weight:800">91,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/haut-en-molleton-%C3%A0-fermeture-eclair-1-4-crest-pour-hommes/25876822.html?dwvar_25876822_color=TNF-BLACK&amp;dwvar_25876822_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25876186_TNF-BLACK_0/Mens-MTN-Range-Down-Jacket-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste en duvet MTN Range pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste en duvet MTN Range pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">325,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-en-duvet-mtn-range-pour-hommes/25876186.html?dwvar_25876186_color=TNF-BLACK&amp;dwvar_25876186_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768490_GREY_0/Womens-Hannah-Zip-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes à glissière Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-61% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes à glissière Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-%C3%A0-glissi%C3%A8re-hannah-pour-femmes/25768490.html?dwvar_25768490_color=GREY&amp;dwvar_25768490_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25871476_CREAM_0/Womens-Steez-Waterproof-Sneaker-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Espadrilles imperméables Steez pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Espadrilles imperméables Steez pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">53,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/espadrilles-impermeables-steez-pour-femmes/25871476.html?dwvar_25871476_color=CREAM&amp;dwvar_25871476_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25761099_0/Radium-Prime-Sigma-Snow-Goggle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Lunettes de ski Radium Prime Sigma" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Lunettes de ski Radium Prime Sigma</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">279,95 $</div>
+              <div style="font-weight:800">194,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/lunettes-de-ski-radium-prime-sigma/25761099.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25774779_0/Womens-Stylus-Flat-Top-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Stylus Flat Top pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Stylus Flat Top pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">359,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-stylus-flat-top-pour-femmes-2025/25774779_000_147.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25524380_0/Womens-Limelight-Step-On-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Limelight Step On® pour femmes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Limelight Step On® pour femmes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">459,99 $</div>
+              <div style="font-weight:800">344,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-limelight-step-on-pour-femmes-2025/25524380_000_060.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886045_YELLOW_0/Mens-GORE-TEX-2L-Pillowline-Jacket-YELLOW?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste GORE-TEX® 2L Pillowline pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-24% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste GORE-TEX® 2L Pillowline pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">519,99 $</div>
+              <div style="font-weight:800">394,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-planche-%C3%A0-neige/veste-gore-tex-2l-pillowline-pour-hommes/25886045.html?dwvar_25886045_color=YELLOW&amp;dwvar_25886045_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25890658_BLACK_0/Mens-Opside-Hoodie-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste à capuchon Opside pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste à capuchon Opside pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">350,00 $</div>
+              <div style="font-weight:800">247,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-%C3%A0-capuchon-opside-pour-hommes/25890658.html?dwvar_25890658_color=BLACK&amp;dwvar_25890658_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25886094_OLIVE_0/Mens-Oak-Crew-Neck-Fleece-Sweatshirt-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col rond en molleton Oak pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col rond en molleton Oak pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-rond-en-molleton-oak-pour-hommes/25886094.html?dwvar_25886094_color=OLIVE&amp;dwvar_25886094_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25767526_0/Stance-80-W-Ski--M-10-GW-Binding-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Skis Stance 80 + fixations M10 GW [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Skis Stance 80 + fixations M10 GW [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">649,95 $</div>
+              <div style="font-weight:800">389,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/skis-stance-80-%2B-fixations-m10-gw-2025/25767526_000_141.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763921_0/Mens-S/Pro-Supra-Boa-110-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Botte de ski S/Pro Supra Boa 110 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Botte de ski S/Pro Supra Boa 110 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">699,95 $</div>
+              <div style="font-weight:800">489,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/botte-de-ski-s-pro-supra-boa-110-pour-hommes-2025/25763921_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25766650_0/Mens-S/Pro-Supra-Boa-120-Ski-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de ski S/Pro Supra Boa 120 pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">799,95 $</div>
+              <div style="font-weight:800">559,97 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-ski-s-pro-supra-boa-120-pour-hommes-2025/25766650_000_255.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25743030_BLACK_0/Womens-Thermo-Fractal-Mid-Waterproof-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables Thermo Fractal Mid pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-71% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables Thermo Fractal Mid pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">190,00 $</div>
+              <div style="font-weight:800">54,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-thermo-fractal-mid-pour-femmes/25743030.html?dwvar_25743030_color=BLACK&amp;dwvar_25743030_size=5&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25572520_BLACK_0/Womens-Hannah-Mid-Boot-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes mi-hautes Hannah pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes mi-hautes Hannah pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">120,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-mi-hautes-hannah-pour-femmes/25572520.html?dwvar_25572520_color=BLACK&amp;dwvar_25572520_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25738600_FIR-GREEN_0/Mens-Sportswear-Club-Puffer-Jacket-FIR-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste bouffante Sportswear Club pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-34% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste bouffante Sportswear Club pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">158,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/veste-bouffante-sportswear-club-pour-hommes/25738600.html?dwvar_25738600_color=FIR-GREEN&amp;dwvar_25738600_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25737784_GREY_0/Mens-Tech-Fleece-Crew-Sweatshirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à col ras-du-cou Tech Fleece pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à col ras-du-cou Tech Fleece pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">140,00 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-col-ras-du-cou-tech-fleece-pour-hommes/25737784.html?dwvar_25737784_color=GREY&amp;dwvar_25737784_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856188_AQUA_0/Womens-Gazelle-Shoe-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-femmes/25856188.html?dwvar_25856188_color=AQUA&amp;dwvar_25856188_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25856642_WHITE_0/Mens-Samba-OG-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chausssures Samba OG pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chausssures Samba OG pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chausssures-samba-og-pour-hommes/25856642.html?dwvar_25856642_color=WHITE&amp;dwvar_25856642_size=10&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25911876_GREEN_0/Womens-Adizero-Aruku-Shoe-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Adizero Aruku pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Adizero Aruku pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">180,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-adizero-aruku-pour-femmes/25911876.html?dwvar_25911876_color=GREEN&amp;dwvar_25911876_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840265_BLACK_0/Junior-Girls-7-16-Sportswear-Novelty-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Sportswear Novelty pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Sportswear Novelty pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-sportswear-novelty-pour-filles-juniors-7-16/25840265.html?dwvar_25840265_color=BLACK&amp;dwvar_25840265_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25878448_TNF-BLACK_0/Junior-Girls-7-20-Camp-Fleece-1/4-Zip-Top-TNF-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à glissière 1/4 en molleton Camp pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,99 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/chandails-%C3%A0-capuchon-et-en-molleton/haut-%C3%A0-glissi%C3%A8re-1-4-en-molleton-camp-pour-filles-juniors-7-20/25878448.html?dwvar_25878448_color=TNF-BLACK&amp;dwvar_25878448_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25883232_DARK-GREY-HEATHER_0/Juniors-7-16-Sportswear-Novelty-T-Shirt-DARK-GREY-HEATHER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Sportswear Novelty pour juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Sportswear Novelty pour juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">30,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/t-shirt-sportswear-novelty-pour-juniors-7-16/25883232.html?dwvar_25883232_color=DARK-GREY-HEATHER&amp;dwvar_25883232_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923019_SUPER-GREY_0/Kanken-Laptop-15-Backpack-SUPER-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923019.html?dwvar_25923019_color=SUPER-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918035_BLACK_0/Mens-Ashton-Air-Down-Shirt-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Ashton Air en duvet pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Ashton Air en duvet pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">565,00 $</div>
+              <div style="font-weight:800">338,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-chemise-ashton-air-en-duvet-pour-hommes/25918035.html?dwvar_25918035_color=BLACK&amp;dwvar_25918035_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25889064_OLIVE_0/Mens-Granite-Hybrid-Bomber-Jacket-OLIVE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Blouson aviateur hybride Granite pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-43% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Blouson aviateur hybride Granite pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">645,00 $</div>
+              <div style="font-weight:800">366,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-bomber/blouson-aviateur-hybride-granite-pour-hommes/25889064.html?dwvar_25889064_color=OLIVE&amp;dwvar_25889064_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917322_BLACK_0/Mens-Hadiko-Rib-Pant-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon Hadiko Rib pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon Hadiko Rib pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-hadiko-rib-pour-hommes/25917322.html?dwvar_25917322_color=BLACK&amp;dwvar_25917322_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915666_HOT-MANGO-ANGORA-BLACK_0/Mens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-hommes/25915666.html?dwvar_25915666_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915666_size=8.5&amp;dwvar_25915666_style=D&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25915665_HOT-MANGO-ANGORA-BLACK_0/Womens-FuelCell-Rebel-v4-Running-Shoe-HOT-MANGO-ANGORA-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course FuelCell Rebel v4 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course FuelCell Rebel v4 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">179,99 $</div>
+              <div style="font-weight:800">143,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-course/chaussures-de-course-coussinees/chaussures-de-course-fuelcell-rebel-v4-pour-femmes/25915665.html?dwvar_25915665_color=HOT-MANGO-ANGORA-BLACK&amp;dwvar_25915665_size=6&amp;dwvar_25915665_style=B&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917096_OPEN-MISCELLANEOUS_0/Womens-Dantiana-Dress-OPEN-MISCELLANEOUS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe Dantiana pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe Dantiana pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">298,00 $</div>
+              <div style="font-weight:800">124,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-dantiana-pour-femmes/25917096.html?dwvar_25917096_color=OPEN-MISCELLANEOUS&amp;dwvar_25917096_size=32&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25902016_GREEN_0/Womens-Oversized-B1-Hoodie-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à capuchon surdimensionné B1 pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à capuchon surdimensionné B1 pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">178,00 $</div>
+              <div style="font-weight:800">73,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-capuchon-surdimensionne-b1-pour-femmes/25902016.html?dwvar_25902016_color=GREEN&amp;dwvar_25902016_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779562_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779562.html?dwvar_25779562_color=WHITE&amp;dwvar_25779562_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25779570_WHITE_0/Womens-Gamma-Force-Shoe-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gamma Force pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gamma Force pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">99,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gamma-force-pour-femmes/25779570.html?dwvar_25779570_color=WHITE&amp;dwvar_25779570_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789223_TOBACCO-BLURRED-OMBRE_0/Mens-Windward-II-Shirt-Jacket-TOBACCO-BLURRED-OMBRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise Windward II pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise Windward II pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,99 $</div>
+              <div style="font-weight:800">64,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/veste-chemise-windward-ii-pour-hommes/25789223.html?dwvar_25789223_color=TOBACCO-BLURRED-OMBRE&amp;dwvar_25789223_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25840919_0/Recruit-V3-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Recruit V3" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Recruit V3</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-recruit-v3/25840919.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25625997_0/Composite-Stryker-4-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Stryker 4 en composite" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Stryker 4 en composite</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">71,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-stryker-4-en-composite/25625997.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916125_ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT_0/Junior-Girls-7-20-Cyclone-Wind-Jacket-ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste coupe-vent Cyclone pour filles juniors [7-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste coupe-vent Cyclone pour filles juniors [7-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">79,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-coupe-vent-cyclone-pour-filles-juniors-7-20/25916125.html?dwvar_25916125_color=ESTATE-BLUE-FLUORESCENT-FLORAL-PRINT&amp;dwvar_25916125_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919618_TRUE-BLACK_0/Mens-Veridry-2L-Rain-Jacket-TRUE-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau de pluie Veridry 2L pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau de pluie Veridry 2L pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">229,99 $</div>
+              <div style="font-weight:800">108,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/v%C3%AAtements-techniques/manteau-de-pluie-veridry-2l-pour-hommes/25919618.html?dwvar_25919618_color=TRUE-BLACK&amp;dwvar_25919618_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25879032_BROWN_0/Mens-Skateboarding-Quarter-Zip-Sweatshirt-BROWN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chandail à glissière quart de longueur Skateboarding pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chandail à glissière quart de longueur Skateboarding pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">98,00 $</div>
+              <div style="font-weight:800">48,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/chandails-%C3%A0-capuchon-et-chandails-en-molleton/chandail-%C3%A0-glissi%C3%A8re-quart-de-longueur-skateboarding-pour-hommes/25879032.html?dwvar_25879032_color=BROWN&amp;dwvar_25879032_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25849977_KHAKI_0/Mens-511-Slim-Fit-Jean-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Jean 511 à coupe ajustée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Jean 511 à coupe ajustée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">118,00 $</div>
+              <div style="font-weight:800">48,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/denim/jean-511-%C3%A0-coupe-ajustee-pour-hommes/25849977.html?dwvar_25849977_color=KHAKI&amp;dwvar_25849977_size=29&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822073_AQUA_0/Juniors-1-7-Base-Camp-III-Slide-Sandal-AQUA?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Base Camp III pour juniors [1-7]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-51% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Base Camp III pour juniors [1-7]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">44,99 $</div>
+              <div style="font-weight:800">21,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-base-camp-iii-pour-juniors-1-7/25822073.html?dwvar_25822073_color=AQUA&amp;dwvar_25822073_size=2&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25364399_BLUE_0/Juniors-1-6-Seacamp-II-CNX-Sandal-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sandales Seacamp II CNX pour juniors [1-6]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-60% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sandales Seacamp II CNX pour juniors [1-6]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">29,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/enfants/sandales/sandales-seacamp-ii-cnx-pour-juniors-1-6/25364399.html?dwvar_25364399_color=BLUE&amp;dwvar_25364399_size=4&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25822883_BLACK_0/Junior-Girls-7-16-Sportswear-Oversized-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste surdimensionnée Sportswear pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste surdimensionnée Sportswear pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">44,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-surdimensionnee-sportswear-pour-filles-juniors-7-16/25822883.html?dwvar_25822883_color=BLACK&amp;dwvar_25822883_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25867490_0/IG-Radical-XCeed-Tennis-Racquet?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de tennis IG Radical XCeed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de tennis IG Radical XCeed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">139,95 $</div>
+              <div style="font-weight:800">69,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-tennis-ig-radical-xceed/25867490_000_004.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25862830_0/Tempo-16-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball Tempo 16" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball Tempo 16</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">189,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-tempo-16/25862830.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25763061_WHITE_0/Womens-Tennis-Essentials-Laser-Cut-Crossback-Tank-Top-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Camisole Tennis Essentials à sangles croisées au dos pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-69% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Camisole Tennis Essentials à sangles croisées au dos pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">80,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/camisole-tennis-essentials-%C3%A0-sangles-croisees-au-dos-pour-femmes/25763061.html?dwvar_25763061_color=WHITE&amp;dwvar_25763061_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25757485_MULTI_0/Womens-Dri-FIT-Slam-Tank-Top-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Débardeur NikeCourt Dri-FIT Slam pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Débardeur NikeCourt Dri-FIT Slam pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">95,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/hauts/hauts-de-sport/debardeur-nikecourt-dri-fit-slam-pour-femmes/25757485.html?dwvar_25757485_color=MULTI&amp;dwvar_25757485_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25891730_BLACK_0/Mens-Gavin-Light-Down-Jacket-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau léger en duvet Gavin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau léger en duvet Gavin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">129,00 $</div>
+              <div style="font-weight:800">59,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/manteau-leger-en-duvet-gavin-pour-hommes/25891730.html?dwvar_25891730_color=BLACK&amp;dwvar_25891730_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25768243_GREY_0/Womens-V-Five-Suede-Shearling-Waterproof-Boot-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes imperméables V-Five Leather Shearling pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-70% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes imperméables V-Five Leather Shearling pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">240,00 $</div>
+              <div style="font-weight:800">71,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/bottes-dhiver/bottes-impermeables-v-five-leather-shearling-pour-femmes/25768243.html?dwvar_25768243_color=GREY&amp;dwvar_25768243_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866708_BLUE_0/Mens-5.75-Classic-Fit-Swim-Trunk-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain à coupe classique 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain à coupe classique 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">188,00 $</div>
+              <div style="font-weight:800">93,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-%C3%A0-coupe-classique-575-po-pour-hommes/25866708.html?dwvar_25866708_color=BLUE&amp;dwvar_25866708_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25866690_MULTI_0/Mens-5.75-Traveler-Classic-Swim-Trunk-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain Traveler Classic de 5,75 po pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain Traveler Classic de 5,75 po pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">125,00 $</div>
+              <div style="font-weight:800">61,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/maillots/maillots-de-bain/maillot-de-bain-traveler-classic-de-575-po-pour-hommes/25866690.html?dwvar_25866690_color=MULTI&amp;dwvar_25866690_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25852237_BLACK_0/Womens-Smoothies-Sandbar-One-Piece-Swimsuit-Plus-Size-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-50% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Maillot de bain une pièce Smoothies Sandbar pour femmes (Grandes Tailles)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">64,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/maillots/maillots-1-pi%C3%A8ce/maillot-de-bain-une-pi%C3%A8ce-smoothies-sandbar-pour-femmes-grandes-tailles/25852237.html?dwvar_25852237_color=BLACK&amp;dwvar_25852237_size=1%20%20%20Size%201&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25887381_BLACK_0/Unisex-Lohja-Insulated-Coat-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Manteau isolé Lohja unisexe" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Manteau isolé Lohja unisexe</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">475,00 $</div>
+              <div style="font-weight:800">224,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-dhiver/manteau-isole-lohja-unisexe/25887381.html?dwvar_25887381_color=BLACK&amp;dwvar_25887381_size=Xs%20%20%20X-Sma&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25834771_STONE_0/Mens-Art-Jacket-STONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Art pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Art pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">89,00 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/vestes-intermediaires/veste-art-pour-hommes/25834771.html?dwvar_25834771_color=STONE&amp;dwvar_25834771_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25789207_KHAKI_0/Mens-Landroamer-Quilted-Shirt-Jacket-KHAKI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste-chemise matelassée Landroamer pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste-chemise matelassée Landroamer pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">149,99 $</div>
+              <div style="font-weight:800">70,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/veste-chemise-matelassee-landroamer-pour-hommes/25789207.html?dwvar_25789207_color=KHAKI&amp;dwvar_25789207_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25775065_BLUE_0/Mens-Siz-Jacket-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Siz pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Siz pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">425,00 $</div>
+              <div style="font-weight:800">200,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/vestes-et-manteaux/manteaux-de-ski/veste-siz-pour-hommes/25775065.html?dwvar_25775065_color=BLUE&amp;dwvar_25775065_size=Lg%20%20%20Large&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25407156_ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO_0/Mens-Arroyo-Flannel-Shirt-ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise en flanelle Arroyo pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise en flanelle Arroyo pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">119,99 $</div>
+              <div style="font-weight:800">55,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-en-flanelle-arroyo-pour-hommes/25407156.html?dwvar_25407156_color=ASPHALT-GREY-LARGE-HALF-DOME-STRIPE-TWO&amp;dwvar_25407156_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25638164_BLACK_0/Mens-Pump-Lightweight-Long-Sleeve-Top-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Haut à manches longues léger Pump pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-63% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Haut à manches longues léger Pump pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">99,00 $</div>
+              <div style="font-weight:800">36,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/haut-%C3%A0-manches-longues-leger-pump-pour-hommes/25638164.html?dwvar_25638164_color=BLACK&amp;dwvar_25638164_size=Sml%20%20Small&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25534033_PINK_0/Junior-Girls-6-16-Mighty-Mogul-II-Jacket-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mighty Mogul pour filles juniors [6-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mighty Mogul pour filles juniors [6-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">169,99 $</div>
+              <div style="font-weight:800">79,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/manteaux-et-vestes/veste-mighty-mogul-pour-filles-juniors-6-16/25534033.html?dwvar_25534033_color=PINK&amp;dwvar_25534033_size=Med%20%20Mediu&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25895988_NAVY_0/Junior-Boys-8-14-Mattan-Jacket-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Veste Mattan pour garçons juniors [8-14]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-53% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Veste Mattan pour garçons juniors [8-14]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">1 280,00 $</div>
+              <div style="font-weight:800">606,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/manteaux-et-vestes/veste-mattan-pour-gar%C3%A7ons-juniors-8-14/25895988.html?dwvar_25895988_color=NAVY&amp;dwvar_25895988_size=8%20%20%20%20Size&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920024_0/Mens-Crank-Laced-Snowboard-Boot-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bottes de planche à neige Crank Laced pour hommes [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bottes de planche à neige Crank Laced pour hommes [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">249,95 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/bottes-de-planche-%C3%A0-neige-crank-laced-pour-hommes-2025/25920024-00158994.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920121_0/Unisex-Family-Tree-Hometown-Hero-Camber-Wide-Snowboard-2025?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Planche à neige Family Tree Hometown Hero Camber Wide unisexe [2025]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">879,99 $</div>
+              <div style="font-weight:800">659,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/planche-%C3%A0-neige-family-tree-hometown-hero-camber-wide-unisexe-2025/25920121-00160476.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922487_GREY_0/Hustle-6.0-Backpack-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922487.html?dwvar_25922487_color=GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25919212_BLACK_0/Mens-Field-General-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Field General pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Field General pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-field-general-pour-hommes/25919212.html?dwvar_25919212_color=BLACK&amp;dwvar_25919212_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924374_FLINTSTONE_0/Traverse-Light-20-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924374.html?dwvar_25924374_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924375_PETROL-BLUE_0/Traverse-Light-20-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924375.html?dwvar_25924375_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924372_PETROL-BLUE_0/Traverse-Light-15-Backpack-PETROL-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924372.html?dwvar_25924372_color=PETROL-BLUE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924376_WINE-TASTING_0/Traverse-Light-20-Backpack-WINE-TASTING?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924376.html?dwvar_25924376_color=WINE-TASTING&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924370_DIRTY-DAISY_0/Traverse-Light-15-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924370.html?dwvar_25924370_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924373_DIRTY-DAISY_0/Traverse-Light-20-Backpack-DIRTY-DAISY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 20" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 20</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-20/25924373.html?dwvar_25924373_color=DIRTY-DAISY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25924371_FLINTSTONE_0/Traverse-Light-15-Backpack-FLINTSTONE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Traverse Light 15" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Traverse Light 15</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">185,00 $</div>
+              <div style="font-weight:800">147,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-dos-traverse-light-15/25924371.html?dwvar_25924371_color=FLINTSTONE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922476_BLUE-VOID-BLACK-MINT-FOAM_0/Brasilia-9.5-Duffel-Bag-Medium-BLUE-VOID-BLACK-MINT-FOAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac de sport Brasilia 9.5 (moyen)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac de sport Brasilia 9.5 (moyen)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">47,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-voyage/sac-de-sport-brasilia-9.5-moyen/25922476.html?dwvar_25922476_color=BLUE-VOID-BLACK-MINT-FOAM&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25900135_BLACK_0/Hustle-6.0-Backpack-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25900135.html?dwvar_25900135_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25788407_BLACK_0/Square-Futura-Lunch-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à lunch Futura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à lunch Futura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/camping/sacs-et-sacs-%C3%A0-dos/sac-%C3%A0-lunch-futura/25788407.html?dwvar_25788407_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922489_PINE-FOREST_0/Startle-Backpack-PINE-FOREST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Startle" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Startle</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">60,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-startle/25922489.html?dwvar_25922489_color=PINE-FOREST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922488_ROYAL-BLUE-SILVER_0/Hustle-6.0-Backpack-ROYAL-BLUE-SILVER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Hustle 6.0" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Hustle 6.0</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">44,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-hustle-6.0/25922488.html?dwvar_25922488_color=ROYAL-BLUE-SILVER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25551516_0/Recovery-Ball?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Balle de massage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Balle de massage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/balle-de-massage/25551516.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917802_POWDER-TEAL-BLISS-LILAC-PURE-TEAL_0/Womens-Gazelle-Bold-Shoe-POWDER-TEAL-BLISS-LILAC-PURE-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle Bold pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle Bold pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">160,00 $</div>
+              <div style="font-weight:800">119,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-gazelle-bold-pour-femmes/25917802.html?dwvar_25917802_color=POWDER-TEAL-BLISS-LILAC-PURE-TEAL&amp;dwvar_25917802_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923021_FOLIAGE-GREEN_0/Raven-28-Backpack-FOLIAGE-GREEN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Raven 28" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Raven 28</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">155,00 $</div>
+              <div style="font-weight:800">107,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-raven-28/25923021.html?dwvar_25923021_color=FOLIAGE-GREEN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923020_OX-RED_0/Kanken-Laptop-15-Backpack-OX-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923020.html?dwvar_25923020_color=OX-RED&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923017_ACORN_0/Kanken-Laptop-15-Backpack-ACORN?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Kanken pour ordinateur portable 15 po" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Kanken pour ordinateur portable 15 po</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">135,00 $</div>
+              <div style="font-weight:800">93,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-kanken-pour-ordinateur-portable-15-po/25923017.html?dwvar_25923017_color=ACORN&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25824715_GREY_0/Womens-GP-Challenge-Pro-Premium-Tennis-Shoe-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de tennis GP Challenge Pro Premium pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de tennis GP Challenge Pro Premium pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">170,00 $</div>
+              <div style="font-weight:800">126,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-tennis/chaussures-de-tennis-gp-challenge-pro-premium-pour-femmes/25824715.html?dwvar_25824715_color=GREY&amp;dwvar_25824715_size=6&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920787_DARK-SMOKE-WHITE_0/Icon-Air-Max-90-Card-Wallet-DARK-SMOKE-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920787.html?dwvar_25920787_color=DARK-SMOKE-WHITE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920892_BLACK_0/Fundamental-Speed-Rope-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Corde à sauter Fundamental Speed" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-23% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Corde à sauter Fundamental Speed</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">26,00 $</div>
+              <div style="font-weight:800">19,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/equipement-dentra%C3%AEnement/abdominaux-entra%C3%AEnement-et-exercice/corde-%C3%A0-sauter-fundamental-speed/25920892.html?dwvar_25920892_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25920786_INFARED-COOL-GREY_0/Icon-Air-Max-90-Card-Wallet-INFARED-COOL-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Porte-cartes Icon Air Max 90" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Porte-cartes Icon Air Max 90</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">40,00 $</div>
+              <div style="font-weight:800">31,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/porte-cartes-icon-air-max-90/25920786.html?dwvar_25920786_color=INFARED-COOL-GREY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923558_RUBBER_0/Split-Adventure-Backpack-38L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Split Adventure (38L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Split Adventure (38L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">200,00 $</div>
+              <div style="font-weight:800">159,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/bagages-et-voyage/sac-%C3%A0-dos-split-adventure-38l/25923558.html?dwvar_25923558_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923307_BLACKOUT_0/Enduro-25L-4.0-Backpack-BLACKOUT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923307.html?dwvar_25923307_color=BLACKOUT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923306_FORGED-IRON-REDLINE_0/Enduro-25L-4.0-Backpack-FORGED-IRON-REDLINE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923306.html?dwvar_25923306_color=FORGED-IRON-REDLINE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25923308_MIST_0/Enduro-25L-4.0-Backpack-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à dos Enduro 4.0 25L" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-30% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à dos Enduro 4.0 25L</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">90,00 $</div>
+              <div style="font-weight:800">62,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-%C3%A0-dos/sac-%C3%A0-dos-enduro-4.0-25l/25923308.html?dwvar_25923308_color=MIST&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907007_RAZZLE-RASPBERRY_0/Aura-Crossbody-Bag-RAZZLE-RASPBERRY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-de-taille-et-sacs-ceinture/sac-%C3%A0-bandouli%C3%A8re-aura/25907007.html?dwvar_25907007_color=RAZZLE-RASPBERRY&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917290_CLOUD-DANCER_0/Mens-Chris-Life-Short-Seeve-T-Shirt-CLOUD-DANCER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Chris Life pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-54% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Chris Life pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">15,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-chris-life-pour-hommes/25917290.html?dwvar_25917290_color=CLOUD-DANCER&amp;dwvar_25917290_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917916_RED_0/Womens-SL-72-OG-Shoe-RED?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures SL 72 OG pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures SL 72 OG pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">77,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/femmes/chaussures-de-sport-decontractees/chaussures-sl-72-og-pour-femmes/25917916.html?dwvar_25917916_color=RED&amp;dwvar_25917916_size=7&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922692_0/WZRD-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball WZRD" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball WZRD</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-wzrd/25922692.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25464470_0/Patella-Knee-Strap?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sangle pour le genou" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sangle pour le genou</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">19,99 $</div>
+              <div style="font-weight:800">14,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/sangle-pour-le-genou/25464470.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25912064_PINK_0/Mens-Gazelle-Shoe-PINK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures Gazelle pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures Gazelle pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">130,00 $</div>
+              <div style="font-weight:800">96,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-gazelle-pour-hommes/25912064.html?dwvar_25912064_color=PINK&amp;dwvar_25912064_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922691_0/BALLR-Pickleball-Paddle?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Raquette de pickleball BALLR+" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-40% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Raquette de pickleball BALLR+</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">289,99 $</div>
+              <div style="font-weight:800">173,94 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/solde-eclair/raquette-de-pickleball-ballr%2B/25922691.html?cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916430_MULTI_0/Skills-Next-Nature-Mini-Basketball-MULTI?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Mini-ballon de basketball Skills Next Nature" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-22% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Mini-ballon de basketball Skills Next Nature</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">18,00 $</div>
+              <div style="font-weight:800">13,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/loisirs-aquatiques/gilets-de-sauvetage-et-protection-contre-leau/mini-ballon-de-basketball-skills-next-nature/25916430.html?dwvar_25916430_color=MULTI&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921136_BLACK_0/Recharge-Stainless-Steel-Straw-Bottle-32-oz-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille en acier inoxydable Recharge avec paille (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille en acier inoxydable Recharge avec paille (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteilles-deau-et-gobelets/acier-inoxydable/bouteille-en-acier-inoxydable-recharge-avec-paille-32-oz/25921136.html?dwvar_25921136_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921827_TIGER-CAMO_0/Lunch-Box-5L-TIGER-CAMO?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-5l/25921827.html?dwvar_25921827_color=TIGER-CAMO&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921828_BLACK-ONYX_0/Snacktime-Lunch-Box-5L-BLACK-ONYX?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921828.html?dwvar_25921828_color=BLACK-ONYX&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921826_RUBBER_0/Snacktime-Lunch-Box-5L-RUBBER?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921826.html?dwvar_25921826_color=RUBBER&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921825_TRELLIS_0/Snacktime-Lunch-Box-5L-TRELLIS?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Boîte à lunch Snacktime (5L)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Boîte à lunch Snacktime (5L)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">42,00 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-accessoire/bo%C3%AEte-%C3%A0-lunch-snacktime-5l/25921825.html?dwvar_25921825_color=TRELLIS&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25922184_WHITE_0/Junior-Boys-8-20-Cotton-Seersucker-Short-Sleeve-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-35% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes en coton Seersucker pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">65,00 $</div>
+              <div style="font-weight:800">41,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/hauts/chemise-%C3%A0-manches-courtes-en-coton-seersucker-pour-gar%C3%A7ons-juniors-8-20/25922184.html?dwvar_25922184_color=WHITE&amp;dwvar_25922184_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917289_DARK-SAPPHIRE_0/Mens-Kasper-Knit-Resort-Shirt-DARK-SAPPHIRE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Kasper Resort en tricot pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Kasper Resort en tricot pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">52,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-kasper-resort-en-tricot-pour-hommes/25917289.html?dwvar_25917289_color=DARK-SAPPHIRE&amp;dwvar_25917289_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721226_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">250,00 $</div>
+              <div style="font-weight:800">186,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721226.html?dwvar_25721226_color=BLACK&amp;dwvar_25721226_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25721234_BLACK_0/Mens-Ultraboost-1.0-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Ultraboost 1.0 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Ultraboost 1.0 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">260,00 $</div>
+              <div style="font-weight:800">194,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-sport-decontractees/chaussures-de-course-ultraboost-1.0-pour-hommes/25721234.html?dwvar_25721234_color=BLACK&amp;dwvar_25721234_size=9&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917111_GREY-MIST_0/Womens-Evida-Short-Dress-GREY-MIST?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe courte Evida pour femmes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe courte Evida pour femmes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,00 $</div>
+              <div style="font-weight:800">33,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/femmes/v%C3%AAtements/robes/robe-courte-evida-pour-femmes/25917111.html?dwvar_25917111_color=GREY-MIST&amp;dwvar_25917111_size=Xs&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917281_DARK-NAVY_0/Mens-Loc-Short-DARK-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short Loc pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-64% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short Loc pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">69,00 $</div>
+              <div style="font-weight:800">24,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/shorts/short-loc-pour-hommes/25917281.html?dwvar_25917281_color=DARK-NAVY&amp;dwvar_25917281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25907031_PARACHUTE-BEIGE_0/Heritage-Crossbody-Bag-PARACHUTE-BEIGE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac bandoulière Heritage" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac bandoulière Heritage</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">35,00 $</div>
+              <div style="font-weight:800">27,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-bandouli%C3%A8re-heritage/25907031.html?dwvar_25907031_color=PARACHUTE-BEIGE&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25906991_BLACK_0/Aura-Crossbody-Bag-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Sac à bandoulière Aura" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-20% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Sac à bandoulière Aura</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">35,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/tous-les-sacs/sacs-fourre-tout-messager-et-bandouli%C3%A8re/sac-%C3%A0-bandouli%C3%A8re-aura/25906991.html?dwvar_25906991_color=BLACK&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918278_DEEP-TEAL_0/Mens-Gills-Camp-Shirt-DEEP-TEAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gills Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gills Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gills-camp-pour-hommes/25918278.html?dwvar_25918278_color=DEEP-TEAL&amp;dwvar_25918278_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918281_CHARCOAL_0/Mens-Trailer-Rider-2.0-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Trailer Rider 2.0 Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Trailer Rider 2.0 Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-trailer-rider-2.0-camp-pour-hommes/25918281.html?dwvar_25918281_color=CHARCOAL&amp;dwvar_25918281_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918276_NAVY_0/Mens-Baywatch-Camp-Shirt-NAVY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Baywatch Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Baywatch Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-baywatch-camp-pour-hommes/25918276.html?dwvar_25918276_color=NAVY&amp;dwvar_25918276_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918279_CHARCOAL_0/Mens-Star-Gazer-Camp-Shirt-CHARCOAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Star Gazer Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Star Gazer Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-star-gazer-camp--pour-hommes/25918279.html?dwvar_25918279_color=CHARCOAL&amp;dwvar_25918279_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918280_BUTTER-CREAM_0/Mens-Cottage-Country-Camp-Shirt-BUTTER-CREAM?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Cottage Country Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Cottage Country Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-cottage-country-camp-pour-hommes/25918280.html?dwvar_25918280_color=BUTTER-CREAM&amp;dwvar_25918280_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25918277_WHITE_0/Mens-Gear-Up-Camp-Shirt-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise Gear Up Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-44% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise Gear Up Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">84,00 $</div>
+              <div style="font-weight:800">46,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-gear-up-camp-pour-hommes/25918277.html?dwvar_25918277_color=WHITE&amp;dwvar_25918277_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25921654_BLACK_0/Mens-Endorphin-Speed-4-Running-Shoe-BLACK?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chaussures de course Endorphin Speed 4 pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-25% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chaussures de course Endorphin Speed 4 pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">220,00 $</div>
+              <div style="font-weight:800">164,96 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/chaussures/hommes/chaussures-de-course/chaussures-de-course-de-stabilite/chaussures-de-course-endorphin-speed-4-pour-hommes/25921654.html?dwvar_25921654_color=BLACK&amp;dwvar_25921654_size=14&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917736_WHITE_0/Junior-Girls-7-16-Big-Pony-Logo-Terry-Dress-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Robe en tissu éponge avec logo Big Pony pour filles juniors [7-16]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">85,00 $</div>
+              <div style="font-weight:800">58,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/filles/robes/robe-en-tissu-eponge-avec-logo-big-pony-pour-filles-juniors-7-16/25917736.html?dwvar_25917736_color=WHITE&amp;dwvar_25917736_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917380_CORAL_0/Mens-Allover-Print-Short-Sleeve-Shirt-CORAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes à motif intégral pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-33% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes à motif intégral pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">32,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-%C3%A0-motif-integral-pour-hommes/25917380.html?dwvar_25917380_color=CORAL&amp;dwvar_25917380_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917765_BLUE_0/Junior-Boys-8-20-Relaxed-Fit-Flex-Abrasion-Twill-Short-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-31% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Short en sergé Flex Abrasion Relaxed Fit pour garçons juniors [8-20]</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">59,50 $</div>
+              <div style="font-weight:800">40,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/enfants/gar%C3%A7ons/shorts/short-en-serge-flex-abrasion-relaxed-fit-pour-gar%C3%A7ons-juniors-8-20/25917765.html?dwvar_25917765_color=BLUE&amp;dwvar_25917765_size=8&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917383_BLUE_0/Mens-3-Button-Performance-Short-Sleeve-Polo-BLUE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Polo à manches courtes et 3 boutons pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-37% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Polo à manches courtes et 3 boutons pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">30,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/polos/polo-%C3%A0-manches-courtes-et-3-boutons-pour-hommes/25917383.html?dwvar_25917383_color=BLUE&amp;dwvar_25917383_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917224_NATURAL_0/Mens-Linen-Blend-Pant-NATURAL?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Pantalon en mélange de lin pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Pantalon en mélange de lin pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">75,00 $</div>
+              <div style="font-weight:800">53,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/pantalons/pantalons-decontractes/pantalon-en-melange-de-lin-pour-hommes/25917224.html?dwvar_25917224_color=NATURAL&amp;dwvar_25917224_size=XXL&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917379_OFF-WHITE_0/Mens-Striped-Short-Sleeve-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes rayée pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-29% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes rayée pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">49,50 $</div>
+              <div style="font-weight:800">34,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-rayee-pour-hommes/25917379.html?dwvar_25917379_color=OFF-WHITE&amp;dwvar_25917379_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917381_GREY_0/Mens-Camp-Short-Sleeve-Shirt-GREY?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Chemise à manches courtes Camp pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-28% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Chemise à manches courtes Camp pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">54,50 $</div>
+              <div style="font-weight:800">38,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/chemises-et-blouses/chemise-%C3%A0-manches-courtes-camp-pour-hommes/25917381.html?dwvar_25917381_color=GREY&amp;dwvar_25917381_size=M&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25917375_OFF-WHITE_0/Mens-Expeditions-of-the-Obsessed-T-Shirt-OFF-WHITE?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="T-shirt Expeditions of the Obsessed pour hommes" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-58% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">T-shirt Expeditions of the Obsessed pour hommes</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">45,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/hommes/v%C3%AAtements/hauts/t-shirts/t-shirt-expeditions-of-the-obsessed-pour-hommes/25917375.html?dwvar_25917375_color=OFF-WHITE&amp;dwvar_25917375_size=S&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        
+        <article class="card" style="background:linear-gradient(180deg,#111827,#0b1220);border:1px solid #2b3446;border-radius:14px;overflow:hidden">
+          <img src="https://cdn.media.amplience.net/i/sportinglife/25916161_BALTIC-BLUE-BLACK-IRIDESCENT_0/Refuel-Locking-Lid-Water-Bottle-32-oz-BALTIC-BLUE-BLACK-IRIDESCENT?$medium$&amp;fmt=auto&amp;w=315&amp;h=315" alt="Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)" loading="lazy" style="width:100%;height:160px;object-fit:cover;background:#0b0b10"/>
+          <div class="body" style="padding:14px">
+            <div class="badge" style="display:inline-flex;gap:6px;align-items:center;background:rgba(34,197,94,.12);border:1px solid rgba(34,197,94,.35);color:#86efac;border-radius:999px;padding:6px 10px;font-weight:600;font-size:12px">-21% <span class="label">Rabais</span></div>
+            <h3 style="margin:8px 0 6px;font-size:16px">Bouteille d&#x27;eau Refuel avec couvercle verrouillable (32 oz)</h3>
+            <div class="muted" style="font-size:13px;color:#9ca3af">Sporting Life · Saint-Jérôme</div>
+            <div class="price" style="display:flex;gap:10px;align-items:baseline;margin:8px 0">
+              <div class="old" style="text-decoration:line-through;color:#9ca3af">24,00 $</div>
+              <div style="font-weight:800">18,98 $</div>
+            </div>
+            <a class="btn" href="https://www.sportinglife.ca/fr-CA/equipement/plus-d%E2%80%99equipement/hydratation/bouteille-deau-refuel-avec-couvercle-verrouillable-32-oz/25916161.html?dwvar_25916161_color=BALTIC-BLUE-BLACK-IRIDESCENT&amp;cgid=flash-sale" target="_blank" rel="noopener" style="display:inline-flex;justify-content:center;align-items:center;padding:10px 14px;border:1px solid #2b3446;border-radius:12px;color:#e5e7eb;text-decoration:none;width:100%">Voir</a>
+          </div>
+        </article>
+        </div>
+</body>


### PR DESCRIPTION
## Summary
- add static preview pages for Sporting Life branches so scraped deals can be viewed on GitHub
- document the new previews in the README for quick access

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68df0512409c832e845484b026238b72