### PR TITLE
Add shared baseline for member count display

### DIFF
--- a/best-deals.html
+++ b/best-deals.html
@@ -204,9 +204,22 @@
         const parsed = parseInt(value ?? '0', 10);
         return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
       }
+      const CLIENT_COUNT_BASELINE_KEY = 'econodealClientCountBaseline';
+      const CLIENT_COUNT_REMOTE_URL = 'data/metrics.json';
+
       function setClientCount(value){
         const normalized = Math.max(0, value);
         safeSet('econodealClientCount', String(normalized));
+        return normalized;
+      }
+
+      function getClientCountBaseline(){
+        return parseCount(safeGet(CLIENT_COUNT_BASELINE_KEY));
+      }
+
+      function setClientCountBaseline(value){
+        const normalized = Math.max(0, value);
+        safeSet(CLIENT_COUNT_BASELINE_KEY, String(normalized));
         return normalized;
       }
       function deriveClientCountFromRegistrations(){
@@ -221,7 +234,8 @@
       function resolveClientCount(){
         const stored = parseCount(safeGet('econodealClientCount'));
         const derived = deriveClientCountFromRegistrations();
-        const resolved = Math.max(stored, derived);
+        const baseline = getClientCountBaseline();
+        const resolved = Math.max(stored, derived, baseline);
         if(resolved !== stored){ setClientCount(resolved); }
         return resolved;
       }
@@ -232,8 +246,27 @@
       }
       function hideOverlay(){ if(!overlay) return; overlay.classList.add('hidden'); overlay.setAttribute('aria-hidden','true'); document.body.classList.remove('overlay-active'); }
       function showOverlay(){ if(!overlay) return; overlay.classList.remove('hidden'); overlay.removeAttribute('aria-hidden'); document.body.classList.add('overlay-active'); updateClientCountDisplays(); }
+      async function fetchRemoteClientCount(){
+        try{
+          const response = await fetch(CLIENT_COUNT_REMOTE_URL, {cache:'no-store'});
+          if(!response?.ok) return null;
+          const payload = await response.json();
+          const remote = parseCount(payload?.clientCount ?? payload?.client_count ?? payload?.count);
+          if(remote > 0){
+            const previousBaseline = getClientCountBaseline();
+            if(remote !== previousBaseline){ setClientCountBaseline(remote); }
+            updateClientCountDisplays();
+          }
+          return remote;
+        }catch(error){
+          console.warn('Impossible de charger le nombre total de membres', error);
+          return null;
+        }
+      }
+
       resolveClientCount();
       updateClientCountDisplays();
+      fetchRemoteClientCount();
       const alreadyRegistered = safeGet('econodealClientRegistered') === 'true';
       if(alreadyRegistered){ hideOverlay(); }
       else{ showOverlay(); }
@@ -262,7 +295,7 @@
 
       window.addEventListener('storage', (event) => {
         if(!event) return;
-        if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount'){
+        if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount' || event.key === CLIENT_COUNT_BASELINE_KEY){
           updateClientCountDisplays();
         }
       });

--- a/data/metrics.json
+++ b/data/metrics.json
@@ -1,0 +1,5 @@
+{
+  "clientCount": 4,
+  "updatedAt": "2024-04-12T00:00:00Z",
+  "source": "Baseline cumulée toutes plateformes"
+}

--- a/index.html
+++ b/index.html
@@ -492,9 +492,22 @@
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
     }
 
+    const CLIENT_COUNT_BASELINE_KEY = 'econodealClientCountBaseline';
+    const CLIENT_COUNT_REMOTE_URL = 'data/metrics.json';
+
     function setClientCount(value){
       const normalized = Math.max(0, value);
       safeSet('econodealClientCount', String(normalized));
+      return normalized;
+    }
+
+    function getClientCountBaseline(){
+      return parseCount(safeGet(CLIENT_COUNT_BASELINE_KEY));
+    }
+
+    function setClientCountBaseline(value){
+      const normalized = Math.max(0, value);
+      safeSet(CLIENT_COUNT_BASELINE_KEY, String(normalized));
       return normalized;
     }
 
@@ -511,7 +524,8 @@
     function resolveClientCount(){
       const stored = parseCount(safeGet('econodealClientCount'));
       const derived = deriveClientCountFromRegistrations();
-      const resolved = Math.max(stored, derived);
+      const baseline = getClientCountBaseline();
+      const resolved = Math.max(stored, derived, baseline);
       if(resolved !== stored){
         setClientCount(resolved);
       }
@@ -541,8 +555,29 @@
       updateClientCountDisplays();
     }
 
+    async function fetchRemoteClientCount(){
+      try{
+        const response = await fetch(CLIENT_COUNT_REMOTE_URL, {cache:'no-store'});
+        if(!response?.ok) return null;
+        const payload = await response.json();
+        const remote = parseCount(payload?.clientCount ?? payload?.client_count ?? payload?.count);
+        if(remote > 0){
+          const previousBaseline = getClientCountBaseline();
+          if(remote !== previousBaseline){
+            setClientCountBaseline(remote);
+          }
+          updateClientCountDisplays();
+        }
+        return remote;
+      }catch(error){
+        console.warn('Impossible de charger le nombre total de membres', error);
+        return null;
+      }
+    }
+
     resolveClientCount();
     updateClientCountDisplays();
+    fetchRemoteClientCount();
 
     const alreadyRegistered = safeGet('econodealClientRegistered') === 'true';
     if(alreadyRegistered){
@@ -581,7 +616,7 @@
 
     window.addEventListener('storage', (event) => {
       if(!event) return;
-      if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount'){
+      if(event.key === 'econodealRegistrations' || event.key === 'econodealClientCount' || event.key === CLIENT_COUNT_BASELINE_KEY){
         updateClientCountDisplays();
       }
     });


### PR DESCRIPTION
## Summary
- add a shared metrics.json file to store the baseline member count used across pages
- read the baseline from localStorage and refresh it from the metrics file on both the landing and deals pages
- update the member counter to react to storage changes for the new baseline key

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68df1c6599fc832eac554c1c290d15d9