### PR TITLE
Fix client counter to reflect stored registrations

### DIFF
--- a/best-deals.html
+++ b/best-deals.html
@@ -204,8 +204,27 @@
         const parsed = parseInt(value ?? '0', 10);
         return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
       }
-      function getClientCount(){ return parseCount(safeGet('econodealClientCount')); }
-      function setClientCount(value){ safeSet('econodealClientCount', String(Math.max(0, value))); }
+      function setClientCount(value){
+        const normalized = Math.max(0, value);
+        safeSet('econodealClientCount', String(normalized));
+        return normalized;
+      }
+      function deriveClientCountFromRegistrations(){
+        const registrations = getRegistrations();
+        if(!registrations.length) return 0;
+        const uniqueEmails = new Set();
+        registrations.forEach(item => {
+          if(item?.email) uniqueEmails.add(item.email);
+        });
+        return uniqueEmails.size;
+      }
+      function getClientCount(){
+        const stored = parseCount(safeGet('econodealClientCount'));
+        const derived = deriveClientCountFromRegistrations();
+        const resolved = Math.max(stored, derived);
+        if(resolved !== stored){ setClientCount(resolved); }
+        return resolved;
+      }
       function updateClientCountDisplays(){
         const formatter = new Intl.NumberFormat('fr-CA');
         const count = getClientCount();

--- a/index.html
+++ b/index.html
@@ -473,12 +473,30 @@
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
     }
 
-    function getClientCount(){
-      return parseCount(safeGet('econodealClientCount'));
+    function setClientCount(value){
+      const normalized = Math.max(0, value);
+      safeSet('econodealClientCount', String(normalized));
+      return normalized;
     }
 
-    function setClientCount(value){
-      safeSet('econodealClientCount', String(Math.max(0, value)));
+    function deriveClientCountFromRegistrations(){
+      const registrations = getRegistrations();
+      if(!registrations.length) return 0;
+      const uniqueEmails = new Set();
+      registrations.forEach(item => {
+        if(item?.email) uniqueEmails.add(item.email);
+      });
+      return uniqueEmails.size;
+    }
+
+    function getClientCount(){
+      const stored = parseCount(safeGet('econodealClientCount'));
+      const derived = deriveClientCountFromRegistrations();
+      const resolved = Math.max(stored, derived);
+      if(resolved !== stored){
+        setClientCount(resolved);
+      }
+      return resolved;
     }
 
     function updateClientCountDisplays(){


### PR DESCRIPTION
## Summary
- derive the displayed client count from stored registrations when the explicit counter is missing
- normalize and persist the synchronized client count for both the landing and best deals pages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deed0c6cb4832ebe6e0bafa7f931b0