### PR TITLE
Move store ads carousel into header

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,15 +143,26 @@
     .store-menu-item:hover{background:linear-gradient(160deg,rgba(59,130,246,.2),rgba(34,197,94,.18));box-shadow:0 16px 32px rgba(59,130,246,.28);transform:translateY(-4px)}
     .store-menu-label{font-size:15px;letter-spacing:-.01em}
     .store-menu-note{font-size:13px;color:var(--muted);font-weight:500}
-    .store-ads{position:fixed;top:120px;right:24px;width:240px;max-width:80vw;height:420px;padding:18px;border-radius:18px;border:1px solid rgba(59,130,246,.28);background:linear-gradient(200deg,rgba(6,12,24,.94),rgba(12,24,44,.9));box-shadow:0 24px 48px rgba(2,6,23,.65);display:flex;flex-direction:column;gap:14px;z-index:30;overflow:hidden}
+    header .container{display:grid;gap:12px}
+    .header-top{justify-content:space-between;align-items:center;gap:16px}
+    .store-ads{border:1px solid rgba(59,130,246,.28);background:linear-gradient(200deg,rgba(6,12,24,.94),rgba(12,24,44,.9));box-shadow:0 16px 32px rgba(2,6,23,.55);border-radius:18px;padding:16px 18px;display:flex;flex-direction:column;gap:12px;overflow:hidden;margin-top:6px}
     .store-ads[aria-hidden="true"]{display:none}
     .store-ads-header{font-size:13px;letter-spacing:.18em;text-transform:uppercase;color:rgba(148,163,184,.9);font-weight:700}
-    .store-ads-window{flex:1;overflow:hidden;mask-image:linear-gradient(180deg,transparent 0%,rgba(255,255,255,.9) 12%,rgba(255,255,255,.9) 88%,transparent 100%)}
-    .store-ads-track{display:flex;flex-direction:column;gap:12px;animation:storeAdsScroll 28s linear infinite;will-change:transform}
-    .store-ads-item{padding:14px;border-radius:12px;border:1px solid rgba(59,130,246,.24);background:linear-gradient(160deg,rgba(34,197,94,.18),rgba(59,130,246,.16));box-shadow:0 12px 30px rgba(15,23,42,.45);display:flex;flex-direction:column;gap:4px;color:var(--text)}
+    .store-ads-window{width:100%;overflow:hidden;mask-image:linear-gradient(90deg,transparent 0%,rgba(255,255,255,.9) 10%,rgba(255,255,255,.9) 90%,transparent 100%)}
+    .store-ads-track{display:flex;align-items:stretch;gap:12px;animation:storeAdsScroll 28s linear infinite;will-change:transform;width:max-content}
+    .store-ads:hover .store-ads-track{animation-play-state:paused}
+    .store-ads-item{flex:0 0 auto;min-width:200px;padding:14px 16px;border-radius:12px;border:1px solid rgba(59,130,246,.24);background:linear-gradient(160deg,rgba(34,197,94,.18),rgba(59,130,246,.16));box-shadow:0 12px 30px rgba(15,23,42,.45);display:flex;flex-direction:column;gap:4px;color:var(--text)}
     .store-ads-name{font-weight:700;letter-spacing:-.01em}
     .store-ads-coverage{font-size:12px;color:var(--muted)}
-    @keyframes storeAdsScroll{0%{transform:translateY(0)}100%{transform:translateY(-50%)}}
+    @keyframes storeAdsScroll{0%{transform:translateX(0)}100%{transform:translateX(-50%)}}
+    @media (max-width:720px){
+      .store-ads{padding:14px}
+      .store-ads-item{min-width:160px}
+    }
+    @media (prefers-reduced-motion:reduce){
+      .store-ads-track{animation:none}
+      .store-ads-window{overflow-x:auto;mask-image:none}
+    }
   </style>
 </head>
 <body class="overlay-active">
@@ -182,31 +193,33 @@
       </form>
     </div>
   </div>
-  <aside id="storeAds" class="store-ads" aria-label="Publicités des magasins" aria-hidden="true"></aside>
   <header>
-    <div class="container row" style="justify-content:space-between">
-      <div class="row" style="gap:16px;align-items:center;flex-wrap:wrap">
-        <a class="brand" href="index.html">
-          <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs Amazon" />
-          <span class="brand-text">
-            <span class="brand-title">EconoDeal</span>
-            <span class="brand-tagline">Votre hub Amazon</span>
-          </span>
-        </a>
-        <div class="country-toggle country-toggle--header" role="group" aria-label="Choisir le pays">
-          <button type="button" class="country-button active" data-country="canada" aria-pressed="true">Canada</button>
-          <button type="button" class="country-button" data-country="usa" aria-pressed="false">États-Unis</button>
-          <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europe</button>
+    <div class="container">
+      <div class="row header-top">
+        <div class="row" style="gap:16px;align-items:center;flex-wrap:wrap">
+          <a class="brand" href="index.html">
+            <img src="assets/logo.svg" alt="EconoDeal – accélérateur de revendeurs Amazon" />
+            <span class="brand-text">
+              <span class="brand-title">EconoDeal</span>
+              <span class="brand-tagline">Votre hub Amazon</span>
+            </span>
+          </a>
+          <div class="country-toggle country-toggle--header" role="group" aria-label="Choisir le pays">
+            <button type="button" class="country-button active" data-country="canada" aria-pressed="true">Canada</button>
+            <button type="button" class="country-button" data-country="usa" aria-pressed="false">États-Unis</button>
+            <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europe</button>
+          </div>
+        </div>
+        <div class="row" style="gap:12px;align-items:center">
+          <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>
+          <a class="nav-button" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
+          <a class="nav-button" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
+          <span class="header-region" data-exchange-indicator aria-live="polite" aria-label="Taux de change 1 CAD pour 1 CAD">1 CAD = 1 CAD</span>
+          <div class="muted" style="white-space:nowrap">Clients inscrits&nbsp;: <span data-client-count>0</span></div>
+          <div class="muted">© <span id="year"></span></div>
         </div>
       </div>
-      <div class="row" style="gap:12px;align-items:center">
-        <a class="nav-button" href="best-deals.html" style="white-space:nowrap">Meilleurs rabais</a>
-        <a class="nav-button" href="pricing.html" style="white-space:nowrap">Forfaits / prix</a>
-        <a class="nav-button" href="roadmap.html" style="white-space:nowrap">Roadmap / vision</a>
-        <span class="header-region" data-exchange-indicator aria-live="polite" aria-label="Taux de change 1 CAD pour 1 CAD">1 CAD = 1 CAD</span>
-        <div class="muted" style="white-space:nowrap">Clients inscrits&nbsp;: <span data-client-count>0</span></div>
-        <div class="muted">© <span id="year"></span></div>
-      </div>
+      <aside id="storeAds" class="store-ads" aria-label="Publicités des magasins" aria-hidden="true"></aside>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- relocate the dynamic store ads component into the sticky header with a horizontal marquee layout
- adjust header spacing and styling so the marquee no longer obscures the main content
- add reduced-motion and hover safeguards for the animated marquee

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df161e8fc0832eae298259abab0711