### PR TITLE
Add footer disclaimer about stock responsibility and privacy

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,8 @@
   </main>
 
   <div class="container footer">
-    © <span id="yearFooter"></span> EconoDeal · Tous droits réservés
+    <p style="margin:0 0 8px">EconoDeal n'est pas responsable de la disponibilité des stocks affichés et n'enregistre aucun renseignement personnel des visiteurs.</p>
+    <div>© <span id="yearFooter"></span> EconoDeal · Tous droits réservés</div>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add a footer disclaimer clarifying that EconoDeal n'est pas responsable des stocks affichés
- specify that no personal information from visitors is recorded

## Testing
- not run (static content update)


------
https://chatgpt.com/codex/tasks/task_e_68dfb0c76864832ebecf640681bcf49c