### PR TITLE
Fix client counter sync with local registrations

### DIFF
--- a/best-deals.html
+++ b/best-deals.html
@@ -218,7 +218,7 @@
         });
         return uniqueEmails.size;
       }
-      function getClientCount(){
+      function resolveClientCount(){
         const stored = parseCount(safeGet('econodealClientCount'));
         const derived = deriveClientCountFromRegistrations();
         const resolved = Math.max(stored, derived);
@@ -227,11 +227,12 @@
       }
       function updateClientCountDisplays(){
         const formatter = new Intl.NumberFormat('fr-CA');
-        const count = getClientCount();
+        const count = resolveClientCount();
         clientCountDisplays.forEach(el => { el.textContent = formatter.format(count); });
       }
       function hideOverlay(){ if(!overlay) return; overlay.classList.add('hidden'); overlay.setAttribute('aria-hidden','true'); document.body.classList.remove('overlay-active'); }
       function showOverlay(){ if(!overlay) return; overlay.classList.remove('hidden'); overlay.removeAttribute('aria-hidden'); document.body.classList.add('overlay-active'); updateClientCountDisplays(); }
+      resolveClientCount();
       updateClientCountDisplays();
       const alreadyRegistered = safeGet('econodealClientRegistered') === 'true';
       if(alreadyRegistered){ hideOverlay(); }
@@ -244,11 +245,6 @@
         form.addEventListener('submit', (event) => {
           event.preventDefault();
           if(!form.reportValidity()) return;
-          const wasRegistered = safeGet('econodealClientRegistered') === 'true';
-          if(!wasRegistered){
-            const current = getClientCount();
-            setClientCount(current + 1);
-          }
           const payload = {
             name: (form.fullName?.value ?? '').trim(),
             email: (form.email?.value ?? '').trim(),
@@ -257,11 +253,19 @@
           };
           safeSet('econodealUser', JSON.stringify(payload));
           upsertRegistration(payload);
+          resolveClientCount();
           safeSet('econodealClientRegistered', 'true');
           updateClientCountDisplays();
           hideOverlay();
         });
       }
+
+      window.addEventListener('storage', (event) => {
+        if(!event) return;
+        if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount'){
+          updateClientCountDisplays();
+        }
+      });
 
       function baseBranches(){
         return [

--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
       return uniqueEmails.size;
     }
 
-    function getClientCount(){
+    function resolveClientCount(){
       const stored = parseCount(safeGet('econodealClientCount'));
       const derived = deriveClientCountFromRegistrations();
       const resolved = Math.max(stored, derived);
@@ -520,7 +520,7 @@
 
     function updateClientCountDisplays(){
       const formatter = new Intl.NumberFormat('fr-CA');
-      const count = getClientCount();
+      const count = resolveClientCount();
       clientCountDisplays.forEach(el => {
         el.textContent = formatter.format(count);
       });
@@ -541,6 +541,7 @@
       updateClientCountDisplays();
     }
 
+    resolveClientCount();
     updateClientCountDisplays();
 
     const alreadyRegistered = safeGet('econodealClientRegistered') === 'true';
@@ -562,12 +563,6 @@
         event.preventDefault();
         if(!form.reportValidity()) return;
 
-        const wasRegistered = safeGet('econodealClientRegistered') === 'true';
-        if(!wasRegistered){
-          const current = getClientCount();
-          setClientCount(current + 1);
-        }
-
         const payload = {
           name: (form.fullName?.value ?? '').trim(),
           email: (form.email?.value ?? '').trim(),
@@ -577,11 +572,19 @@
 
         safeSet('econodealUser', JSON.stringify(payload));
         upsertRegistration(payload);
+        resolveClientCount();
         safeSet('econodealClientRegistered', 'true');
         updateClientCountDisplays();
         hideOverlay();
       });
     }
+
+    window.addEventListener('storage', (event) => {
+      if(!event) return;
+      if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount'){
+        updateClientCountDisplays();
+      }
+    });
 
     function baseBranches(){
       return [


### PR DESCRIPTION
## Summary
- resolve the client counter from deduplicated local registrations before updating the UI
- update both landing pages to sync the displayed count after each submission and when storage changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df1ae9a538832e9e5be3ac32a2956d