### PR TITLE
Add lightweight HTTP Walmart scraper variant

### DIFF
--- a/incoming/README.md
+++ b/incoming/README.md
@@ -33,6 +33,16 @@ Quelques options pratiques :
 
 Le script crée un fichier `liquidations_walmart_qc.json` (agrégat global) et un fichier JSON par magasin dans `data/walmart/` (ou dans le dossier fourni via `--output-dir`).
 
+### Variante HTTP (sans navigateur)
+
+Pour un environnement plus contraint (ex.: exécution locale rapide ou proxy HTTP dédié), le script `incoming/walmart_requests_scraper.py` effectue la même extraction à l'aide de requêtes `requests`/`BeautifulSoup`.
+
+```bash
+python incoming/walmart_requests_scraper.py --store saint-jerome
+```
+
+Les options (`--store`, `--output-dir`, `--aggregated-path`, etc.) sont identiques à la version Playwright. Ce scraper repose sur la disponibilité du JSON `__NEXT_DATA__` dans la page et peut échouer si Walmart modifie la structure. En contrepartie, il démarre en quelques secondes et nécessite moins de ressources.
+
 ## Automatisation
 
 Une action GitHub (`.github/workflows/walmart-scraper.yml`) planifie l'exécution chaque jour à 21h UTC. Pour l'activer :

--- a/incoming/walmart_common.py
+++ b/incoming/walmart_common.py
@@ -1,0 +1,169 @@
+"""Shared utilities for Walmart liquidation scrapers."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urljoin
+
+BASE_URL = "https://www.walmart.ca/fr/store/{store_id}/liquidation"
+WALMART_BASE_URL = "https://www.walmart.ca"
+
+
+def slugify(value: str) -> str:
+    """Return an ASCII slug from a city name (e.g. "Saint-Jérôme" -> "saint-jerome")."""
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    ascii_only = ascii_only.lower()
+    ascii_only = re.sub(r"[^a-z0-9]+", "-", ascii_only).strip("-")
+    return ascii_only or "store"
+
+
+@dataclass(slots=True)
+class Store:
+    """Metadata describing a Walmart store."""
+
+    id_store: str
+    ville: str
+    adresse: str = ""
+    slug: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.slug:
+            self.slug = slugify(self.ville)
+
+    @property
+    def url(self) -> str:
+        return BASE_URL.format(store_id=self.id_store)
+
+
+@dataclass(slots=True)
+class Deal:
+    """Normalized representation of a liquidation product."""
+
+    title: str
+    price: float
+    sale_price: float
+    url: str
+    image: Optional[str] = None
+
+    def to_payload(self, store: Store) -> Dict[str, Any]:
+        return {
+            "title": self.title,
+            "image": self.image or "",
+            "price": round(self.price, 2),
+            "salePrice": round(self.sale_price, 2),
+            "store": "Walmart",
+            "city": store.ville,
+            "url": self.url,
+        }
+
+
+def parse_price(text: Optional[str]) -> Optional[float]:
+    """Convert a price string to a float."""
+
+    if not text:
+        return None
+    clean = (
+        text.replace("\u00a0", " ")
+        .replace("$", "")
+        .replace("CAD", "")
+        .replace("cda", "")
+        .strip()
+    )
+    clean = clean.replace(" ", "")
+    match = re.search(r"[0-9]+(?:[.,][0-9]{1,2})?", clean)
+    if not match:
+        return None
+    value = match.group(0).replace(",", ".")
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def deduplicate_deals(deals: Iterable[Deal]) -> List[Deal]:
+    """Remove duplicate deals based on their URL."""
+
+    seen: set[str] = set()
+    unique: List[Deal] = []
+    for deal in deals:
+        key = deal.url
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(deal)
+    return unique
+
+
+def extract_from_state(raw_state: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Discover product dictionaries within ``raw_state`` recursively."""
+
+    candidates: List[Dict[str, Any]] = []
+
+    def walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            if {"name", "price", "productId"}.issubset(obj.keys()):
+                candidates.append(obj)
+            for value in obj.values():
+                walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                walk(item)
+
+    walk(raw_state)
+    return candidates
+
+
+def build_deal_from_dict(data: Dict[str, Any]) -> Optional[Deal]:
+    """Transform a raw JSON dictionary into a :class:`Deal`."""
+
+    title = data.get("name") or data.get("title")
+    if not title:
+        return None
+    url = data.get("productUrl") or data.get("url") or data.get("canonicalUrl")
+    if not url:
+        return None
+
+    regular_price = data.get("price") or data.get("listPrice") or data.get("regularPrice")
+    current_price = data.get("salePrice") or data.get("price") or data.get("offerPrice")
+
+    if isinstance(regular_price, dict):
+        regular_price = (
+            regular_price.get("price")
+            or regular_price.get("amount")
+            or regular_price.get("value")
+        )
+    if isinstance(current_price, dict):
+        current_price = (
+            current_price.get("price")
+            or current_price.get("amount")
+            or current_price.get("value")
+        )
+
+    price = parse_price(str(regular_price)) if regular_price is not None else None
+    sale_price = parse_price(str(current_price)) if current_price is not None else None
+
+    if price is None and sale_price is None:
+        return None
+    if price is None:
+        price = sale_price
+    if sale_price is None:
+        sale_price = price
+
+    image = None
+    images = data.get("image") or data.get("images") or []
+    if isinstance(images, list) and images:
+        image = images[0]
+    elif isinstance(images, dict):
+        image = images.get("main") or images.get("large") or images.get("thumbnail")
+    elif isinstance(images, str):
+        image = images
+
+    normalized_url = urljoin(WALMART_BASE_URL, url)
+
+    return Deal(title=title.strip(), price=price, sale_price=sale_price, url=normalized_url, image=image)
+

