### PR TITLE
Add registration metrics to admin dashboard

### DIFF
--- a/admin/inscriptions.html
+++ b/admin/inscriptions.html
@@ -41,6 +41,15 @@
     tbody tr:nth-child(even){background:rgba(15,23,42,.35)}
     .badge{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:rgba(34,197,94,.18);color:#86efac;font-size:12px}
     .actions{display:flex;flex-wrap:wrap;gap:10px;margin:20px 0}
+    .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin:20px 0}
+    .metric-card{background:var(--panel);border:1px solid var(--border);border-radius:var(--radius);padding:16px;display:grid;gap:6px;box-shadow:0 16px 36px rgba(8,13,26,.45)}
+    .metric-label{font-size:12px;text-transform:uppercase;letter-spacing:.12em;color:var(--muted);font-weight:600}
+    .metric-value{font-size:28px;font-weight:700;color:#bbf7d0}
+    .metric-detail{font-size:13px;color:var(--muted);line-height:1.5}
+    .active-client{display:grid;gap:4px}
+    .active-client strong{font-size:16px;color:#fff}
+    .active-client a{color:inherit;text-decoration:none;font-weight:600}
+    .active-client time{font-size:12px;color:var(--muted)}
     button{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 14px;font-size:14px;cursor:pointer;transition:background .2s ease,color .2s ease}
     button:hover{background:var(--panel-2)}
     .muted{color:var(--muted)}
@@ -88,6 +97,17 @@
         <button id="btnRefresh" type="button">Actualiser</button>
         <button id="btnExport" type="button">Exporter en CSV</button>
       </div>
+      <div class="metrics" role="list">
+        <article class="metric-card" role="listitem">
+          <span class="metric-label">Clients inscrits</span>
+          <span class="metric-value" id="metricTotalValue">0</span>
+          <p class="metric-detail">Nombre total de contacts uniques stockés sur ce navigateur.</p>
+        </article>
+        <article class="metric-card" role="listitem">
+          <span class="metric-label">Client actuellement actif</span>
+          <div id="activeClient" class="metric-detail"><span class="muted">Aucun client actif enregistré.</span></div>
+        </article>
+      </div>
       <div id="tableWrapper"></div>
     </div>
   </main>
@@ -107,6 +127,8 @@
     const countEl = document.getElementById('entryCount');
     const btnRefresh = document.getElementById('btnRefresh');
     const btnExport = document.getElementById('btnExport');
+    const metricTotalValue = document.getElementById('metricTotalValue');
+    const activeClientEl = document.getElementById('activeClient');
 
     document.getElementById('year').textContent = new Date().getFullYear();
 
@@ -175,9 +197,65 @@
         .sort((a,b) => (a.registeredAt > b.registeredAt ? -1 : 1));
     }
 
+    function dedupeEntries(entries){
+      if(!Array.isArray(entries)) return [];
+      const byEmail = new Map();
+      entries.forEach(entry => {
+        if(!entry?.email) return;
+        const existing = byEmail.get(entry.email);
+        if(!existing){
+          byEmail.set(entry.email, entry);
+          return;
+        }
+        const currentDate = Date.parse(entry.registeredAt ?? '');
+        const existingDate = Date.parse(existing.registeredAt ?? '');
+        if(Number.isFinite(currentDate) && (!Number.isFinite(existingDate) || currentDate > existingDate)){
+          byEmail.set(entry.email, entry);
+          return;
+        }
+        if(!Number.isFinite(currentDate) && !Number.isFinite(existingDate) && entry.name && !existing.name){
+          byEmail.set(entry.email, entry);
+        }
+      });
+      return Array.from(byEmail.values()).sort((a,b) => {
+        const dateA = Date.parse(a?.registeredAt ?? '') || 0;
+        const dateB = Date.parse(b?.registeredAt ?? '') || 0;
+        return dateB - dateA;
+      });
+    }
+
+    function renderMetrics(entries){
+      const safeEntries = Array.isArray(entries) ? entries : [];
+      const formatter = new Intl.NumberFormat('fr-CA');
+      if(metricTotalValue){
+        metricTotalValue.textContent = formatter.format(safeEntries.length);
+      }
+      if(activeClientEl){
+        if(safeEntries.length === 0){
+          activeClientEl.innerHTML = '<span class="muted">Aucun client actif enregistré.</span>';
+          return;
+        }
+        const active = safeEntries[0];
+        const parts = splitNames(active.name);
+        const displayName = [parts.firstName, parts.lastName].filter(Boolean).join(' ').trim();
+        const name = displayName || active.email || 'Client confirmé';
+        const emailLink = active.email ? `<a href="mailto:${active.email}">${active.email}</a>` : '';
+        const formattedDate = formatDate(active.registeredAt);
+        const dateText = formattedDate ? `<time datetime="${active.registeredAt}">${formattedDate}</time>` : '';
+        activeClientEl.innerHTML = `
+          <div class="active-client">
+            <strong>${name}</strong>
+            ${emailLink ? `<span>${emailLink}</span>` : ''}
+            ${dateText}
+          </div>
+        `;
+      }
+    }
+
     function renderTable(){
-      const entries = getRegistrations();
+      const entries = dedupeEntries(getRegistrations());
       countEl.textContent = entries.length.toString();
+      renderMetrics(entries);
 
       if(entries.length === 0){
         tableWrapper.innerHTML = '<div class="empty">Aucune inscription n\'est enregistrée sur ce navigateur.</div>';
@@ -230,7 +308,7 @@
     }
 
     function downloadCSV(){
-      const entries = getRegistrations();
+      const entries = dedupeEntries(getRegistrations());
       if(entries.length === 0){
         alert('Aucune inscription à exporter.');
         return;


### PR DESCRIPTION
## Summary
- add registration metrics cards to the admin inscriptions page
- deduplicate registrations before rendering the table or exporting CSV so counts stay accurate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0a6b000c832e91e92d0f75b300d6