--- a/incoming/walmart_requests_scraper.py
+++ b/incoming/walmart_requests_scraper.py
@@ -1,0 +1,291 @@
+"""Scraper Walmart (HTTP) avec rotation de proxies.
+
+Ce module propose une alternative légère au scraper Playwright en utilisant
+des requêtes ``requests`` classiques. Il récupère le JSON ``__NEXT_DATA__``
+exposé dans les pages liquidation de Walmart Canada puis exporte des fichiers
+compatibles avec le site statique.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from pathlib import Path
+from typing import List, Optional, Sequence, Set, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+from requests import Response
+
+try:  # Support exécution directe et import au sein du package
+    from incoming.walmart_common import (
+        Deal,
+        Store,
+        build_deal_from_dict,
+        deduplicate_deals,
+        extract_from_state,
+    )
+    from incoming.walmart_scraper import (
+        ensure_output_paths,
+        load_proxies,
+        load_stores,
+        normalize_store_token,
+        store_matches_filters,
+        write_json,
+    )
+except ImportError:  # pragma: no cover - fallback pour exécution directe
+    from walmart_common import (
+        Deal,
+        Store,
+        build_deal_from_dict,
+        deduplicate_deals,
+        extract_from_state,
+    )
+    from walmart_scraper import (
+        ensure_output_paths,
+        load_proxies,
+        load_stores,
+        normalize_store_token,
+        store_matches_filters,
+        write_json,
+    )
+
+DEFAULT_TIMEOUT = 15
+DEFAULT_MAX_RETRIES = 10
+DEFAULT_DELAY_RANGE: Tuple[float, float] = (1.0, 4.0)
+DEFAULT_AGGREGATED_FILENAME = "liquidations_walmart_qc.json"
+
+USER_AGENTS: Tuple[str, ...] = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+)
+
+
+def pick_proxy(proxies: List[str]) -> Optional[str]:
+    if not proxies:
+        return None
+    return random.choice(proxies)
+
+
+def build_headers() -> dict[str, str]:
+    return {
+        "User-Agent": random.choice(USER_AGENTS),
+        "Accept-Language": "fr-FR,fr;q=0.9",
+    }
+
+
+def fetch_page(
+    url: str,
+    proxies: List[str],
+    *,
+    max_retries: int,
+    timeout: int,
+    delay_range: Tuple[float, float],
+) -> str:
+    """Download ``url`` using random proxies until success or timeout."""
+
+    last_error: Optional[Exception] = None
+    for attempt in range(1, max_retries + 1):
+        proxy = pick_proxy(proxies)
+        proxy_label = proxy or "direct"
+        headers = build_headers()
+        proxies_dict = {"http": proxy, "https": proxy} if proxy else None
+        try:
+            response: Response = requests.get(
+                url,
+                headers=headers,
+                proxies=proxies_dict,
+                timeout=timeout,
+            )
+            if response.status_code == 200:
+                return response.text
+            print(
+                f"Echec (status {response.status_code}) avec le proxy {proxy_label} "
+                f"(essai {attempt}/{max_retries})."
+            )
+        except Exception as exc:  # noqa: BLE001 - on loggue l'erreur pour inspection
+            last_error = exc
+            print(
+                f"Echec avec le proxy {proxy_label} à l'essai {attempt}/{max_retries}: {exc}"
+            )
+
+        time.sleep(random.uniform(*delay_range))
+
+    raise RuntimeError(
+        "Impossible de charger la page après plusieurs tentatives via proxy."
+    ) from last_error
+
+
+def extract_deals_from_html(page_source: str) -> List[Deal]:
+    """Parse ``page_source`` and return normalized deals."""
+
+    soup = BeautifulSoup(page_source, "html.parser")
+    script_tag = soup.find("script", {"id": "__NEXT_DATA__"})
+    if script_tag is None or not script_tag.string:
+        raise ValueError("Section JSON '__NEXT_DATA__' non trouvée.")
+
+    try:
+        json_data = json.loads(script_tag.string)
+    except json.JSONDecodeError as exc:  # pragma: no cover - logging context
+        raise ValueError("Impossible de décoder le JSON '__NEXT_DATA__'.") from exc
+
+    deals: List[Deal] = []
+    for candidate in extract_from_state(json_data):
+        deal = build_deal_from_dict(candidate)
+        if deal:
+            deals.append(deal)
+
+    return deduplicate_deals(deals)
+
+
+def scrape_store(
+    store: Store,
+    proxies: List[str],
+    *,
+    max_retries: int,
+    timeout: int,
+    delay_range: Tuple[float, float],
+) -> List[Deal]:
+    page_source = fetch_page(
+        store.url,
+        proxies,
+        max_retries=max_retries,
+        timeout=timeout,
+        delay_range=delay_range,
+    )
+    deals = extract_deals_from_html(page_source)
+    print(f"✔ {store.ville}: {len(deals)} produits (HTTP)")
+    return deals
+
+
+def run(
+    *,
+    store_filters: Optional[Set[str]] = None,
+    output_dir: Optional[Path] = None,
+    aggregated_path: Optional[Path] = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    timeout: int = DEFAULT_TIMEOUT,
+    delay_range: Tuple[float, float] = DEFAULT_DELAY_RANGE,
+) -> None:
+    proxies = load_proxies()
+    stores = load_stores()
+    if not stores:
+        raise ValueError("Aucun magasin Walmart n'a été configuré.")
+
+    normalized_filters: Set[str] = set()
+    if store_filters:
+        for item in store_filters:
+            normalized_filters.update(normalize_store_token(item))
+
+    if normalized_filters:
+        stores = [store for store in stores if store_matches_filters(store, normalized_filters)]
+        if not stores:
+            raise ValueError("Aucun magasin ne correspond aux filtres fournis.")
+
+    per_store_dir = ensure_output_paths(output_dir)
+    aggregated_target = aggregated_path or Path(DEFAULT_AGGREGATED_FILENAME)
+
+    aggregated: List[dict] = []
+    processed = 0
+    for store in stores:
+        try:
+            deals = scrape_store(
+                store,
+                proxies,
+                max_retries=max_retries,
+                timeout=timeout,
+                delay_range=delay_range,
+            )
+        except Exception as exc:  # noqa: BLE001 - trace par magasin
+            print(f"⚠️  {store.ville}: {exc}")
+            continue
+
+        payload = [deal.to_payload(store) for deal in deals]
+        write_json(per_store_dir / f"{store.slug}.json", payload)
+        aggregated.extend(payload)
+        processed += 1
+
+    write_json(aggregated_target, aggregated)
+    print(
+        "🗂️  Export terminé: "
+        f"{len(aggregated)} produits sur {processed}/{len(stores)} magasins traités."
+    )
+
+
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scraper les liquidations Walmart via requêtes HTTP."
+    )
+    parser.add_argument(
+        "--store",
+        "-s",
+        action="append",
+        dest="stores",
+        help="Filtrer les magasins par ID, ville ou slug (répétable).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Dossier de sortie pour les fichiers JSON par magasin (défaut: data/walmart).",
+    )
+    parser.add_argument(
+        "--aggregated-path",
+        type=Path,
+        default=None,
+        help="Chemin du fichier JSON agrégé (défaut: liquidations_walmart_qc.json).",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help="Nombre maximum de tentatives par requête HTTP.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help="Délai maximum (en secondes) pour chaque requête HTTP.",
+    )
+    parser.add_argument(
+        "--min-delay",
+        type=float,
+        default=DEFAULT_DELAY_RANGE[0],
+        help="Delai minimal entre les tentatives (en secondes).",
+    )
+    parser.add_argument(
+        "--max-delay",
+        type=float,
+        default=DEFAULT_DELAY_RANGE[1],
+        help="Delai maximal entre les tentatives (en secondes).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_arguments(argv)
+
+    if args.min_delay < 0 or args.max_delay < 0:
+        raise ValueError("Les délais doivent être positifs.")
+    if args.min_delay > args.max_delay:
+        raise ValueError("Le délai minimal doit être inférieur ou égal au délai maximal.")
+
+    store_filters = set(args.stores) if args.stores else None
+    delay_range = (args.min_delay, args.max_delay)
+
+    run(
+        store_filters=store_filters,
+        output_dir=args.output_dir,
+        aggregated_path=args.aggregated_path,
+        max_retries=args.max_retries,
+        timeout=args.timeout,
+        delay_range=delay_range,
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 playwright>=1.44,<2.0
+requests>=2.31,<3.0
+beautifulsoup4>=4.12,<5.0


### PR DESCRIPTION
## Summary
- extract the shared store/deal helpers into `incoming/walmart_common.py`
- add a requests/BeautifulSoup-based Walmart scraper that reuses the proxy rotation logic
- document the new option and add the required dependencies to `requirements.txt`

## Testing
- python -m compileall incoming

------
https://chatgpt.com/codex/tasks/task_e_68dfa6149434832ea702d09ac7b3eb9f