### PR TITLE
Update Canadian Tire store directory

### DIFF
--- a/data/canadian-tire/stores.json
+++ b/data/canadian-tire/stores.json
@@ -1,706 +1,4547 @@
 [
   {
-    "store_id": null,
-    "label": "Canadian Tire Alma",
-    "city": "Alma",
-    "nickname": "Alma",
-    "slug": "alma",
-    "province": "QC"
+    "store_id": "0271",
+    "label": "Canadian Tire St. Jerome, QC",
+    "city": "St. Jerome",
+    "nickname": "St. Jerome",
+    "province": "QC",
+    "address": "700, boul. Monseigneur-Dubois, St. Jerome, QC, J7Y 4Y9",
+    "slug": "st-jerome-qc-0271"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Amos",
-    "city": "Amos",
-    "nickname": "Amos",
-    "slug": "amos",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Baie-Comeau",
-    "city": "Baie-Comeau",
-    "nickname": "Baie-Comeau",
-    "slug": "baie-comeau",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Beauport",
-    "city": "Beauport",
-    "nickname": "Beauport",
-    "slug": "beauport",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Beloeil",
-    "city": "Beloeil",
-    "nickname": "Beloeil",
-    "slug": "beloeil",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Blainville",
+    "store_id": "0649",
+    "label": "Canadian Tire Blainville, QC",
     "city": "Blainville",
     "nickname": "Blainville",
-    "slug": "blainville",
-    "province": "QC"
+    "province": "QC",
+    "address": "500, boul. de la Seigneurie Ouest, Blainville, QC, J7C 5T7",
+    "slug": "blainville-qc-0649"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Boucherville",
-    "city": "Boucherville",
-    "nickname": "Boucherville",
-    "slug": "boucherville",
-    "province": "QC"
+    "store_id": "0418",
+    "label": "Canadian Tire Rosemere, QC",
+    "city": "Rosemere",
+    "nickname": "Rosemere",
+    "province": "QC",
+    "address": "10, boul. Bouthillier, Rosemere, QC, J7A 4B4",
+    "slug": "rosemere-qc-0418"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Brossard (DIX 30)",
-    "city": "Brossard",
-    "nickname": "Brossard (DIX 30)",
-    "slug": "brossard-dix-30",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Buckingham",
-    "city": "Buckingham",
-    "nickname": "Buckingham",
-    "slug": "buckingham",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Cap-de-la-Madeleine",
-    "city": "Cap-de-la-Madeleine",
-    "nickname": "Cap-de-la-Madeleine",
-    "slug": "cap-de-la-madeleine",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Chambly",
-    "city": "Chambly",
-    "nickname": "Chambly",
-    "slug": "chambly",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Châteauguay",
-    "city": "Châteauguay",
-    "nickname": "Châteauguay",
-    "slug": "chateauguay",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Chicoutimi",
-    "city": "Chicoutimi",
-    "nickname": "Chicoutimi",
-    "slug": "chicoutimi",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Cowansville",
-    "city": "Cowansville",
-    "nickname": "Cowansville",
-    "slug": "cowansville",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Delson",
-    "city": "Delson",
-    "nickname": "Delson",
-    "slug": "delson",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Dolbeau",
-    "city": "Dolbeau",
-    "nickname": "Dolbeau",
-    "slug": "dolbeau",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Donnacona",
-    "city": "Donnacona",
-    "nickname": "Donnacona",
-    "slug": "donnacona",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Drummondville",
-    "city": "Drummondville",
-    "nickname": "Drummondville",
-    "slug": "drummondville",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Fabreville",
-    "city": "Fabreville",
-    "nickname": "Fabreville",
-    "slug": "fabreville",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Fleurimont",
-    "city": "Fleurimont",
-    "nickname": "Fleurimont",
-    "slug": "fleurimont",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Gaspésie",
-    "city": "Gaspésie",
-    "nickname": "Gaspésie",
-    "slug": "gaspesie",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Gatineau",
-    "city": "Gatineau",
-    "nickname": "Gatineau",
-    "slug": "gatineau",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Gatineau - Le Plateau",
-    "city": "Gatineau",
-    "nickname": "Gatineau - Le Plateau",
-    "slug": "gatineau-le-plateau",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Granby",
-    "city": "Granby",
-    "nickname": "Granby",
-    "slug": "granby",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Greenfield Park",
-    "city": "Greenfield Park",
-    "nickname": "Greenfield Park",
-    "slug": "greenfield-park",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Hull",
-    "city": "Hull",
-    "nickname": "Hull",
-    "slug": "hull",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Joliette",
-    "city": "Joliette",
-    "nickname": "Joliette",
-    "slug": "joliette",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Jonquière",
-    "city": "Jonquière",
-    "nickname": "Jonquière",
-    "slug": "jonquiere",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire La Baie",
-    "city": "La Baie",
-    "nickname": "La Baie",
-    "slug": "la-baie",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire La Malbaie",
-    "city": "La Malbaie",
-    "nickname": "La Malbaie",
-    "slug": "la-malbaie",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire La Plaine",
+    "store_id": "0641",
+    "label": "Canadian Tire La Plaine, QC",
     "city": "La Plaine",
     "nickname": "La Plaine",
-    "slug": "la-plaine",
-    "province": "QC"
+    "province": "QC",
+    "address": "4785, boul. Laurier, Terrebonne, QC, J7M 1C3",
+    "slug": "la-plaine-qc-0641"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire La Pocatière",
-    "city": "La Pocatière",
-    "nickname": "La Pocatière",
-    "slug": "la-pocatiere",
-    "province": "QC"
+    "store_id": "0218",
+    "label": "Canadian Tire St. Eustache, QC",
+    "city": "St. Eustache",
+    "nickname": "St. Eustache",
+    "province": "QC",
+    "address": "500, boul. Arthur-Sauve, Saint-Eustache, QC, J7R 4Z3",
+    "slug": "st-eustache-qc-0218"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire La Sarre",
-    "city": "La Sarre",
-    "nickname": "La Sarre",
-    "slug": "la-sarre",
-    "province": "QC"
+    "store_id": "0690",
+    "label": "Canadian Tire Laval Fabreville, QC",
+    "city": "Laval Fabreville",
+    "nickname": "Laval Fabreville",
+    "province": "QC",
+    "address": "544, boul. Cure-Labelle, Fabreville, QC, H7P 2P4",
+    "slug": "laval-fabreville-qc-0690"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Les Saules",
-    "city": "Les Saules",
-    "nickname": "Les Saules",
-    "slug": "les-saules",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Lévis",
-    "city": "Lévis",
-    "nickname": "Lévis",
-    "slug": "levis",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Longueuil",
-    "city": "Longueuil",
-    "nickname": "Longueuil",
-    "slug": "longueuil",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Magog",
-    "city": "Magog",
-    "nickname": "Magog",
-    "slug": "magog",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Maniwaki",
-    "city": "Maniwaki",
-    "nickname": "Maniwaki",
-    "slug": "maniwaki",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Matane",
-    "city": "Matane",
-    "nickname": "Matane",
-    "slug": "matane",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Mont-Laurier",
-    "city": "Mont-Laurier",
-    "nickname": "Mont-Laurier",
-    "slug": "mont-laurier",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montmagny",
-    "city": "Montmagny",
-    "nickname": "Montmagny",
-    "slug": "montmagny",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Anjou",
-    "city": "Montréal",
-    "nickname": "Anjou",
-    "slug": "montreal-anjou",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Bellechasse",
-    "city": "Montréal",
-    "nickname": "Bellechasse",
-    "slug": "montreal-bellechasse",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Centre",
-    "city": "Montréal",
-    "nickname": "Centre",
-    "slug": "montreal-centre",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Côte-des-Neiges",
-    "city": "Montréal",
-    "nickname": "Côte-des-Neiges",
-    "slug": "montreal-cote-des-neiges",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Crémazie",
-    "city": "Montréal",
-    "nickname": "Crémazie",
-    "slug": "montreal-cremazie",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Dollard-des-Ormeaux",
-    "city": "Montréal",
-    "nickname": "Dollard-des-Ormeaux",
-    "slug": "montreal-dollard-des-ormeaux",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Kirkland",
-    "city": "Montréal",
-    "nickname": "Kirkland",
-    "slug": "montreal-kirkland",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - LaSalle",
-    "city": "Montréal",
-    "nickname": "LaSalle",
-    "slug": "montreal-lasalle",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Marché Central",
-    "city": "Montréal",
-    "nickname": "Marché Central",
-    "slug": "montreal-marche-central",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Place Alexis Nihon",
-    "city": "Montréal",
-    "nickname": "Place Alexis Nihon",
-    "slug": "montreal-place-alexis-nihon",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Place Versailles",
-    "city": "Montréal",
-    "nickname": "Place Versailles",
-    "slug": "montreal-place-versailles",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Place Vertu",
-    "city": "Montréal",
-    "nickname": "Place Vertu",
-    "slug": "montreal-place-vertu",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Saint-Léonard (Langelier)",
-    "city": "Montréal",
-    "nickname": "Saint-Léonard (Langelier)",
-    "slug": "montreal-saint-leonard-langelier",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Saint-Léonard (Pie-IX)",
-    "city": "Montréal",
-    "nickname": "Saint-Léonard (Pie-IX)",
-    "slug": "montreal-saint-leonard-pie-ix",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Montréal - Verdun",
-    "city": "Montréal",
-    "nickname": "Verdun",
-    "slug": "montreal-verdun",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Mont-Tremblant",
-    "city": "Mont-Tremblant",
-    "nickname": "Mont-Tremblant",
-    "slug": "mont-tremblant",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Nicolet",
-    "city": "Nicolet",
-    "nickname": "Nicolet",
-    "slug": "nicolet",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Paspébiac",
-    "city": "Paspébiac",
-    "nickname": "Paspébiac",
-    "slug": "paspebiac",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Québec - Lebourgneuf",
-    "city": "Québec",
-    "nickname": "Lebourgneuf",
-    "slug": "quebec-lebourgneuf",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Québec - Les Saules",
-    "city": "Québec",
-    "nickname": "Les Saules",
-    "slug": "quebec-les-saules",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Québec - Sainte-Foy",
-    "city": "Québec",
-    "nickname": "Sainte-Foy",
-    "slug": "quebec-sainte-foy",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Québec - Vanier",
-    "city": "Québec",
-    "nickname": "Vanier",
-    "slug": "quebec-vanier",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Rimouski",
-    "city": "Rimouski",
-    "nickname": "Rimouski",
-    "slug": "rimouski",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Rivière-du-Loup",
-    "city": "Rivière-du-Loup",
-    "nickname": "Rivière-du-Loup",
-    "slug": "riviere-du-loup",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Roberval",
-    "city": "Roberval",
-    "nickname": "Roberval",
-    "slug": "roberval",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Rouyn-Noranda",
-    "city": "Rouyn-Noranda",
-    "nickname": "Rouyn-Noranda",
-    "slug": "rouyn-noranda",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Bruno",
-    "city": "Saint-Bruno",
-    "nickname": "Saint-Bruno",
-    "slug": "saint-bruno",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Sainte-Agathe-des-Monts",
-    "city": "Sainte-Agathe-des-Monts",
-    "nickname": "Sainte-Agathe-des-Monts",
-    "slug": "sainte-agathe-des-monts",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Sainte-Marie",
-    "city": "Sainte-Marie",
-    "nickname": "Sainte-Marie",
-    "slug": "sainte-marie",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Eustache",
-    "city": "Saint-Eustache",
-    "nickname": "Saint-Eustache",
-    "slug": "saint-eustache",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Georges-de-Beauce",
-    "city": "Saint-Georges-de-Beauce",
-    "nickname": "Saint-Georges-de-Beauce",
-    "slug": "saint-georges-de-beauce",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Hyacinthe",
-    "city": "Saint-Hyacinthe",
-    "nickname": "Saint-Hyacinthe",
-    "slug": "saint-hyacinthe",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Jean-sur-Richelieu",
-    "city": "Saint-Jean-sur-Richelieu",
-    "nickname": "Saint-Jean-sur-Richelieu",
-    "slug": "saint-jean-sur-richelieu",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Jérôme",
-    "city": "Saint-Jérôme",
-    "nickname": "Saint-Jérôme",
-    "slug": "saint-jerome",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Saint-Romuald",
-    "city": "Saint-Romuald",
-    "nickname": "Saint-Romuald",
-    "slug": "saint-romuald",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Sept-Îles",
-    "city": "Sept-Îles",
-    "nickname": "Sept-Îles",
-    "slug": "sept-iles",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Shawinigan",
-    "city": "Shawinigan",
-    "nickname": "Shawinigan",
-    "slug": "shawinigan",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Sherbrooke",
-    "city": "Sherbrooke",
-    "nickname": "Sherbrooke",
-    "slug": "sherbrooke",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Sorel",
-    "city": "Sorel",
-    "nickname": "Sorel",
-    "slug": "sorel",
-    "province": "QC"
-  },
-  {
-    "store_id": null,
-    "label": "Canadian Tire Terrebonne",
+    "store_id": "0312",
+    "label": "Canadian Tire Terrebonne, QC",
     "city": "Terrebonne",
     "nickname": "Terrebonne",
-    "slug": "terrebonne",
-    "province": "QC"
+    "province": "QC",
+    "address": "1250, boul. Moody, Terrebonne, QC, J6W 3K9",
+    "slug": "terrebonne-qc-0312"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Thetford Mines",
-    "city": "Thetford Mines",
-    "nickname": "Thetford Mines",
-    "slug": "thetford-mines",
-    "province": "QC"
+    "store_id": "0262",
+    "label": "Canadian Tire Lachute, QC",
+    "city": "Lachute",
+    "nickname": "Lachute",
+    "province": "QC",
+    "address": "505, avenue Bethany, Lachute, QC, J8H 4A6",
+    "slug": "lachute-qc-0262"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Trois-Rivières",
-    "city": "Trois-Rivières",
-    "nickname": "Trois-Rivières",
-    "slug": "trois-rivieres",
-    "province": "QC"
+    "store_id": "0231",
+    "label": "Canadian Tire Laval Vimont, QC",
+    "city": "Laval Vimont",
+    "nickname": "Laval Vimont",
+    "province": "QC",
+    "address": "4975, boul. Robert-Bourassa, Laval, QC, H7E 0A4",
+    "slug": "laval-vimont-qc-0231"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Val-d'Or",
-    "city": "Val-d'Or",
-    "nickname": "Val-d'Or",
-    "slug": "val-d-or",
-    "province": "QC"
+    "store_id": "0257",
+    "label": "Canadian Tire Ste. Agathe des Monts, QC",
+    "city": "Ste. Agathe des Monts",
+    "nickname": "Ste. Agathe des Monts",
+    "province": "QC",
+    "address": "50, boul. Morin, Sainte-Agathe-des-Monts, QC, J8C 2V6",
+    "slug": "ste-agathe-des-monts-qc-0257"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Valleyfield",
-    "city": "Valleyfield",
-    "nickname": "Valleyfield",
-    "slug": "valleyfield",
-    "province": "QC"
+    "store_id": "0300",
+    "label": "Canadian Tire Laval, Bl. Le Corbusier, QC",
+    "city": "Laval, Bl. Le Corbusier",
+    "nickname": "Laval, Bl. Le Corbusier",
+    "province": "QC",
+    "address": "1450, boul. Le Corbusier, Laval, QC, H7N 6J5",
+    "slug": "laval-bl-le-corbusier-qc-0300"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Vaudreuil",
+    "store_id": "0155",
+    "label": "Canadian Tire Laval, Ste-Dorothee, QC",
+    "city": "Laval, Ste-Dorothee",
+    "nickname": "Laval, Ste-Dorothee",
+    "province": "QC",
+    "address": "500 Chomedey (A-13) Ouest, Laval, QC, H7X 3S9",
+    "slug": "laval-ste-dorothee-qc-0155"
+  },
+  {
+    "store_id": "0454",
+    "label": "Canadian Tire Rivieres des Prairies, QC",
+    "city": "Rivieres des Prairies",
+    "nickname": "Rivieres des Prairies",
+    "province": "QC",
+    "address": "7555, boul. Maurice-Duplessis, Montreal, QC, H1E 7N2",
+    "slug": "rivieres-des-prairies-qc-0454"
+  },
+  {
+    "store_id": "0267",
+    "label": "Canadian Tire Montreal Nord, QC",
+    "city": "Montreal Nord",
+    "nickname": "Montreal Nord",
+    "province": "QC",
+    "address": "6000, boul. Henri-Bourassa Est, Unit Z1, Montreal-nord, QC, H1G 2T6",
+    "slug": "montreal-nord-qc-0267"
+  },
+  {
+    "store_id": "0234",
+    "label": "Canadian Tire Dollard des Ormeaux, QC",
+    "city": "Dollard des Ormeaux",
+    "nickname": "Dollard des Ormeaux",
+    "province": "QC",
+    "address": "3079, boul. des Sources, Dollard-Des-Ormeaux, QC, H9B 1Z6",
+    "slug": "dollard-des-ormeaux-qc-0234"
+  },
+  {
+    "store_id": "0149",
+    "label": "Canadian Tire Kirkland, QC",
+    "city": "Kirkland",
+    "nickname": "Kirkland",
+    "province": "QC",
+    "address": "16821, Route Transcanadienne, Kirkland, QC, H9H 5J1",
+    "slug": "kirkland-qc-0149"
+  },
+  {
+    "store_id": "0064",
+    "label": "Canadian Tire Montreal Cremazie & Papineau, QC",
+    "city": "Montreal Cremazie & Papineau",
+    "nickname": "Montreal Cremazie & Papineau",
+    "province": "QC",
+    "address": "2225, boul. Cremazie Est, Montreal, QC, H1Z 4N4",
+    "slug": "montreal-cremazie-papineau-qc-0064"
+  },
+  {
+    "store_id": "0292",
+    "label": "Canadian Tire Marche Central, QC",
+    "city": "Marche Central",
+    "nickname": "Marche Central",
+    "province": "QC",
+    "address": "9050, boul. de l'Acadie, Montreal, QC, H4N 2S5",
+    "slug": "marche-central-qc-0292"
+  },
+  {
+    "store_id": "0009",
+    "label": "Canadian Tire Langelier, QC",
+    "city": "Langelier",
+    "nickname": "Langelier",
+    "province": "QC",
+    "address": "6565, rue Jean-Talon Est, St. Leonard, QC, H1S 1N2",
+    "slug": "langelier-qc-0009"
+  },
+  {
+    "store_id": "0235",
+    "label": "Canadian Tire Ville St. Laurent, QC",
+    "city": "Ville St. Laurent",
+    "nickname": "Ville St. Laurent",
+    "province": "QC",
+    "address": "11200, boul. Cavendish, Ville Saint-Laurent, QC, H4R 2J7",
+    "slug": "ville-st-laurent-qc-0235"
+  },
+  {
+    "store_id": "0247",
+    "label": "Canadian Tire St. Leonard, QC",
+    "city": "St. Leonard",
+    "nickname": "St. Leonard",
+    "province": "QC",
+    "address": "4250, rue Jean-Talon Est, St. Leonard, QC, H1S 1J7",
+    "slug": "st-leonard-qc-0247"
+  },
+  {
+    "store_id": "0303",
+    "label": "Canadian Tire Pointe aux Trembles, QC",
+    "city": "Pointe aux Trembles",
+    "nickname": "Pointe aux Trembles",
+    "province": "QC",
+    "address": "3500, boul. du Tricentenaire, Montreal, QC, H1B 0A3",
+    "slug": "pointe-aux-trembles-qc-0303"
+  },
+  {
+    "store_id": "0928",
+    "label": "Canadian Tire Place Versailles, QC",
+    "city": "Place Versailles",
+    "nickname": "Place Versailles",
+    "province": "QC",
+    "address": "7275, rue Sherbrooke Est, Suite 140, Montreal, QC, H1N 1E9",
+    "slug": "place-versailles-qc-0928"
+  },
+  {
+    "store_id": "0222",
+    "label": "Canadian Tire Repentigny, QC",
+    "city": "Repentigny",
+    "nickname": "Repentigny",
+    "province": "QC",
+    "address": "115, boul. Brien, Repentigny, QC, J6A 8J3",
+    "slug": "repentigny-qc-0222"
+  },
+  {
+    "store_id": "0343",
+    "label": "Canadian Tire Montreal Bellechasse, QC",
+    "city": "Montreal Bellechasse",
+    "nickname": "Montreal Bellechasse",
+    "province": "QC",
+    "address": "6275, boul. St. Laurent, Montreal, QC, H2S 3C3",
+    "slug": "montreal-bellechasse-qc-0343"
+  },
+  {
+    "store_id": "0646",
+    "label": "Canadian Tire Vaudreuil, QC",
     "city": "Vaudreuil",
     "nickname": "Vaudreuil",
-    "slug": "vaudreuil",
-    "province": "QC"
+    "province": "QC",
+    "address": "50, boul. de la Cite-des-Jeunes, Vaudreuil-Dorion, QC, J7V 9L5",
+    "slug": "vaudreuil-qc-0646"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Victoriaville",
+    "store_id": "0401",
+    "label": "Canadian Tire Cote des Neiges, QC",
+    "city": "Cote des Neiges",
+    "nickname": "Cote des Neiges",
+    "province": "QC",
+    "address": "6700, chemin de la Cote-des-Neiges, Montreal, QC, H3S 2B2",
+    "slug": "cote-des-neiges-qc-0401"
+  },
+  {
+    "store_id": "0400",
+    "label": "Canadian Tire Montreal Maisonneuve, QC",
+    "city": "Montreal Maisonneuve",
+    "nickname": "Montreal Maisonneuve",
+    "province": "QC",
+    "address": "3025, rue Sherbrooke Est, Montreal, QC, H1W 1B2",
+    "slug": "montreal-maisonneuve-qc-0400"
+  },
+  {
+    "store_id": "0181",
+    "label": "Canadian Tire Ile Perrot, QC",
+    "city": "Ile Perrot",
+    "nickname": "Ile Perrot",
+    "province": "QC",
+    "address": "101, boul. Cardinal-Leger, Pincourt, QC, J7W 3Y3",
+    "slug": "ile-perrot-qc-0181"
+  },
+  {
+    "store_id": "0435",
+    "label": "Canadian Tire Montreal Downtown, QC",
+    "city": "Montreal Downtown",
+    "nickname": "Montreal Downtown",
+    "province": "QC",
+    "address": "1500, avenue Atwater, Place Alexis Nihon, Montreal, QC, H3Z 1X5",
+    "slug": "montreal-downtown-qc-0435"
+  },
+  {
+    "store_id": "0627",
+    "label": "Canadian Tire St. Jacques - Montreal, QC",
+    "city": "St. Jacques - Montreal",
+    "nickname": "St. Jacques - Montreal",
+    "province": "QC",
+    "address": "7200, boul. de Sainte-Anne-de-Bellevue, Montreal, QC, H4B 1T4",
+    "slug": "st-jacques-montreal-qc-0627"
+  },
+  {
+    "store_id": "0230",
+    "label": "Canadian Tire Ville La Salle, QC",
+    "city": "Ville La Salle",
+    "nickname": "Ville La Salle",
+    "province": "QC",
+    "address": "2221, boul. Angrignon, LaSalle, QC, H8N 3E3",
+    "slug": "ville-la-salle-qc-0230"
+  },
+  {
+    "store_id": "0117",
+    "label": "Canadian Tire Verdun, QC",
+    "city": "Verdun",
+    "nickname": "Verdun",
+    "province": "QC",
+    "address": "3180, rue Wellington, Verdun, QC, H4G 1T3",
+    "slug": "verdun-qc-0117"
+  },
+  {
+    "store_id": "0332",
+    "label": "Canadian Tire Boucherville, QC",
+    "city": "Boucherville",
+    "nickname": "Boucherville",
+    "province": "QC",
+    "address": "1055, boul. de Montarville, Boucherville, QC, J4B 6P5",
+    "slug": "boucherville-qc-0332"
+  },
+  {
+    "store_id": "0157",
+    "label": "Canadian Tire Hawkesbury, ON",
+    "city": "Hawkesbury",
+    "nickname": "Hawkesbury",
+    "province": "ON",
+    "address": "1525 Cameron Street, Hawkesbury, ON, K6A 3R3",
+    "slug": "hawkesbury-on-0157"
+  },
+  {
+    "store_id": "0256",
+    "label": "Canadian Tire Longueuil, QC",
+    "city": "Longueuil",
+    "nickname": "Longueuil",
+    "province": "QC",
+    "address": "2211, boul. Roland-Therrien, Longueuil, QC, J4N 1P2",
+    "slug": "longueuil-qc-0256"
+  },
+  {
+    "store_id": "0200",
+    "label": "Canadian Tire Joliette, QC",
+    "city": "Joliette",
+    "nickname": "Joliette",
+    "province": "QC",
+    "address": "1475, boul. Firestone, Joliette, QC, J6E 9E5",
+    "slug": "joliette-qc-0200"
+  },
+  {
+    "store_id": "0147",
+    "label": "Canadian Tire Chateauguay, QC",
+    "city": "Chateauguay",
+    "nickname": "Chateauguay",
+    "province": "QC",
+    "address": "140, boul. d'Anjou, Chateauguay, QC, J6K 1C4",
+    "slug": "chateauguay-qc-0147"
+  },
+  {
+    "store_id": "0461",
+    "label": "Canadian Tire Mont-Tremblant, QC",
+    "city": "Mont-Tremblant",
+    "nickname": "Mont-Tremblant",
+    "province": "QC",
+    "address": "370 Route 117, Mont-Tremblant, QC, J8E 2X3",
+    "slug": "mont-tremblant-qc-0461"
+  },
+  {
+    "store_id": "0190",
+    "label": "Canadian Tire Greenfield Park, QC",
+    "city": "Greenfield Park",
+    "nickname": "Greenfield Park",
+    "province": "QC",
+    "address": "4909, boul. Taschereau, Greenfield Park, QC, J4V 3G9",
+    "slug": "greenfield-park-qc-0190"
+  },
+  {
+    "store_id": "0396",
+    "label": "Canadian Tire Delson, QC",
+    "city": "Delson",
+    "nickname": "Delson",
+    "province": "QC",
+    "address": "65 132 Route, Delson, QC, J5B 1H1",
+    "slug": "delson-qc-0396"
+  },
+  {
+    "store_id": "0484",
+    "label": "Canadian Tire St. Bruno, QC",
+    "city": "St. Bruno",
+    "nickname": "St. Bruno",
+    "province": "QC",
+    "address": "900, rue de l'Etang, Saint-Bruno-de-Montarville, QC, J3V 6K8",
+    "slug": "st-bruno-qc-0484"
+  },
+  {
+    "store_id": "0115",
+    "label": "Canadian Tire Valleyfield, QC",
+    "city": "Valleyfield",
+    "nickname": "Valleyfield",
+    "province": "QC",
+    "address": "1770, boul. Monseigneur-Langlois, Salaberry-de-valleyfield, QC, J6S 5R1",
+    "slug": "valleyfield-qc-0115"
+  },
+  {
+    "store_id": "0643",
+    "label": "Canadian Tire Brossard, QC",
+    "city": "Brossard",
+    "nickname": "Brossard",
+    "province": "QC",
+    "address": "9900, boul. Leduc, Quartier DIX30, Brossard, QC, J4Y 0B4",
+    "slug": "brossard-qc-0643"
+  },
+  {
+    "store_id": "0228",
+    "label": "Canadian Tire Beloeil, QC",
+    "city": "Beloeil",
+    "nickname": "Beloeil",
+    "province": "QC",
+    "address": "600, boul. Sir-Wilfrid-Laurier, Beloeil, QC, J3G 4J2",
+    "slug": "beloeil-qc-0228"
+  },
+  {
+    "store_id": "0626",
+    "label": "Canadian Tire Chambly, QC",
+    "city": "Chambly",
+    "nickname": "Chambly",
+    "province": "QC",
+    "address": "3400, boul. Frechette, Chambly, QC, J3L 6Z6",
+    "slug": "chambly-qc-0626"
+  },
+  {
+    "store_id": "0238",
+    "label": "Canadian Tire Alexandria, ON",
+    "city": "Alexandria",
+    "nickname": "Alexandria",
+    "province": "ON",
+    "address": "400 Main Street South, Alexandria, ON, K0C 1A0",
+    "slug": "alexandria-on-0238"
+  },
+  {
+    "store_id": "0148",
+    "label": "Canadian Tire Sorel & Tracy, QC",
+    "city": "Sorel & Tracy",
+    "nickname": "Sorel & Tracy",
+    "province": "QC",
+    "address": "280, boul. Fiset, Sorel-Tracy, QC, J3P 5X7",
+    "slug": "sorel-tracy-qc-0148"
+  },
+  {
+    "store_id": "0153",
+    "label": "Canadian Tire St. Jean-sur-Richelieu, QC",
+    "city": "St. Jean-sur-Richelieu",
+    "nickname": "St. Jean-sur-Richelieu",
+    "province": "QC",
+    "address": "855, boul. du Seminaire Nord, Saint-Jean-sur-Richelieu, QC, J3A 1J2",
+    "slug": "st-jean-sur-richelieu-qc-0153"
+  },
+  {
+    "store_id": "0151",
+    "label": "Canadian Tire St. Hyacinthe, QC",
+    "city": "St. Hyacinthe",
+    "nickname": "St. Hyacinthe",
+    "province": "QC",
+    "address": "5930, rue Martineau, Saint-Hyacinthe, QC, J2R 2H6",
+    "slug": "st-hyacinthe-qc-0151"
+  },
+  {
+    "store_id": "0625",
+    "label": "Canadian Tire Casselman, ON",
+    "city": "Casselman",
+    "nickname": "Casselman",
+    "province": "ON",
+    "address": "95 Lafleche Blvd., Casselman, ON, K0A 1M0",
+    "slug": "casselman-on-0625"
+  },
+  {
+    "store_id": "0026",
+    "label": "Canadian Tire Cornwall, ON",
+    "city": "Cornwall",
+    "nickname": "Cornwall",
+    "province": "ON",
+    "address": "201 Ninth Street East, Cornwall, ON, K6H 2V1",
+    "slug": "cornwall-on-0026"
+  },
+  {
+    "store_id": "0623",
+    "label": "Canadian Tire Rockland, ON",
+    "city": "Rockland",
+    "nickname": "Rockland",
+    "province": "ON",
+    "address": "9040 County Road 17, Rockland, ON, K4K 1V5",
+    "slug": "rockland-on-0623"
+  },
+  {
+    "store_id": "0138",
+    "label": "Canadian Tire Granby, QC",
+    "city": "Granby",
+    "nickname": "Granby",
+    "province": "QC",
+    "address": "70, rue Simonds Nord, Granby, QC, J2J 2L1",
+    "slug": "granby-qc-0138"
+  },
+  {
+    "store_id": "0015",
+    "label": "Canadian Tire Buckingham, QC",
+    "city": "Buckingham",
+    "nickname": "Buckingham",
+    "province": "QC",
+    "address": "170, avenue Lepine, Gatineau, QC, J8L 4M4",
+    "slug": "buckingham-qc-0015"
+  },
+  {
+    "store_id": "0158",
+    "label": "Canadian Tire Drummondville, QC",
+    "city": "Drummondville",
+    "nickname": "Drummondville",
+    "province": "QC",
+    "address": "715, boul. St-Joseph, Drummondville, QC, J2C 7V2",
+    "slug": "drummondville-qc-0158"
+  },
+  {
+    "store_id": "0274",
+    "label": "Canadian Tire Cowansville, QC",
+    "city": "Cowansville",
+    "nickname": "Cowansville",
+    "province": "QC",
+    "address": "145, rue de Salaberry, Cowansville, QC, J2K 5G9",
+    "slug": "cowansville-qc-0274"
+  },
+  {
+    "store_id": "0686",
+    "label": "Canadian Tire Nicolet, QC",
+    "city": "Nicolet",
+    "nickname": "Nicolet",
+    "province": "QC",
+    "address": "2000, boul. Louis-Frechette, Nicolet, QC, J3T 1M9",
+    "slug": "nicolet-qc-0686"
+  },
+  {
+    "store_id": "0422",
+    "label": "Canadian Tire Ottawa Orleans, ON",
+    "city": "Ottawa Orleans",
+    "nickname": "Ottawa Orleans",
+    "province": "ON",
+    "address": "3910 Innes Road, Orleans, ON, K1W 1K9",
+    "slug": "ottawa-orleans-on-0422"
+  },
+  {
+    "store_id": "0308",
+    "label": "Canadian Tire Trois-Rivieres, QC",
+    "city": "Trois-Rivieres",
+    "nickname": "Trois-Rivieres",
+    "province": "QC",
+    "address": "3525, boul. des Forges, Trois-Rivieres, QC, G8Y 4P2",
+    "slug": "trois-rivieres-qc-0308"
+  },
+  {
+    "store_id": "0131",
+    "label": "Canadian Tire Shawinigan, QC",
+    "city": "Shawinigan",
+    "nickname": "Shawinigan",
+    "province": "QC",
+    "address": "1555, rue Trudel, Shawinigan, QC, G9N 8K8",
+    "slug": "shawinigan-qc-0131"
+  },
+  {
+    "store_id": "0109",
+    "label": "Canadian Tire Cap-de-la-Madeleine, QC",
+    "city": "Cap-de-la-Madeleine",
+    "nickname": "Cap-de-la-Madeleine",
+    "province": "QC",
+    "address": "350, rue Barkoff, Trois-Rivieres, QC, G8T 9P5",
+    "slug": "cap-de-la-madeleine-qc-0109"
+  },
+  {
+    "store_id": "0297",
+    "label": "Canadian Tire Ottawa Gloucester, ON",
+    "city": "Ottawa Gloucester",
+    "nickname": "Ottawa Gloucester",
+    "province": "ON",
+    "address": "2010 Ogilvie Road, Gloucester, ON, K1J 8X3",
+    "slug": "ottawa-gloucester-on-0297"
+  },
+  {
+    "store_id": "0174",
+    "label": "Canadian Tire Ottawa East, ON",
+    "city": "Ottawa East",
+    "nickname": "Ottawa East",
+    "province": "ON",
+    "address": "330 Coventry Road, Ottawa, ON, K1K 4S3",
+    "slug": "ottawa-east-on-0174"
+  },
+  {
+    "store_id": "0191",
+    "label": "Canadian Tire Gatineau, QC",
+    "city": "Gatineau",
+    "nickname": "Gatineau",
+    "province": "QC",
+    "address": "700, boul Maloney Ouest, Gatineau, QC, J8T 8K7",
+    "slug": "gatineau-qc-0191"
+  },
+  {
+    "store_id": "0659",
+    "label": "Canadian Tire Leitrim, ON",
+    "city": "Leitrim",
+    "nickname": "Leitrim",
+    "province": "ON",
+    "address": "4776 Bank Street, Gloucester, ON, K1T 0K8",
+    "slug": "leitrim-on-0659"
+  },
+  {
+    "store_id": "0120",
+    "label": "Canadian Tire Morrisburg, ON",
+    "city": "Morrisburg",
+    "nickname": "Morrisburg",
+    "province": "ON",
+    "address": "12329 County Road 2, Morrisburg, ON, K0C 1X0",
+    "slug": "morrisburg-on-0120"
+  },
+  {
+    "store_id": "0210",
+    "label": "Canadian Tire Ottawa South, ON",
+    "city": "Ottawa South",
+    "nickname": "Ottawa South",
+    "province": "ON",
+    "address": "1170 Heron Road, Ottawa, ON, K1V 6B2",
+    "slug": "ottawa-south-on-0210"
+  },
+  {
+    "store_id": "0648",
+    "label": "Canadian Tire Mont-Laurier, QC",
+    "city": "Mont-Laurier",
+    "nickname": "Mont-Laurier",
+    "province": "QC",
+    "address": "1675, boul. Albiny-Paquette, Mont-Laurier, QC, J9L 1M8",
+    "slug": "mont-laurier-qc-0648"
+  },
+  {
+    "store_id": "0176",
+    "label": "Canadian Tire Hull, QC",
+    "city": "Hull",
+    "nickname": "Hull",
+    "province": "QC",
+    "address": "355, boul. de la Carriere, Gatineau, QC, J8Y 6W4",
+    "slug": "hull-qc-0176"
+  },
+  {
+    "store_id": "0258",
+    "label": "Canadian Tire Ottawa Merivale, ON",
+    "city": "Ottawa Merivale",
+    "nickname": "Ottawa Merivale",
+    "province": "ON",
+    "address": "1820 Merivale Road, Nepean, ON, K2G 1E6",
+    "slug": "ottawa-merivale-on-0258"
+  },
+  {
+    "store_id": "0318",
+    "label": "Canadian Tire Gatineau Le Plateau, QC",
+    "city": "Gatineau Le Plateau",
+    "nickname": "Gatineau Le Plateau",
+    "province": "QC",
+    "address": "213, boul. des Grives, Gatineau, QC, J9A 0C7",
+    "slug": "gatineau-le-plateau-qc-0318"
+  },
+  {
+    "store_id": "0290",
+    "label": "Canadian Tire Ottawa Carling Ave, ON",
+    "city": "Ottawa Carling Ave",
+    "nickname": "Ottawa Carling Ave",
+    "province": "ON",
+    "address": "2165 Carling Avenue, Ottawa, ON, K2A 1J2",
+    "slug": "ottawa-carling-ave-on-0290"
+  },
+  {
+    "store_id": "0442",
+    "label": "Canadian Tire Barrhaven, ON",
+    "city": "Barrhaven",
+    "nickname": "Barrhaven",
+    "province": "ON",
+    "address": "2501 Greenbank Road, Nepean, ON, K2J 4Y6",
+    "slug": "barrhaven-on-0442"
+  },
+  {
+    "store_id": "0272",
+    "label": "Canadian Tire Ottawa Bells Cnrs, ON",
+    "city": "Ottawa Bells Cnrs",
+    "nickname": "Ottawa Bells Cnrs",
+    "province": "ON",
+    "address": "2135 Robertson Road, Nepean, ON, K2H 5Z2",
+    "slug": "ottawa-bells-cnrs-on-0272"
+  },
+  {
+    "store_id": "0227",
+    "label": "Canadian Tire Kemptville, ON",
+    "city": "Kemptville",
+    "nickname": "Kemptville",
+    "province": "ON",
+    "address": "311 Ryans Well Drive, Kemptville, ON, K0G 1J0",
+    "slug": "kemptville-on-0227"
+  },
+  {
+    "store_id": "0240",
+    "label": "Canadian Tire Magog, QC",
+    "city": "Magog",
+    "nickname": "Magog",
+    "province": "QC",
+    "address": "2135, rue Sherbrooke, Magog, QC, J1X 2T5",
+    "slug": "magog-qc-0240"
+  },
+  {
+    "store_id": "0457",
+    "label": "Canadian Tire Kanata, ON",
+    "city": "Kanata",
+    "nickname": "Kanata",
+    "province": "ON",
+    "address": "8181 Campeau Drive, Kanata, ON, K2T 1B7",
+    "slug": "kanata-on-0457"
+  },
+  {
+    "store_id": "0243",
+    "label": "Canadian Tire Victoriaville, QC",
     "city": "Victoriaville",
     "nickname": "Victoriaville",
-    "slug": "victoriaville",
-    "province": "QC"
+    "province": "QC",
+    "address": "571, boul Jutras Est, Victoriaville, QC, G6P 7H4",
+    "slug": "victoriaville-qc-0243"
   },
   {
-    "store_id": null,
-    "label": "Canadian Tire Vimont",
-    "city": "Vimont",
-    "nickname": "Vimont",
-    "slug": "vimont",
-    "province": "QC"
+    "store_id": "0096",
+    "label": "Canadian Tire Sherbrooke, QC",
+    "city": "Sherbrooke",
+    "nickname": "Sherbrooke",
+    "province": "QC",
+    "address": "4100, boul. Josaphat-Rancourt, Sherbrooke, QC, J1L 3C6",
+    "slug": "sherbrooke-qc-0096"
+  },
+  {
+    "store_id": "0196",
+    "label": "Canadian Tire Maniwaki, QC",
+    "city": "Maniwaki",
+    "nickname": "Maniwaki",
+    "province": "QC",
+    "address": "250, boul. Desjardins, Maniwaki, QC, J9E 3G4",
+    "slug": "maniwaki-qc-0196"
+  },
+  {
+    "store_id": "0085",
+    "label": "Canadian Tire Prescott, ON",
+    "city": "Prescott",
+    "nickname": "Prescott",
+    "province": "ON",
+    "address": "140 Prescott Centre Drive, Prescott, ON, K0E 1T0",
+    "slug": "prescott-on-0085"
+  },
+  {
+    "store_id": "0348",
+    "label": "Canadian Tire Sherbrooke Fleurimont, QC",
+    "city": "Sherbrooke Fleurimont",
+    "nickname": "Sherbrooke Fleurimont",
+    "province": "QC",
+    "address": "1645, rue King Est, Sherbrooke, QC, J1G 5G7",
+    "slug": "sherbrooke-fleurimont-qc-0348"
+  },
+  {
+    "store_id": "0018",
+    "label": "Canadian Tire Carleton Place, ON",
+    "city": "Carleton Place",
+    "nickname": "Carleton Place",
+    "province": "ON",
+    "address": "485 McNeely Avenue, at Hwy 7, Carleton Place, ON, K7C 4S6",
+    "slug": "carleton-place-on-0018"
+  },
+  {
+    "store_id": "0098",
+    "label": "Canadian Tire Smiths Falls, ON",
+    "city": "Smiths Falls",
+    "nickname": "Smiths Falls",
+    "province": "ON",
+    "address": "10 Ferrara Drive, Smiths Falls, ON, K7A 5K4",
+    "slug": "smiths-falls-on-0098"
+  },
+  {
+    "store_id": "0014",
+    "label": "Canadian Tire Brockville, ON",
+    "city": "Brockville",
+    "nickname": "Brockville",
+    "province": "ON",
+    "address": "2360 Parkedale Avenue, Brockville, ON, K6V 7J5",
+    "slug": "brockville-on-0014"
+  },
+  {
+    "store_id": "0004",
+    "label": "Canadian Tire Arnprior, ON",
+    "city": "Arnprior",
+    "nickname": "Arnprior",
+    "province": "ON",
+    "address": "375 Daniel Street South, Arnprior, ON, K7S 3K6",
+    "slug": "arnprior-on-0004"
+  },
+  {
+    "store_id": "0099",
+    "label": "Canadian Tire Shawville, QC",
+    "city": "Shawville",
+    "nickname": "Shawville",
+    "province": "QC",
+    "address": "431 148 Route, Shawville, QC, J0X 2Y0",
+    "slug": "shawville-qc-0099"
+  },
+  {
+    "store_id": "0423",
+    "label": "Canadian Tire Donnacona, QC",
+    "city": "Donnacona",
+    "nickname": "Donnacona",
+    "province": "QC",
+    "address": "223 138 Route, Donnacona, QC, G3M 1C1",
+    "slug": "donnacona-qc-0423"
+  },
+  {
+    "store_id": "0080",
+    "label": "Canadian Tire Perth, ON",
+    "city": "Perth",
+    "nickname": "Perth",
+    "province": "ON",
+    "address": "45 Dufferin Street, Perth, ON, K7H 3A5",
+    "slug": "perth-on-0080"
+  },
+  {
+    "store_id": "0352",
+    "label": "Canadian Tire La Tuque, QC",
+    "city": "La Tuque",
+    "nickname": "La Tuque",
+    "province": "QC",
+    "address": "1200, boul. Ducharme, La Tuque, QC, G9X 3Z9",
+    "slug": "la-tuque-qc-0352"
+  },
+  {
+    "store_id": "0086",
+    "label": "Canadian Tire Renfrew, ON",
+    "city": "Renfrew",
+    "nickname": "Renfrew",
+    "province": "ON",
+    "address": "1050 O'Brien Road, Renfrew, ON, K7V 0B4",
+    "slug": "renfrew-on-0086"
+  },
+  {
+    "store_id": "0156",
+    "label": "Canadian Tire Thetford Mines, QC",
+    "city": "Thetford Mines",
+    "nickname": "Thetford Mines",
+    "province": "QC",
+    "address": "70, boul. Frontenac Est, Thetford Mines, QC, G6G 1N4",
+    "slug": "thetford-mines-qc-0156"
+  },
+  {
+    "store_id": "0692",
+    "label": "Canadian Tire Ancienne Lorette, QC",
+    "city": "Ancienne Lorette",
+    "nickname": "Ancienne Lorette",
+    "province": "QC",
+    "address": "1233, autoroute Duplessis, L'Ancienne-Lorette, QC, G2G 2B4",
+    "slug": "ancienne-lorette-qc-0692"
+  },
+  {
+    "store_id": "0037",
+    "label": "Canadian Tire Gananoque, ON",
+    "city": "Gananoque",
+    "nickname": "Gananoque",
+    "province": "ON",
+    "address": "705 King Street East, Gananoque, ON, K7G 1H4",
+    "slug": "gananoque-on-0037"
+  },
+  {
+    "store_id": "0624",
+    "label": "Canadian Tire St. Romuald, QC",
+    "city": "St. Romuald",
+    "nickname": "St. Romuald",
+    "province": "QC",
+    "address": "600, rue de la Concorde, St. Romuald, QC, G6W 8A8",
+    "slug": "st-romuald-qc-0624"
+  },
+  {
+    "store_id": "0342",
+    "label": "Canadian Tire Quebec Les Saules, QC",
+    "city": "Quebec Les Saules",
+    "nickname": "Quebec Les Saules",
+    "province": "QC",
+    "address": "4500, rue Armand-Viau, Quebec, QC, G2C 2B9",
+    "slug": "quebec-les-saules-qc-0342"
+  },
+  {
+    "store_id": "0245",
+    "label": "Canadian Tire Quebec Ste. Foy, QC",
+    "city": "Quebec Ste. Foy",
+    "nickname": "Quebec Ste. Foy",
+    "province": "QC",
+    "address": "1170, route de l'Eglise, Quebec, QC, G1V 3W7",
+    "slug": "quebec-ste-foy-qc-0245"
+  },
+  {
+    "store_id": "0079",
+    "label": "Canadian Tire Pembroke, ON",
+    "city": "Pembroke",
+    "nickname": "Pembroke",
+    "province": "ON",
+    "address": "1104 Pembroke Street East, Pembroke, ON, K8A 8M1",
+    "slug": "pembroke-on-0079"
+  },
+  {
+    "store_id": "0405",
+    "label": "Canadian Tire Lebourgneuf, QC",
+    "city": "Lebourgneuf",
+    "nickname": "Lebourgneuf",
+    "province": "QC",
+    "address": "5500, boul. des Gradins, Quebec, QC, G2J 1A1",
+    "slug": "lebourgneuf-qc-0405"
+  },
+  {
+    "store_id": "0101",
+    "label": "Canadian Tire Quebec Vanier, QC",
+    "city": "Quebec Vanier",
+    "nickname": "Quebec Vanier",
+    "province": "QC",
+    "address": "630, boul. Wilfrid-Hamel, Quebec, QC, G1M 3P9",
+    "slug": "quebec-vanier-qc-0101"
+  },
+  {
+    "store_id": "0416",
+    "label": "Canadian Tire Ste. Marie De Beauce, QC",
+    "city": "Ste. Marie De Beauce",
+    "nickname": "Ste. Marie De Beauce",
+    "province": "QC",
+    "address": "980, boul. Vachon Nord, Sainte-Marie, QC, G6E 1M2",
+    "slug": "ste-marie-de-beauce-qc-0416"
+  },
+  {
+    "store_id": "0225",
+    "label": "Canadian Tire Lac Megantic, QC",
+    "city": "Lac Megantic",
+    "nickname": "Lac Megantic",
+    "province": "QC",
+    "address": "3642, rue Laval, Lac-Megantic, QC, G6B 1A4",
+    "slug": "lac-megantic-qc-0225"
+  },
+  {
+    "store_id": "0165",
+    "label": "Canadian Tire Levis, QC",
+    "city": "Levis",
+    "nickname": "Levis",
+    "province": "QC",
+    "address": "100 Route du President-Kennedy, Levis, QC, G6V 6C9",
+    "slug": "levis-qc-0165"
+  },
+  {
+    "store_id": "0184",
+    "label": "Canadian Tire Beauport, QC",
+    "city": "Beauport",
+    "nickname": "Beauport",
+    "province": "QC",
+    "address": "705, rue Clemenceau, Quebec, QC, G1C 7T9",
+    "slug": "beauport-qc-0184"
+  },
+  {
+    "store_id": "0694",
+    "label": "Canadian Tire Kingston Division St., ON",
+    "city": "Kingston Division St.",
+    "nickname": "Kingston Division St.",
+    "province": "ON",
+    "address": "1040 Division Street, Kingston, ON, K7K 0C3",
+    "slug": "kingston-division-st-on-0694"
+  },
+  {
+    "store_id": "0173",
+    "label": "Canadian Tire St. Georges, QC",
+    "city": "St. Georges",
+    "nickname": "St. Georges",
+    "province": "QC",
+    "address": "500, 107e Rue, Saint-Georges, QC, G5Y 8K1",
+    "slug": "st-georges-qc-0173"
+  },
+  {
+    "store_id": "0195",
+    "label": "Canadian Tire Kingston, ON",
+    "city": "Kingston",
+    "nickname": "Kingston",
+    "province": "ON",
+    "address": "59 Bath Road, Kingston, ON, K7L 5G3",
+    "slug": "kingston-on-0195"
+  },
+  {
+    "store_id": "0417",
+    "label": "Canadian Tire Kingston Township, ON",
+    "city": "Kingston Township",
+    "nickname": "Kingston Township",
+    "province": "ON",
+    "address": "2560 Princess Street, Kingston, ON, K7P 2S8",
+    "slug": "kingston-township-on-0417"
+  },
+  {
+    "store_id": "0253",
+    "label": "Canadian Tire Deep River, ON",
+    "city": "Deep River",
+    "nickname": "Deep River",
+    "province": "ON",
+    "address": "33277 Hwy 17 West, Deep River, ON, K0J 1P0",
+    "slug": "deep-river-on-0253"
+  },
+  {
+    "store_id": "0065",
+    "label": "Canadian Tire Napanee, ON",
+    "city": "Napanee",
+    "nickname": "Napanee",
+    "province": "ON",
+    "address": "476 Centre Street North, Napanee, ON, K7R 1P8",
+    "slug": "napanee-on-0065"
+  },
+  {
+    "store_id": "0180",
+    "label": "Canadian Tire Montmagny, QC",
+    "city": "Montmagny",
+    "nickname": "Montmagny",
+    "province": "QC",
+    "address": "488, avenue Saint-David, Montmagny, QC, G5V 4P9",
+    "slug": "montmagny-qc-0180"
+  },
+  {
+    "store_id": "0005",
+    "label": "Canadian Tire Bancroft, ON",
+    "city": "Bancroft",
+    "nickname": "Bancroft",
+    "province": "ON",
+    "address": "341 Hastings Street North, Bancroft, ON, K0L 1C0",
+    "slug": "bancroft-on-0005"
+  },
+  {
+    "store_id": "0082",
+    "label": "Canadian Tire Picton, ON",
+    "city": "Picton",
+    "nickname": "Picton",
+    "province": "ON",
+    "address": "13321 Loyalist Parkway, Picton, ON, K0K 2T0",
+    "slug": "picton-on-0082"
+  },
+  {
+    "store_id": "0007",
+    "label": "Canadian Tire Belleville, ON",
+    "city": "Belleville",
+    "nickname": "Belleville",
+    "province": "ON",
+    "address": "101 Bell Blvd., Belleville, ON, K8P 4V2",
+    "slug": "belleville-on-0007"
+  },
+  {
+    "store_id": "0458",
+    "label": "Canadian Tire Roberval, QC",
+    "city": "Roberval",
+    "nickname": "Roberval",
+    "province": "QC",
+    "address": "1056, boul. Olivier-Vien, Roberval, QC, G8H 3G3",
+    "slug": "roberval-qc-0458"
+  },
+  {
+    "store_id": "0112",
+    "label": "Canadian Tire Trenton, ON",
+    "city": "Trenton",
+    "nickname": "Trenton",
+    "province": "ON",
+    "address": "285 Dundas Street East, Trenton, ON, K8V 1M1",
+    "slug": "trenton-on-0112"
+  },
+  {
+    "store_id": "0017",
+    "label": "Canadian Tire Campbellford, ON",
+    "city": "Campbellford",
+    "nickname": "Campbellford",
+    "province": "ON",
+    "address": "130 Grand Road, Campbellford, ON, K0L 1L0",
+    "slug": "campbellford-on-0017"
+  },
+  {
+    "store_id": "0633",
+    "label": "Canadian Tire La Pocatiere, QC",
+    "city": "La Pocatiere",
+    "nickname": "La Pocatiere",
+    "province": "QC",
+    "address": "175 230 Route Ouest, La Pocatiere, QC, G0R 1Z0",
+    "slug": "la-pocatiere-qc-0633"
+  },
+  {
+    "store_id": "0298",
+    "label": "Canadian Tire Alma, QC",
+    "city": "Alma",
+    "nickname": "Alma",
+    "province": "QC",
+    "address": "50, boul. St. Luc, Alma, QC, G8B 6K1",
+    "slug": "alma-qc-0298"
+  },
+  {
+    "store_id": "0306",
+    "label": "Canadian Tire La Malbaie, QC",
+    "city": "La Malbaie",
+    "nickname": "La Malbaie",
+    "province": "QC",
+    "address": "375, boul. de Comporte, La Malbaie, QC, G5A 1T9",
+    "slug": "la-malbaie-qc-0306"
+  },
+  {
+    "store_id": "0221",
+    "label": "Canadian Tire Jonquiere, QC",
+    "city": "Jonquiere",
+    "nickname": "Jonquiere",
+    "province": "QC",
+    "address": "2290, boul. Rene-Levesque, Jonquiere, QC, G7S 5Y5",
+    "slug": "jonquiere-qc-0221"
+  },
+  {
+    "store_id": "0268",
+    "label": "Canadian Tire Chicoutimi, QC",
+    "city": "Chicoutimi",
+    "nickname": "Chicoutimi",
+    "province": "QC",
+    "address": "1257, boul. Talbot, Chicoutimi, QC, G7H 4C1",
+    "slug": "chicoutimi-qc-0268"
+  },
+  {
+    "store_id": "0284",
+    "label": "Canadian Tire Dolbeau-Mistassini, QC",
+    "city": "Dolbeau-Mistassini",
+    "nickname": "Dolbeau-Mistassini",
+    "province": "QC",
+    "address": "1751, boul. Vezina, Dolbeau-Mistassini, QC, G8L 3S4",
+    "slug": "dolbeau-mistassini-qc-0284"
+  },
+  {
+    "store_id": "0335",
+    "label": "Canadian Tire La Baie, QC",
+    "city": "La Baie",
+    "nickname": "La Baie",
+    "province": "QC",
+    "address": "2300, rue Bagot, La Baie, QC, G7B 3Z3",
+    "slug": "la-baie-qc-0335"
+  },
+  {
+    "store_id": "0660",
+    "label": "Canadian Tire Peterborough North, ON",
+    "city": "Peterborough North",
+    "nickname": "Peterborough North",
+    "province": "ON",
+    "address": "1050 Chemong Road, Peterborough, ON, K9H 7S2",
+    "slug": "peterborough-north-on-0660"
+  },
+  {
+    "store_id": "0682",
+    "label": "Canadian Tire Minden, ON",
+    "city": "Minden",
+    "nickname": "Minden",
+    "province": "ON",
+    "address": "92 Water Street, Minden, ON, K0M 2K0",
+    "slug": "minden-on-0682"
+  },
+  {
+    "store_id": "0081",
+    "label": "Canadian Tire Peterborough, ON",
+    "city": "Peterborough",
+    "nickname": "Peterborough",
+    "province": "ON",
+    "address": "1200 Lansdowne Street West, Peterborough, ON, K9J 2A1",
+    "slug": "peterborough-on-0081"
+  },
+  {
+    "store_id": "0114",
+    "label": "Canadian Tire Val d'Or, QC",
+    "city": "Val d'Or",
+    "nickname": "Val d'Or",
+    "province": "QC",
+    "address": "1806, 3rd Avenue, Val-d'Or, QC, J9P 7A9",
+    "slug": "val-d-or-qc-0114"
+  },
+  {
+    "store_id": "0023",
+    "label": "Canadian Tire Cobourg, ON",
+    "city": "Cobourg",
+    "nickname": "Cobourg",
+    "province": "ON",
+    "address": "1125 Elgin Street West, Cobourg, ON, K9A 5T9",
+    "slug": "cobourg-on-0023"
+  },
+  {
+    "store_id": "0038",
+    "label": "Canadian Tire Fenelon Falls, ON",
+    "city": "Fenelon Falls",
+    "nickname": "Fenelon Falls",
+    "province": "ON",
+    "address": "160 Lindsay Street, PO Box 208, Fenelon Falls, ON, K0M 1N0",
+    "slug": "fenelon-falls-on-0038"
+  },
+  {
+    "store_id": "0056",
+    "label": "Canadian Tire Lindsay, ON",
+    "city": "Lindsay",
+    "nickname": "Lindsay",
+    "province": "ON",
+    "address": "377 Kent Street West, Lindsay, ON, K9V 2Z7",
+    "slug": "lindsay-on-0056"
+  },
+  {
+    "store_id": "0323",
+    "label": "Canadian Tire Riviere du Loup, QC",
+    "city": "Riviere du Loup",
+    "nickname": "Riviere du Loup",
+    "province": "QC",
+    "address": "237, boul. de l'Hotel de Ville, Riviere-du-Loup, QC, G5R 4E5",
+    "slug": "riviere-du-loup-qc-0323"
+  },
+  {
+    "store_id": "0047",
+    "label": "Canadian Tire Huntsville, ON",
+    "city": "Huntsville",
+    "nickname": "Huntsville",
+    "province": "ON",
+    "address": "77 King William Street, Huntsville, ON, P1H 1E5",
+    "slug": "huntsville-on-0047"
+  },
+  {
+    "store_id": "0206",
+    "label": "Canadian Tire Bracebridge, ON",
+    "city": "Bracebridge",
+    "nickname": "Bracebridge",
+    "province": "ON",
+    "address": "450 Muskoka Road, Bracebridge, ON, P1L 1V4",
+    "slug": "bracebridge-on-0206"
+  },
+  {
+    "store_id": "0072",
+    "label": "Canadian Tire North Bay, ON",
+    "city": "North Bay",
+    "nickname": "North Bay",
+    "province": "ON",
+    "address": "890 McNeown Avenue, North Bay, ON, P1B 8M1",
+    "slug": "north-bay-on-0072"
+  },
+  {
+    "store_id": "0170",
+    "label": "Canadian Tire Bowmanville, ON",
+    "city": "Bowmanville",
+    "nickname": "Bowmanville",
+    "province": "ON",
+    "address": "2000 Green Road, Bowmanville, ON, L1C 0K5",
+    "slug": "bowmanville-on-0170"
+  },
+  {
+    "store_id": "0062",
+    "label": "Canadian Tire Gravenhurst, ON",
+    "city": "Gravenhurst",
+    "nickname": "Gravenhurst",
+    "province": "ON",
+    "address": "431 Talisman Drive, Gravenhurst, ON, P1P 0A7",
+    "slug": "gravenhurst-on-0062"
+  },
+  {
+    "store_id": "0226",
+    "label": "Canadian Tire Port Perry, ON",
+    "city": "Port Perry",
+    "nickname": "Port Perry",
+    "province": "ON",
+    "address": "14325 Simcoe Street, Port Perry, ON, L9L 2C8",
+    "slug": "port-perry-on-0226"
+  },
+  {
+    "store_id": "0336",
+    "label": "Canadian Tire Oshawa North, ON",
+    "city": "Oshawa North",
+    "nickname": "Oshawa North",
+    "province": "ON",
+    "address": "1333 Wilson Road North, Oshawa, ON, L1K 2B8",
+    "slug": "oshawa-north-on-0336"
+  },
+  {
+    "store_id": "0285",
+    "label": "Canadian Tire Amos, QC",
+    "city": "Amos",
+    "nickname": "Amos",
+    "province": "QC",
+    "address": "281 Route 111 Est, Amos, QC, J9T 3A2",
+    "slug": "amos-qc-0285"
+  },
+  {
+    "store_id": "0075",
+    "label": "Canadian Tire Oshawa Mid, ON",
+    "city": "Oshawa Mid",
+    "nickname": "Oshawa Mid",
+    "province": "ON",
+    "address": "441 Gibb Street, Oshawa, ON, L1J 1Z4",
+    "slug": "oshawa-mid-on-0075"
+  },
+  {
+    "store_id": "0460",
+    "label": "Canadian Tire Whitby North, ON",
+    "city": "Whitby North",
+    "nickname": "Whitby North",
+    "province": "ON",
+    "address": "4100 Garden Street at Taunton Road, Whitby, ON, L1R 3K5",
+    "slug": "whitby-north-on-0460"
+  },
+  {
+    "store_id": "0187",
+    "label": "Canadian Tire Whitby South, ON",
+    "city": "Whitby South",
+    "nickname": "Whitby South",
+    "province": "ON",
+    "address": "155 Consumers Drive, Whitby, ON, L1N 1C4",
+    "slug": "whitby-south-on-0187"
+  },
+  {
+    "store_id": "0074",
+    "label": "Canadian Tire Orillia, ON",
+    "city": "Orillia",
+    "nickname": "Orillia",
+    "province": "ON",
+    "address": "1029 Brodie Drive, Orillia, ON, L3V 0V2",
+    "slug": "orillia-on-0074"
+  },
+  {
+    "store_id": "0127",
+    "label": "Canadian Tire Uxbridge, ON",
+    "city": "Uxbridge",
+    "nickname": "Uxbridge",
+    "province": "ON",
+    "address": "327 Toronto Street South, Uxbridge, ON, L9P 1Z7",
+    "slug": "uxbridge-on-0127"
+  },
+  {
+    "store_id": "0160",
+    "label": "Canadian Tire Ajax, ON",
+    "city": "Ajax",
+    "nickname": "Ajax",
+    "province": "ON",
+    "address": "250 Kingston Road East, Ajax, ON, L1Z 1C1",
+    "slug": "ajax-on-0160"
+  },
+  {
+    "store_id": "0324",
+    "label": "Canadian Tire Pickering, ON",
+    "city": "Pickering",
+    "nickname": "Pickering",
+    "province": "ON",
+    "address": "1735 Pickering Parkway, Pickering, ON, L1V 7C7",
+    "slug": "pickering-on-0324"
+  },
+  {
+    "store_id": "0102",
+    "label": "Canadian Tire Sturgeon Falls, ON",
+    "city": "Sturgeon Falls",
+    "nickname": "Sturgeon Falls",
+    "province": "ON",
+    "address": "12011 Hwy 17 East, Sturgeon Falls, ON, P2B 2S7",
+    "slug": "sturgeon-falls-on-0102"
+  },
+  {
+    "store_id": "0134",
+    "label": "Canadian Tire Keswick, ON",
+    "city": "Keswick",
+    "nickname": "Keswick",
+    "province": "ON",
+    "address": "24270 Woodbine Avenue, Keswick, ON, L4P 0L3",
+    "slug": "keswick-on-0134"
+  },
+  {
+    "store_id": "0427",
+    "label": "Canadian Tire Scarborough East, ON",
+    "city": "Scarborough East",
+    "nickname": "Scarborough East",
+    "province": "ON",
+    "address": "111 Rylander Blvd., Scarborough, ON, M1B 4X3",
+    "slug": "scarborough-east-on-0427"
+  },
+  {
+    "store_id": "0280",
+    "label": "Canadian Tire Stouffville, ON",
+    "city": "Stouffville",
+    "nickname": "Stouffville",
+    "province": "ON",
+    "address": "1090 Hoover Park Drive, Stouffville, ON, L4A 0K2",
+    "slug": "stouffville-on-0280"
+  },
+  {
+    "store_id": "0399",
+    "label": "Canadian Tire Markham East, ON",
+    "city": "Markham East",
+    "nickname": "Markham East",
+    "province": "ON",
+    "address": "7650 Markham Road, Markham, ON, L3S 4S1",
+    "slug": "markham-east-on-0399"
+  },
+  {
+    "store_id": "0687",
+    "label": "Canadian Tire Innisfil, ON",
+    "city": "Innisfil",
+    "nickname": "Innisfil",
+    "province": "ON",
+    "address": "1455 Innisfil Beach Road, Innisfil, ON, L9S 4B2",
+    "slug": "innisfil-on-0687"
+  },
+  {
+    "store_id": "0089",
+    "label": "Canadian Tire Rouyn, QC",
+    "city": "Rouyn",
+    "nickname": "Rouyn",
+    "province": "QC",
+    "address": "245, boul. Rideau, Rouyn-Noranda, QC, J9X 5Y6",
+    "slug": "rouyn-qc-0089"
+  },
+  {
+    "store_id": "0093",
+    "label": "Canadian Tire Edmundston, NB",
+    "city": "Edmundston",
+    "nickname": "Edmundston",
+    "province": "NB",
+    "address": "590 Victoria Street, Edmundston, NB, E3V 3N1",
+    "slug": "edmundston-nb-0093"
+  },
+  {
+    "store_id": "0078",
+    "label": "Canadian Tire Parry Sound, ON",
+    "city": "Parry Sound",
+    "nickname": "Parry Sound",
+    "province": "ON",
+    "address": "30 Pine Drive, Parry Sound, ON, P2A 3B8",
+    "slug": "parry-sound-on-0078"
+  },
+  {
+    "store_id": "0175",
+    "label": "Canadian Tire Scarborough, ON",
+    "city": "Scarborough",
+    "nickname": "Scarborough",
+    "province": "ON",
+    "address": "3553 Lawrence Avenue East, Scarborough, ON, M1H 1B2",
+    "slug": "scarborough-on-0175"
+  },
+  {
+    "store_id": "0264",
+    "label": "Canadian Tire Agincourt, ON",
+    "city": "Agincourt",
+    "nickname": "Agincourt",
+    "province": "ON",
+    "address": "4630 Sheppard Avenue East, Scarborough, ON, M1S 3V5",
+    "slug": "agincourt-on-0264"
+  },
+  {
+    "store_id": "0189",
+    "label": "Canadian Tire Aurora, ON",
+    "city": "Aurora",
+    "nickname": "Aurora",
+    "province": "ON",
+    "address": "15400 Bayview Avenue, Aurora, ON, L4G 7J1",
+    "slug": "aurora-on-0189"
+  },
+  {
+    "store_id": "0069",
+    "label": "Canadian Tire Newmarket, ON",
+    "city": "Newmarket",
+    "nickname": "Newmarket",
+    "province": "ON",
+    "address": "17750 Yonge Street, Newmarket, ON, L3Y 8P4",
+    "slug": "newmarket-on-0069"
+  },
+  {
+    "store_id": "0068",
+    "label": "Canadian Tire New Liskeard, ON",
+    "city": "New Liskeard",
+    "nickname": "New Liskeard",
+    "province": "ON",
+    "address": "997431 Hwy 11 North, New Liskeard, ON, P0J 1P0",
+    "slug": "new-liskeard-on-0068"
+  },
+  {
+    "store_id": "0006",
+    "label": "Canadian Tire Barrie, ON",
+    "city": "Barrie",
+    "nickname": "Barrie",
+    "province": "ON",
+    "address": "320 Bayfield Street, Barrie, ON, L4M 3C1",
+    "slug": "barrie-on-0006"
+  },
+  {
+    "store_id": "0209",
+    "label": "Canadian Tire Kingston Rd, ON",
+    "city": "Kingston Rd",
+    "nickname": "Kingston Rd",
+    "province": "ON",
+    "address": "2850 Kingston Road, Scarborough, ON, M1M 1M7",
+    "slug": "kingston-rd-on-0209"
+  },
+  {
+    "store_id": "0164",
+    "label": "Canadian Tire Markham, ON",
+    "city": "Markham",
+    "nickname": "Markham",
+    "province": "ON",
+    "address": "2900 Major Mackenzie Drive East, Markham, ON, L6C 0G6",
+    "slug": "markham-on-0164"
+  },
+  {
+    "store_id": "0444",
+    "label": "Canadian Tire Barrie South, ON",
+    "city": "Barrie South",
+    "nickname": "Barrie South",
+    "province": "ON",
+    "address": "75 Mapleview Drive West, Barrie, ON, L4N 9H7",
+    "slug": "barrie-south-on-0444"
+  },
+  {
+    "store_id": "0030",
+    "label": "Canadian Tire Warden & Eglinton, ON",
+    "city": "Warden & Eglinton",
+    "nickname": "Warden & Eglinton",
+    "province": "ON",
+    "address": "1901 Eglinton Avenue East, Scarborough, ON, M1L 2L8",
+    "slug": "warden-eglinton-on-0030"
+  },
+  {
+    "store_id": "0061",
+    "label": "Canadian Tire Midland, ON",
+    "city": "Midland",
+    "nickname": "Midland",
+    "province": "ON",
+    "address": "9303 County Road 93, Hugel Avenue, Midland, ON, L4R 4K4",
+    "slug": "midland-on-0061"
+  },
+  {
+    "store_id": "0446",
+    "label": "Canadian Tire Bradford, ON",
+    "city": "Bradford",
+    "nickname": "Bradford",
+    "province": "ON",
+    "address": "430 Holland Street West, Bradford, ON, L3Z 0G1",
+    "slug": "bradford-on-0446"
+  },
+  {
+    "store_id": "0697",
+    "label": "Canadian Tire Richmond Hill North, ON",
+    "city": "Richmond Hill North",
+    "nickname": "Richmond Hill North",
+    "province": "ON",
+    "address": "11720 Yonge Street, Richmond Hill, ON, L4E 0K4",
+    "slug": "richmond-hill-north-on-0697"
+  },
+  {
+    "store_id": "0087",
+    "label": "Canadian Tire Richmond Hill, ON",
+    "city": "Richmond Hill",
+    "nickname": "Richmond Hill",
+    "province": "ON",
+    "address": "250 Silver Linden Drive, Richmond Hill, ON, L4B 4W7",
+    "slug": "richmond-hill-on-0087"
+  },
+  {
+    "store_id": "0273",
+    "label": "Canadian Tire Toronto Main & Danforth, ON",
+    "city": "Toronto Main & Danforth",
+    "nickname": "Toronto Main & Danforth",
+    "province": "ON",
+    "address": "2681 Danforth Avenue, Toronto, ON, M4C 1L4",
+    "slug": "toronto-main-danforth-on-0273"
+  },
+  {
+    "store_id": "0192",
+    "label": "Canadian Tire Sheppard Ave., ON",
+    "city": "Sheppard Ave.",
+    "nickname": "Sheppard Ave.",
+    "province": "ON",
+    "address": "1019 Sheppard Avenue East, Toronto, ON, M2K 1C2",
+    "slug": "sheppard-ave-on-0192"
+  },
+  {
+    "store_id": "0126",
+    "label": "Canadian Tire Yonge & Steeles, ON",
+    "city": "Yonge & Steeles",
+    "nickname": "Yonge & Steeles",
+    "province": "ON",
+    "address": "6310 Yonge Street, Toronto, ON, M2M 3X4",
+    "slug": "yonge-steeles-on-0126"
+  },
+  {
+    "store_id": "0459",
+    "label": "Canadian Tire Eglinton & Laird, ON",
+    "city": "Eglinton & Laird",
+    "nickname": "Eglinton & Laird",
+    "province": "ON",
+    "address": "825 Eglinton Avenue East, Toronto, ON, M4G 4G9",
+    "slug": "eglinton-laird-on-0459"
+  },
+  {
+    "store_id": "0654",
+    "label": "Canadian Tire Leslie & Lake Shore, ON",
+    "city": "Leslie & Lake Shore",
+    "nickname": "Leslie & Lake Shore",
+    "province": "ON",
+    "address": "1025 Lake Shore Blvd. East, Toronto, ON, M4M 1B4",
+    "slug": "leslie-lake-shore-on-0654"
+  },
+  {
+    "store_id": "0321",
+    "label": "Canadian Tire Dufferin & 407, ON",
+    "city": "Dufferin & 407",
+    "nickname": "Dufferin & 407",
+    "province": "ON",
+    "address": "8081 Dufferin Street, Thornhill, ON, L4J 8R9",
+    "slug": "dufferin-407-on-0321"
+  },
+  {
+    "store_id": "0150",
+    "label": "Canadian Tire Toronto, Yonge & Church, ON",
+    "city": "Toronto, Yonge & Church",
+    "nickname": "Toronto, Yonge & Church",
+    "province": "ON",
+    "address": "839 Yonge Street, Toronto, ON, M4W 2H2",
+    "slug": "toronto-yonge-church-on-0150"
+  },
+  {
+    "store_id": "0485",
+    "label": "Canadian Tire Dufferin & Finch Auto Ctr, ON",
+    "city": "Dufferin & Finch Auto Ctr",
+    "nickname": "Dufferin & Finch Auto Ctr",
+    "province": "ON",
+    "address": "4400 Dufferin Street, North York, ON, M3H 6A8",
+    "slug": "dufferin-finch-auto-ctr-on-0485"
+  },
+  {
+    "store_id": "0600",
+    "label": "Canadian Tire Toronto Eaton Centre, ON",
+    "city": "Toronto Eaton Centre",
+    "nickname": "Toronto Eaton Centre",
+    "province": "ON",
+    "address": "65 Dundas Street West, Toronto, ON, M5G 2C3",
+    "slug": "toronto-eaton-centre-on-0600"
+  },
+  {
+    "store_id": "0019",
+    "label": "Canadian Tire Lawrence & Allen Expwy, ON",
+    "city": "Lawrence & Allen Expwy",
+    "nickname": "Lawrence & Allen Expwy",
+    "province": "ON",
+    "address": "700 Lawrence Avenue West, Toronto, ON, M6A 3B4",
+    "slug": "lawrence-allen-expwy-on-0019"
+  },
+  {
+    "store_id": "0653",
+    "label": "Canadian Tire Maple, ON",
+    "city": "Maple",
+    "nickname": "Maple",
+    "province": "ON",
+    "address": "3200 Rutherford Road, Vaughan, ON, L4K 5R3",
+    "slug": "maple-on-0653"
+  },
+  {
+    "store_id": "0621",
+    "label": "Canadian Tire Liberty Village, ON",
+    "city": "Liberty Village",
+    "nickname": "Liberty Village",
+    "province": "ON",
+    "address": "5 Joe Shuster Way, Toronto, ON, M6K 0C7",
+    "slug": "liberty-village-on-0621"
+  },
+  {
+    "store_id": "0214",
+    "label": "Canadian Tire Eglinton & Caledonia, Toronto, ON",
+    "city": "Eglinton & Caledonia, Toronto",
+    "nickname": "Eglinton & Caledonia, Toronto",
+    "province": "ON",
+    "address": "2360 Eglinton Avenue West, Toronto, ON, M6M 1S6",
+    "slug": "eglinton-caledonia-toronto-on-0214"
+  },
+  {
+    "store_id": "0237",
+    "label": "Canadian Tire Woodbridge, ON",
+    "city": "Woodbridge",
+    "nickname": "Woodbridge",
+    "province": "ON",
+    "address": "3850 Highway 7, Woodbridge, ON, L4L 9C3",
+    "slug": "woodbridge-on-0237"
+  },
+  {
+    "store_id": "0182",
+    "label": "Canadian Tire West Toronto (Stockyards), ON",
+    "city": "West Toronto (Stockyards)",
+    "nickname": "West Toronto (Stockyards)",
+    "province": "ON",
+    "address": "2129 St. Clair Avenue West, Toronto, ON, M6N 5B4",
+    "slug": "west-toronto-stockyards-on-0182"
+  },
+  {
+    "store_id": "0119",
+    "label": "Canadian Tire Weston Road & 401, ON",
+    "city": "Weston Road & 401",
+    "nickname": "Weston Road & 401",
+    "province": "ON",
+    "address": "2625B Weston Road, North York, ON, M9N 3W1",
+    "slug": "weston-road-401-on-0119"
+  },
+  {
+    "store_id": "0294",
+    "label": "Canadian Tire Etobicoke, Albion & Kipling, ON",
+    "city": "Etobicoke, Albion & Kipling",
+    "nickname": "Etobicoke, Albion & Kipling",
+    "province": "ON",
+    "address": "1530 Albion Road, Etobicoke, ON, M9V 1B4",
+    "slug": "etobicoke-albion-kipling-on-0294"
+  },
+  {
+    "store_id": "0242",
+    "label": "Canadian Tire Rexdale, ON",
+    "city": "Rexdale",
+    "nickname": "Rexdale",
+    "province": "ON",
+    "address": "2025 Kipling Avenue, Etobicoke, ON, M9W 4J8",
+    "slug": "rexdale-on-0242"
+  },
+  {
+    "store_id": "0001",
+    "label": "Canadian Tire Alliston, ON",
+    "city": "Alliston",
+    "nickname": "Alliston",
+    "province": "ON",
+    "address": "110 Young Street, Alliston, ON, L9R 1P8",
+    "slug": "alliston-on-0001"
+  },
+  {
+    "store_id": "0137",
+    "label": "Canadian Tire Woodstock, NB",
+    "city": "Woodstock",
+    "nickname": "Woodstock",
+    "province": "NB",
+    "address": "388 Connell Street, Woodstock, NB, E7M 5G9",
+    "slug": "woodstock-nb-0137"
+  },
+  {
+    "store_id": "0652",
+    "label": "Canadian Tire Wasaga Beach, ON",
+    "city": "Wasaga Beach",
+    "nickname": "Wasaga Beach",
+    "province": "ON",
+    "address": "75 - 45th Street South, Wasaga Beach, ON, L9Z 1A7",
+    "slug": "wasaga-beach-on-0652"
+  },
+  {
+    "store_id": "0197",
+    "label": "Canadian Tire Bolton, ON",
+    "city": "Bolton",
+    "nickname": "Bolton",
+    "province": "ON",
+    "address": "99 McEwan Drive East, Bolton, ON, L7E 2Z7",
+    "slug": "bolton-on-0197"
+  },
+  {
+    "store_id": "0219",
+    "label": "Canadian Tire Grand Falls, NB",
+    "city": "Grand Falls",
+    "nickname": "Grand Falls",
+    "province": "NB",
+    "address": "383, chemin Madawaska, Grand Falls, NB, E3Y 1A4",
+    "slug": "grand-falls-nb-0219"
+  },
+  {
+    "store_id": "0070",
+    "label": "Canadian Tire The Queensway, ON",
+    "city": "The Queensway",
+    "nickname": "The Queensway",
+    "province": "ON",
+    "address": "1608 The Queensway, Etobicoke, ON, M8Z 1V1",
+    "slug": "the-queensway-on-0070"
+  },
+  {
+    "store_id": "0152",
+    "label": "Canadian Tire Miss. Dixie & Dundas, ON",
+    "city": "Miss. Dixie & Dundas",
+    "nickname": "Miss. Dixie & Dundas",
+    "province": "ON",
+    "address": "1156 Dundas Street East, Mississauga, ON, L4Y 2C1",
+    "slug": "miss-dixie-dundas-on-0152"
+  },
+  {
+    "store_id": "0305",
+    "label": "Canadian Tire Brampton Bramalea, ON",
+    "city": "Brampton Bramalea",
+    "nickname": "Brampton Bramalea",
+    "province": "ON",
+    "address": "2850 Queen Street East, Brampton, ON, L6S 6E8",
+    "slug": "brampton-bramalea-on-0305"
+  },
+  {
+    "store_id": "0071",
+    "label": "Canadian Tire Niagara Falls North, ON",
+    "city": "Niagara Falls North",
+    "nickname": "Niagara Falls North",
+    "province": "ON",
+    "address": "7190 Morrison Street, Niagara Falls, ON, L2E 7K5",
+    "slug": "niagara-falls-north-on-0071"
+  },
+  {
+    "store_id": "0162",
+    "label": "Canadian Tire St. Catharines N., ON",
+    "city": "St. Catharines N.",
+    "nickname": "St. Catharines N.",
+    "province": "ON",
+    "address": "459 Welland Avenue, St. Catharines, ON, L2M 5V2",
+    "slug": "st-catharines-n-on-0162"
+  },
+  {
+    "store_id": "0033",
+    "label": "Canadian Tire Fort Erie, ON",
+    "city": "Fort Erie",
+    "nickname": "Fort Erie",
+    "province": "ON",
+    "address": "240 Garrison Road, Fort Erie, ON, L2A 1R9",
+    "slug": "fort-erie-on-0033"
+  },
+  {
+    "store_id": "0145",
+    "label": "Canadian Tire St. Catharines S., ON",
+    "city": "St. Catharines S.",
+    "nickname": "St. Catharines S.",
+    "province": "ON",
+    "address": "300 Glendale Avenue, St. Catharines, ON, L2T 2L5",
+    "slug": "st-catharines-s-on-0145"
+  },
+  {
+    "store_id": "0108",
+    "label": "Canadian Tire Collingwood, ON",
+    "city": "Collingwood",
+    "nickname": "Collingwood",
+    "province": "ON",
+    "address": "89 Balsam Street, Collingwood, ON, L9Y 3Y6",
+    "slug": "collingwood-on-0108"
+  },
+  {
+    "store_id": "0411",
+    "label": "Canadian Tire Brampton Trinity Common, ON",
+    "city": "Brampton Trinity Common",
+    "nickname": "Brampton Trinity Common",
+    "province": "ON",
+    "address": "10 Great Lakes Drive, Brampton, ON, L6R 2K7",
+    "slug": "brampton-trinity-common-on-0411"
+  },
+  {
+    "store_id": "0346",
+    "label": "Canadian Tire Miss.Mavis & Dundas, ON",
+    "city": "Miss.Mavis & Dundas",
+    "nickname": "Miss.Mavis & Dundas",
+    "province": "ON",
+    "address": "3050 Mavis Road at Dundas, Mississauga, ON, L5C 1T8",
+    "slug": "miss-mavis-dundas-on-0346"
+  },
+  {
+    "store_id": "0090",
+    "label": "Canadian Tire St. Catharines, ON",
+    "city": "St. Catharines",
+    "nickname": "St. Catharines",
+    "province": "ON",
+    "address": "431 Louth Street, St. Catharines, ON, L2S 4A2",
+    "slug": "st-catharines-on-0090"
+  },
+  {
+    "store_id": "0010",
+    "label": "Canadian Tire Brampton Shoppers World, ON",
+    "city": "Brampton Shoppers World",
+    "nickname": "Brampton Shoppers World",
+    "province": "ON",
+    "address": "499 Main Street South, Brampton, ON, L6Y 1N7",
+    "slug": "brampton-shoppers-world-on-0010"
+  },
+  {
+    "store_id": "0320",
+    "label": "Canadian Tire Rimouski, QC",
+    "city": "Rimouski",
+    "nickname": "Rimouski",
+    "province": "QC",
+    "address": "419, boul. Jessop, Local 1, Rimouski, QC, G5L 7Y5",
+    "slug": "rimouski-qc-0320"
+  },
+  {
+    "store_id": "0497",
+    "label": "Canadian Tire Mississauga Heartland, ON",
+    "city": "Mississauga Heartland",
+    "nickname": "Mississauga Heartland",
+    "province": "ON",
+    "address": "5970 Mavis Road, Mississauga, ON, L5V 2P5",
+    "slug": "mississauga-heartland-on-0497"
+  },
+  {
+    "store_id": "0241",
+    "label": "Canadian Tire Mississauga Southdown, ON",
+    "city": "Mississauga Southdown",
+    "nickname": "Mississauga Southdown",
+    "province": "ON",
+    "address": "900 Southdown Road, Mississauga, ON, L5J 2Y4",
+    "slug": "mississauga-southdown-on-0241"
+  },
+  {
+    "store_id": "0675",
+    "label": "Canadian Tire Brampton McLaughlin Road, ON",
+    "city": "Brampton McLaughlin Road",
+    "nickname": "Brampton McLaughlin Road",
+    "province": "ON",
+    "address": "10031 McLaughlin Road, Brampton, ON, L7A 2X5",
+    "slug": "brampton-mclaughlin-road-on-0675"
+  },
+  {
+    "store_id": "0233",
+    "label": "Canadian Tire La Sarre, QC",
+    "city": "La Sarre",
+    "nickname": "La Sarre",
+    "province": "QC",
+    "address": "91, 2ieme rue Est, La Sarre, QC, J9Z 3J9",
+    "slug": "la-sarre-qc-0233"
+  },
+  {
+    "store_id": "0424",
+    "label": "Canadian Tire Oak., Winston Churchill, ON",
+    "city": "Oak., Winston Churchill",
+    "nickname": "Oak., Winston Churchill",
+    "province": "ON",
+    "address": "2510 Hyde Park Gate, Oakville, ON, L6H 6M2",
+    "slug": "oak-winston-churchill-on-0424"
+  },
+  {
+    "store_id": "0169",
+    "label": "Canadian Tire Meadowvale, ON",
+    "city": "Meadowvale",
+    "nickname": "Meadowvale",
+    "province": "ON",
+    "address": "6670 Meadowvale Town Centre Circle, Mississauga, ON, L5N 4B7",
+    "slug": "meadowvale-on-0169"
+  },
+  {
+    "store_id": "0118",
+    "label": "Canadian Tire Welland, ON",
+    "city": "Welland",
+    "nickname": "Welland",
+    "province": "ON",
+    "address": "158 Primeway Drive, Welland, ON, L3B 0A1",
+    "slug": "welland-on-0118"
+  },
+  {
+    "store_id": "0429",
+    "label": "Canadian Tire Oakville North, ON",
+    "city": "Oakville North",
+    "nickname": "Oakville North",
+    "province": "ON",
+    "address": "400 Dundas Street East, Oakville, ON, L6H 6Z9",
+    "slug": "oakville-north-on-0429"
+  },
+  {
+    "store_id": "0143",
+    "label": "Canadian Tire Oakville, ON",
+    "city": "Oakville",
+    "nickname": "Oakville",
+    "province": "ON",
+    "address": "1100 Kerr Street, Oakville, ON, L6M 0L4",
+    "slug": "oakville-on-0143"
+  },
+  {
+    "store_id": "0159",
+    "label": "Canadian Tire Georgetown, ON",
+    "city": "Georgetown",
+    "nickname": "Georgetown",
+    "province": "ON",
+    "address": "315 Guelph Street, Georgetown, ON, L7G 4B3",
+    "slug": "georgetown-on-0159"
+  },
+  {
+    "store_id": "0073",
+    "label": "Canadian Tire Orangeville, ON",
+    "city": "Orangeville",
+    "nickname": "Orangeville",
+    "province": "ON",
+    "address": "99 First Street, Orangeville, ON, L9W 2E8",
+    "slug": "orangeville-on-0073"
+  },
+  {
+    "store_id": "0052",
+    "label": "Canadian Tire Kirkland Lake, ON",
+    "city": "Kirkland Lake",
+    "nickname": "Kirkland Lake",
+    "province": "ON",
+    "address": "146 Government Road West, Kirkland Lake, ON, P2N 2E9",
+    "slug": "kirkland-lake-on-0052"
+  },
+  {
+    "store_id": "0140",
+    "label": "Canadian Tire Milton, ON",
+    "city": "Milton",
+    "nickname": "Milton",
+    "province": "ON",
+    "address": "1210 Steeles Avenue East, Milton, ON, L9T 6R1",
+    "slug": "milton-on-0140"
+  },
+  {
+    "store_id": "0040",
+    "label": "Canadian Tire Grimsby, ON",
+    "city": "Grimsby",
+    "nickname": "Grimsby",
+    "province": "ON",
+    "address": "44 Livingston Avenue, Grimsby, ON, L3M 1L1",
+    "slug": "grimsby-on-0040"
+  },
+  {
+    "store_id": "0128",
+    "label": "Canadian Tire Port Colborne, ON",
+    "city": "Port Colborne",
+    "nickname": "Port Colborne",
+    "province": "ON",
+    "address": "287 West Side Road, Port Colborne, ON, L3K 5L2",
+    "slug": "port-colborne-on-0128"
+  },
+  {
+    "store_id": "0232",
+    "label": "Canadian Tire St. Stephen, NB",
+    "city": "St. Stephen",
+    "nickname": "St. Stephen",
+    "province": "NB",
+    "address": "250 King Street, St. Stephen, NB, E3L 2E5",
+    "slug": "st-stephen-nb-0232"
+  },
+  {
+    "store_id": "0412",
+    "label": "Canadian Tire Burlington North, ON",
+    "city": "Burlington North",
+    "nickname": "Burlington North",
+    "province": "ON",
+    "address": "2070 Appleby Line, Unit J, Burlington, ON, L7L 6M6",
+    "slug": "burlington-north-on-0412"
+  },
+  {
+    "store_id": "0122",
+    "label": "Canadian Tire Burlington Fairview, ON",
+    "city": "Burlington Fairview",
+    "nickname": "Burlington Fairview",
+    "province": "ON",
+    "address": "777 Guelph Line, Burlington, ON, L7R 3N2",
+    "slug": "burlington-fairview-on-0122"
+  },
+  {
+    "store_id": "0154",
+    "label": "Canadian Tire Hamilton East, ON",
+    "city": "Hamilton East",
+    "nickname": "Hamilton East",
+    "province": "ON",
+    "address": "686 Queenston Road, Hamilton, ON, L8G 1A3",
+    "slug": "hamilton-east-on-0154"
+  },
+  {
+    "store_id": "0278",
+    "label": "Canadian Tire Sudbury North, ON",
+    "city": "Sudbury North",
+    "nickname": "Sudbury North",
+    "province": "ON",
+    "address": "1485 Lasalle Blvd., Sudbury, ON, P3A 5M9",
+    "slug": "sudbury-north-on-0278"
+  },
+  {
+    "store_id": "0129",
+    "label": "Canadian Tire Hamilton Centre, ON",
+    "city": "Hamilton Centre",
+    "nickname": "Hamilton Centre",
+    "province": "ON",
+    "address": "1283 Barton Street East, Hamilton, ON, L8H 2V4",
+    "slug": "hamilton-centre-on-0129"
+  },
+  {
+    "store_id": "0445",
+    "label": "Canadian Tire Sudbury South, ON",
+    "city": "Sudbury South",
+    "nickname": "Sudbury South",
+    "province": "ON",
+    "address": "2259 Regent Street, Sudbury, ON, P3E 5N9",
+    "slug": "sudbury-south-on-0445"
+  },
+  {
+    "store_id": "0220",
+    "label": "Canadian Tire Waterdown, ON",
+    "city": "Waterdown",
+    "nickname": "Waterdown",
+    "province": "ON",
+    "address": "11 Clappison Avenue, Waterdown, ON, L8B 0Y2",
+    "slug": "waterdown-on-0220"
+  },
+  {
+    "store_id": "0045",
+    "label": "Canadian Tire Hamilton Main, ON",
+    "city": "Hamilton Main",
+    "nickname": "Hamilton Main",
+    "province": "ON",
+    "address": "304 Main Street East, Hamilton, ON, L8N 1H9",
+    "slug": "hamilton-main-on-0045"
+  },
+  {
+    "store_id": "0194",
+    "label": "Canadian Tire Hamilton Mt.East, ON",
+    "city": "Hamilton Mt.East",
+    "nickname": "Hamilton Mt.East",
+    "province": "ON",
+    "address": "2160 Rymal Road East, Hannon, ON, L0R 1P0",
+    "slug": "hamilton-mt-east-on-0194"
+  },
+  {
+    "store_id": "0657",
+    "label": "Canadian Tire Hanmer, ON",
+    "city": "Hanmer",
+    "nickname": "Hanmer",
+    "province": "ON",
+    "address": "5206 Highway 69 North, Hanmer, ON, P3P 1R9",
+    "slug": "hanmer-on-0657"
+  },
+  {
+    "store_id": "0177",
+    "label": "Canadian Tire Hamilton Mt.West, ON",
+    "city": "Hamilton Mt.West",
+    "nickname": "Hamilton Mt.West",
+    "province": "ON",
+    "address": "777 Upper James Street, Hamilton, ON, L9C 3A3",
+    "slug": "hamilton-mt-west-on-0177"
+  },
+  {
+    "store_id": "0027",
+    "label": "Canadian Tire Dundas, ON",
+    "city": "Dundas",
+    "nickname": "Dundas",
+    "province": "ON",
+    "address": "119 Osler Drive, Dundas, ON, L9H 6X6",
+    "slug": "dundas-on-0027"
+  },
+  {
+    "store_id": "0029",
+    "label": "Canadian Tire Dunnville, ON",
+    "city": "Dunnville",
+    "nickname": "Dunnville",
+    "province": "ON",
+    "address": "1002 Broad Street East, Dunnville, ON, N1A 2Z2",
+    "slug": "dunnville-on-0029"
+  },
+  {
+    "store_id": "0042",
+    "label": "Canadian Tire Guelph Stone Rd, ON",
+    "city": "Guelph Stone Rd",
+    "nickname": "Guelph Stone Rd",
+    "province": "ON",
+    "address": "127 Stone Road West, Guelph, ON, N1G 5L4",
+    "slug": "guelph-stone-rd-on-0042"
+  },
+  {
+    "store_id": "0031",
+    "label": "Canadian Tire Centre Wellington, ON",
+    "city": "Centre Wellington",
+    "nickname": "Centre Wellington",
+    "province": "ON",
+    "address": "950 Tower Street South, Fergus, ON, N1M 3N7",
+    "slug": "centre-wellington-on-0031"
+  },
+  {
+    "store_id": "0260",
+    "label": "Canadian Tire Guelph North, ON",
+    "city": "Guelph North",
+    "nickname": "Guelph North",
+    "province": "ON",
+    "address": "10 Woodlawn Road East, Guelph, ON, N1H 1G7",
+    "slug": "guelph-north-on-0260"
+  },
+  {
+    "store_id": "0639",
+    "label": "Canadian Tire Ancaster, ON",
+    "city": "Ancaster",
+    "nickname": "Ancaster",
+    "province": "ON",
+    "address": "1060 Wilson Street West, Ancaster, ON, L9G 3K9",
+    "slug": "ancaster-on-0639"
+  },
+  {
+    "store_id": "0077",
+    "label": "Canadian Tire Owen Sound, ON",
+    "city": "Owen Sound",
+    "nickname": "Owen Sound",
+    "province": "ON",
+    "address": "1605 - 16th Street East, Owen Sound, ON, N4K 5N3",
+    "slug": "owen-sound-on-0077"
+  },
+  {
+    "store_id": "0244",
+    "label": "Canadian Tire Chelmsford, ON",
+    "city": "Chelmsford",
+    "nickname": "Chelmsford",
+    "province": "ON",
+    "address": "1 - 3595 Highway 144, Chelmsford, ON, P0M 1L0",
+    "slug": "chelmsford-on-0244"
+  },
+  {
+    "store_id": "0049",
+    "label": "Canadian Tire Caledonia, ON",
+    "city": "Caledonia",
+    "nickname": "Caledonia",
+    "province": "ON",
+    "address": "365 Argyle Street South, Caledonia, ON, N3W 1L0",
+    "slug": "caledonia-on-0049"
+  },
+  {
+    "store_id": "0168",
+    "label": "Canadian Tire Cambridge Hespeler, ON",
+    "city": "Cambridge Hespeler",
+    "nickname": "Cambridge Hespeler",
+    "province": "ON",
+    "address": "65 Pinebush Road, Cambridge, ON, N1R 8J5",
+    "slug": "cambridge-hespeler-on-0168"
+  },
+  {
+    "store_id": "0036",
+    "label": "Canadian Tire Cambridge, ON",
+    "city": "Cambridge",
+    "nickname": "Cambridge",
+    "province": "ON",
+    "address": "75 Dundas Street, Cambridge, ON, N1R 6G5",
+    "slug": "cambridge-on-0036"
+  },
+  {
+    "store_id": "0066",
+    "label": "Canadian Tire Mount Forest, ON",
+    "city": "Mount Forest",
+    "nickname": "Mount Forest",
+    "province": "ON",
+    "address": "101 Mount Forest Drive, Mount Forest, ON, N0G 2L0",
+    "slug": "mount-forest-on-0066"
+  },
+  {
+    "store_id": "0035",
+    "label": "Canadian Tire Fredericton, NB",
+    "city": "Fredericton",
+    "nickname": "Fredericton",
+    "province": "NB",
+    "address": "1110 Smythe Street, Fredericton, NB, E3B 3H6",
+    "slug": "fredericton-nb-0035"
+  },
+  {
+    "store_id": "0337",
+    "label": "Canadian Tire Fredericton North, NB",
+    "city": "Fredericton North",
+    "nickname": "Fredericton North",
+    "province": "NB",
+    "address": "75 Two Nations Crossing, Fredericton, NB, E3A 0T3",
+    "slug": "fredericton-north-nb-0337"
+  },
+  {
+    "store_id": "0139",
+    "label": "Canadian Tire Kitchener East, ON",
+    "city": "Kitchener East",
+    "nickname": "Kitchener East",
+    "province": "ON",
+    "address": "1080 Victoria Street North, Kitchener, ON, N2B 3C4",
+    "slug": "kitchener-east-on-0139"
+  },
+  {
+    "store_id": "0616",
+    "label": "Canadian Tire Elmira, ON",
+    "city": "Elmira",
+    "nickname": "Elmira",
+    "province": "ON",
+    "address": "325 Arthur Street South, Elmira, ON, N3B 3L5",
+    "slug": "elmira-on-0616"
+  },
+  {
+    "store_id": "0053",
+    "label": "Canadian Tire Kitchener South, ON",
+    "city": "Kitchener South",
+    "nickname": "Kitchener South",
+    "province": "ON",
+    "address": "385 Fairway Road South, Kitchener, ON, N2C 2N9",
+    "slug": "kitchener-south-on-0053"
+  },
+  {
+    "store_id": "0265",
+    "label": "Canadian Tire Baie-Comeau, QC",
+    "city": "Baie-Comeau",
+    "nickname": "Baie-Comeau",
+    "province": "QC",
+    "address": "650, rue de Parfondeval, Baie-Comeau, QC, G5C 3R3",
+    "slug": "baie-comeau-qc-0265"
+  },
+  {
+    "store_id": "0664",
+    "label": "Canadian Tire Brantford North, ON",
+    "city": "Brantford North",
+    "nickname": "Brantford North",
+    "province": "ON",
+    "address": "30 Lynden Road, Brantford, ON, N3R 8A4",
+    "slug": "brantford-north-on-0664"
+  },
+  {
+    "store_id": "0251",
+    "label": "Canadian Tire Waterloo, ON",
+    "city": "Waterloo",
+    "nickname": "Waterloo",
+    "province": "ON",
+    "address": "400 Weber Street North, Waterloo, ON, N2J 3J3",
+    "slug": "waterloo-on-0251"
+  },
+  {
+    "store_id": "0420",
+    "label": "Canadian Tire Kitchener West, ON",
+    "city": "Kitchener West",
+    "nickname": "Kitchener West",
+    "province": "ON",
+    "address": "1400 Ottawa Street South, Kitchener, ON, N2E 4E2",
+    "slug": "kitchener-west-on-0420"
+  },
+  {
+    "store_id": "0046",
+    "label": "Canadian Tire Hanover, ON",
+    "city": "Hanover",
+    "nickname": "Hanover",
+    "province": "ON",
+    "address": "896 - 10th Street, Hanover, ON, N4N 3P2",
+    "slug": "hanover-on-0046"
+  },
+  {
+    "store_id": "0674",
+    "label": "Canadian Tire Waterloo West, ON",
+    "city": "Waterloo West",
+    "nickname": "Waterloo West",
+    "province": "ON",
+    "address": "656 Erb Street West, Waterloo, ON, N2T 2Z7",
+    "slug": "waterloo-west-on-0674"
+  },
+  {
+    "store_id": "0043",
+    "label": "Canadian Tire Paris, ON",
+    "city": "Paris",
+    "nickname": "Paris",
+    "province": "ON",
+    "address": "300 Grand River Street North, Paris, ON, N3L 3R7",
+    "slug": "paris-on-0043"
+  },
+  {
+    "store_id": "0309",
+    "label": "Canadian Tire Oromocto, NB",
+    "city": "Oromocto",
+    "nickname": "Oromocto",
+    "province": "NB",
+    "address": "345 Miramichi Road, Oromocto, NB, E2V 4T4",
+    "slug": "oromocto-nb-0309"
+  },
+  {
+    "store_id": "0315",
+    "label": "Canadian Tire Matane, QC",
+    "city": "Matane",
+    "nickname": "Matane",
+    "province": "QC",
+    "address": "145, rue Piuze, Matane, QC, G4W 0H7",
+    "slug": "matane-qc-0315"
+  },
+  {
+    "store_id": "0057",
+    "label": "Canadian Tire Listowel, ON",
+    "city": "Listowel",
+    "nickname": "Listowel",
+    "province": "ON",
+    "address": "500 Mitchell Road South, Listowel, ON, N4W 3G7",
+    "slug": "listowel-on-0057"
+  },
+  {
+    "store_id": "0097",
+    "label": "Canadian Tire Simcoe, ON",
+    "city": "Simcoe",
+    "nickname": "Simcoe",
+    "province": "ON",
+    "address": "142 Queensway East, Simcoe, ON, N3Y 4Y7",
+    "slug": "simcoe-on-0097"
+  },
+  {
+    "store_id": "0269",
+    "label": "Canadian Tire Port Elgin, ON",
+    "city": "Port Elgin",
+    "nickname": "Port Elgin",
+    "province": "ON",
+    "address": "5116 Hwy 21, Port Elgin, ON, N0H 2C0",
+    "slug": "port-elgin-on-0269"
+  },
+  {
+    "store_id": "0022",
+    "label": "Canadian Tire Espanola, ON",
+    "city": "Espanola",
+    "nickname": "Espanola",
+    "province": "ON",
+    "address": "801 Centre Street, Espanola, ON, P5E 1C8",
+    "slug": "espanola-on-0022"
+  },
+  {
+    "store_id": "0016",
+    "label": "Canadian Tire Atholville, NB",
+    "city": "Atholville",
+    "nickname": "Atholville",
+    "province": "NB",
+    "address": "384 Old Val D'Amour Road, Atholville, NB, E3N 4E3",
+    "slug": "atholville-nb-0016"
+  },
+  {
+    "store_id": "0193",
+    "label": "Canadian Tire Delhi, ON",
+    "city": "Delhi",
+    "nickname": "Delhi",
+    "province": "ON",
+    "address": "308 James Street, Delhi, ON, N4B 2B4",
+    "slug": "delhi-on-0193"
+  },
+  {
+    "store_id": "0124",
+    "label": "Canadian Tire Woodstock, ON",
+    "city": "Woodstock",
+    "nickname": "Woodstock",
+    "province": "ON",
+    "address": "465 Norwich Avenue, Woodstock, ON, N4S 9C1",
+    "slug": "woodstock-on-0124"
+  },
+  {
+    "store_id": "0103",
+    "label": "Canadian Tire Stratford, ON",
+    "city": "Stratford",
+    "nickname": "Stratford",
+    "province": "ON",
+    "address": "1093 Ontario Street, Stratford, ON, N5A 6W1",
+    "slug": "stratford-on-0103"
+  },
+  {
+    "store_id": "0349",
+    "label": "Canadian Tire Saint John Fairville, NB",
+    "city": "Saint John Fairville",
+    "nickname": "Saint John Fairville",
+    "province": "NB",
+    "address": "885 Fairville Blvd., Saint John, NB, E2M 5T9",
+    "slug": "saint-john-fairville-nb-0349"
+  },
+  {
+    "store_id": "0254",
+    "label": "Canadian Tire Saint John - Westmorland Road, NB",
+    "city": "Saint John - Westmorland Road",
+    "nickname": "Saint John - Westmorland Road",
+    "province": "NB",
+    "address": "400 Westmorland Road, Saint John, NB, E2J 2G4",
+    "slug": "saint-john-westmorland-road-nb-0254"
+  },
+  {
+    "store_id": "0051",
+    "label": "Canadian Tire Kincardine, ON",
+    "city": "Kincardine",
+    "nickname": "Kincardine",
+    "province": "ON",
+    "address": "811 Durham Street, Kincardine, ON, N2Z 3B8",
+    "slug": "kincardine-on-0051"
+  },
+  {
+    "store_id": "0048",
+    "label": "Canadian Tire Ingersoll, ON",
+    "city": "Ingersoll",
+    "nickname": "Ingersoll",
+    "province": "ON",
+    "address": "98 Mutual Street South, Ingersoll, ON, N5C 1S5",
+    "slug": "ingersoll-on-0048"
+  },
+  {
+    "store_id": "0110",
+    "label": "Canadian Tire Tillsonburg, ON",
+    "city": "Tillsonburg",
+    "nickname": "Tillsonburg",
+    "province": "ON",
+    "address": "248 Broadway Street, Tillsonburg, ON, N4G 3R5",
+    "slug": "tillsonburg-on-0110"
+  },
+  {
+    "store_id": "0476",
+    "label": "Canadian Tire Rothesay, NB",
+    "city": "Rothesay",
+    "nickname": "Rothesay",
+    "province": "NB",
+    "address": "160 Hampton Road, Rothesay, NB, E2E 2R3",
+    "slug": "rothesay-nb-0476"
+  },
+  {
+    "store_id": "0091",
+    "label": "Canadian Tire St. Marys, ON",
+    "city": "St. Marys",
+    "nickname": "St. Marys",
+    "province": "ON",
+    "address": "84 Wellington Street South, St. Marys, ON, N4X 1C5",
+    "slug": "st-marys-on-0091"
+  },
+  {
+    "store_id": "0111",
+    "label": "Canadian Tire Timmins, ON",
+    "city": "Timmins",
+    "nickname": "Timmins",
+    "province": "ON",
+    "address": "2199 Riverside Drive, Timmins, ON, P4R 0A1",
+    "slug": "timmins-on-0111"
+  },
+  {
+    "store_id": "0024",
+    "label": "Canadian Tire Cochrane, ON",
+    "city": "Cochrane",
+    "nickname": "Cochrane",
+    "province": "ON",
+    "address": "201 Highway 11 West, Cochrane, ON, P0L 1C0",
+    "slug": "cochrane-on-0024"
+  },
+  {
+    "store_id": "0039",
+    "label": "Canadian Tire Goderich, ON",
+    "city": "Goderich",
+    "nickname": "Goderich",
+    "province": "ON",
+    "address": "35430 Huron Road, Goderich, ON, N7A 3X8",
+    "slug": "goderich-on-0039"
+  },
+  {
+    "store_id": "0130",
+    "label": "Canadian Tire London East, ON",
+    "city": "London East",
+    "nickname": "London East",
+    "province": "ON",
+    "address": "1975 Dundas Street, London, ON, N5V 1P6",
+    "slug": "london-east-on-0130"
+  },
+  {
+    "store_id": "0142",
+    "label": "Canadian Tire Aylmer, ON",
+    "city": "Aylmer",
+    "nickname": "Aylmer",
+    "province": "ON",
+    "address": "605 John Street North, Aylmer, ON, N5H 2B6",
+    "slug": "aylmer-on-0142"
+  },
+  {
+    "store_id": "0141",
+    "label": "Canadian Tire Exeter, ON",
+    "city": "Exeter",
+    "nickname": "Exeter",
+    "province": "ON",
+    "address": "100 Thames Road East, Exeter, ON, N0M 1S3",
+    "slug": "exeter-on-0141"
+  },
+  {
+    "store_id": "0494",
+    "label": "Canadian Tire London Auto Centre, ON",
+    "city": "London Auto Centre",
+    "nickname": "London Auto Centre",
+    "province": "ON",
+    "address": "378 Horton Street East, London, ON, N6B 1L7",
+    "slug": "london-auto-centre-on-0494"
+  },
+  {
+    "store_id": "0058",
+    "label": "Canadian Tire London South, ON",
+    "city": "London South",
+    "nickname": "London South",
+    "province": "ON",
+    "address": "1125 Wellington Road, London, ON, N6E 1H3",
+    "slug": "london-south-on-0058"
+  },
+  {
+    "store_id": "0106",
+    "label": "Canadian Tire Sussex, NB",
+    "city": "Sussex",
+    "nickname": "Sussex",
+    "province": "NB",
+    "address": "138 Main Street, Sussex, NB, E4E 3E1",
+    "slug": "sussex-nb-0106"
+  },
+  {
+    "store_id": "0025",
+    "label": "Canadian Tire Digby, NS",
+    "city": "Digby",
+    "nickname": "Digby",
+    "province": "NS",
+    "address": "112 Warwick Street, Digby, NS, B0V 1A0",
+    "slug": "digby-ns-0025"
+  },
+  {
+    "store_id": "0425",
+    "label": "Canadian Tire London North, ON",
+    "city": "London North",
+    "nickname": "London North",
+    "province": "ON",
+    "address": "1875 Hyde Park Road, London, ON, N6H 0A3",
+    "slug": "london-north-on-0425"
+  },
+  {
+    "store_id": "0208",
+    "label": "Canadian Tire London West, ON",
+    "city": "London West",
+    "nickname": "London West",
+    "province": "ON",
+    "address": "3100 Wonderland Road South, London, ON, N6L 1A6",
+    "slug": "london-west-on-0208"
+  },
+  {
+    "store_id": "0125",
+    "label": "Canadian Tire Yarmouth, NS",
+    "city": "Yarmouth",
+    "nickname": "Yarmouth",
+    "province": "NS",
+    "address": "120 Starrs Road, Yarmouth, NS, B5A 4T3",
+    "slug": "yarmouth-ns-0125"
+  },
+  {
+    "store_id": "0092",
+    "label": "Canadian Tire St. Thomas, ON",
+    "city": "St. Thomas",
+    "nickname": "St. Thomas",
+    "province": "ON",
+    "address": "1063 Talbot Street, St. Thomas, ON, N5P 1G1",
+    "slug": "st-thomas-on-0092"
+  },
+  {
+    "store_id": "0136",
+    "label": "Canadian Tire Miramichi, NB",
+    "city": "Miramichi",
+    "nickname": "Miramichi",
+    "province": "NB",
+    "address": "2491 King George Highway, Miramichi, NB, E1V 6W3",
+    "slug": "miramichi-nb-0136"
+  },
+  {
+    "store_id": "0011",
+    "label": "Canadian Tire Bathurst, NB",
+    "city": "Bathurst",
+    "nickname": "Bathurst",
+    "province": "NB",
+    "address": "520 St. Peter Avenue, Bathurst, NB, E2A 2Y7",
+    "slug": "bathurst-nb-0011"
+  },
+  {
+    "store_id": "0167",
+    "label": "Canadian Tire Elliot Lake, ON",
+    "city": "Elliot Lake",
+    "nickname": "Elliot Lake",
+    "province": "ON",
+    "address": "50 Hillside Drive South, Elliot Lake, ON, P5A 1L8",
+    "slug": "elliot-lake-on-0167"
+  },
+  {
+    "store_id": "0104",
+    "label": "Canadian Tire Strathroy, ON",
+    "city": "Strathroy",
+    "nickname": "Strathroy",
+    "province": "ON",
+    "address": "24614 Adelaide Road, Strathroy, ON, N7G 2P7",
+    "slug": "strathroy-on-0104"
+  },
+  {
+    "store_id": "0032",
+    "label": "Canadian Tire Forest, ON",
+    "city": "Forest",
+    "nickname": "Forest",
+    "province": "ON",
+    "address": "84 Union Street, Forest, ON, N0N 1J0",
+    "slug": "forest-on-0032"
+  },
+  {
+    "store_id": "0249",
+    "label": "Canadian Tire Moncton Mountain Rd, NB",
+    "city": "Moncton Mountain Rd",
+    "nickname": "Moncton Mountain Rd",
+    "province": "NB",
+    "address": "1380 Mountain Road, Unit 1, Moncton, NB, E1C 2T8",
+    "slug": "moncton-mountain-rd-nb-0249"
+  },
+  {
+    "store_id": "0463",
+    "label": "Canadian Tire Paspebiac, QC",
+    "city": "Paspebiac",
+    "nickname": "Paspebiac",
+    "province": "QC",
+    "address": "49, boul. Gerard-D-Levesque Est, Paspebiac, QC, G0C 2K0",
+    "slug": "paspebiac-qc-0463"
+  },
+  {
+    "store_id": "0691",
+    "label": "Canadian Tire Riverview, NB",
+    "city": "Riverview",
+    "nickname": "Riverview",
+    "province": "NB",
+    "address": "525 Pinewood Road, Riverview, NB, E1B 0L4",
+    "slug": "riverview-nb-0691"
+  },
+  {
+    "store_id": "0261",
+    "label": "Canadian Tire Greenwood, NS",
+    "city": "Greenwood",
+    "nickname": "Greenwood",
+    "province": "NS",
+    "address": "730 Central Avenue, Greenwood, NS, B0P 1N0",
+    "slug": "greenwood-ns-0261"
+  },
+  {
+    "store_id": "0063",
+    "label": "Canadian Tire Moncton Dieppe, NB",
+    "city": "Moncton Dieppe",
+    "nickname": "Moncton Dieppe",
+    "province": "NB",
+    "address": "500 Regis Street, Dieppe, NB, E1A 5V5",
+    "slug": "moncton-dieppe-nb-0063"
+  },
+  {
+    "store_id": "0491",
+    "label": "Canadian Tire Tracadie - Sheila, NB",
+    "city": "Tracadie - Sheila",
+    "nickname": "Tracadie - Sheila",
+    "province": "NB",
+    "address": "450, rue du Moulin, Tracadie-Sheila, NB, E1X 1B5",
+    "slug": "tracadie-sheila-nb-0491"
+  },
+  {
+    "store_id": "0647",
+    "label": "Canadian Tire Shediac, NB",
+    "city": "Shediac",
+    "nickname": "Shediac",
+    "province": "NB",
+    "address": "173 Main Street, Shediac, NB, E4P 2A5",
+    "slug": "shediac-nb-0647"
+  },
+  {
+    "store_id": "0094",
+    "label": "Canadian Tire Sarnia, ON",
+    "city": "Sarnia",
+    "nickname": "Sarnia",
+    "province": "ON",
+    "address": "1380 London Road, Sarnia, ON, N7S 1P8",
+    "slug": "sarnia-on-0094"
+  },
+  {
+    "store_id": "0008",
+    "label": "Canadian Tire Blenheim, ON",
+    "city": "Blenheim",
+    "nickname": "Blenheim",
+    "province": "ON",
+    "address": "20215 Chatham Street North, Blenheim, ON, N0P 1A0",
+    "slug": "blenheim-on-0008"
+  },
+  {
+    "store_id": "0178",
+    "label": "Canadian Tire Kapuskasing, ON",
+    "city": "Kapuskasing",
+    "nickname": "Kapuskasing",
+    "province": "ON",
+    "address": "25 Brunetville Road, Kapuskasing, ON, P5N 2E9",
+    "slug": "kapuskasing-on-0178"
+  },
+  {
+    "store_id": "0307",
+    "label": "Canadian Tire Sept-Iles, QC",
+    "city": "Sept-Iles",
+    "nickname": "Sept-Iles",
+    "province": "QC",
+    "address": "402, boul. Laure, Sept-Iles, QC, G4R 1X5",
+    "slug": "sept-iles-qc-0307"
+  },
+  {
+    "store_id": "0054",
+    "label": "Canadian Tire New Minas, NS",
+    "city": "New Minas",
+    "nickname": "New Minas",
+    "province": "NS",
+    "address": "9212 Commercial Street, New Minas, NS, B4N 3E5",
+    "slug": "new-minas-ns-0054"
+  },
+  {
+    "store_id": "0021",
+    "label": "Canadian Tire Chatham, ON",
+    "city": "Chatham",
+    "nickname": "Chatham",
+    "province": "ON",
+    "address": "575 Grand Avenue West, Chatham, ON, N7L 1C5",
+    "slug": "chatham-on-0021"
+  },
+  {
+    "store_id": "0135",
+    "label": "Canadian Tire Wallaceburg, ON",
+    "city": "Wallaceburg",
+    "nickname": "Wallaceburg",
+    "province": "ON",
+    "address": "74 McNaughton Avenue, Wallaceburg, ON, N8A 1R9",
+    "slug": "wallaceburg-on-0135"
+  },
+  {
+    "store_id": "0013",
+    "label": "Canadian Tire Bridgewater, NS",
+    "city": "Bridgewater",
+    "nickname": "Bridgewater",
+    "province": "NS",
+    "address": "16 Pine Grove Road, RR 2, Unit 1, Cookville, NS, B4V 7P1",
+    "slug": "bridgewater-ns-0013"
+  },
+  {
+    "store_id": "0003",
+    "label": "Canadian Tire Amherst, NS",
+    "city": "Amherst",
+    "nickname": "Amherst",
+    "province": "NS",
+    "address": "152 Albion Street South, Amherst, NS, B4H 4H4",
+    "slug": "amherst-ns-0003"
+  },
+  {
+    "store_id": "0215",
+    "label": "Canadian Tire Tilbury, ON",
+    "city": "Tilbury",
+    "nickname": "Tilbury",
+    "province": "ON",
+    "address": "37 Mill Street East, PO Box 280, Tilbury, ON, N0P 2L0",
+    "slug": "tilbury-on-0215"
+  },
+  {
+    "store_id": "0132",
+    "label": "Canadian Tire Summerside, PE",
+    "city": "Summerside",
+    "nickname": "Summerside",
+    "province": "PE",
+    "address": "474 Granville Street, Summerside, PE, C1N 4K6",
+    "slug": "summerside-pe-0132"
+  },
+  {
+    "store_id": "0456",
+    "label": "Canadian Tire Gaspe, QC",
+    "city": "Gaspe",
+    "nickname": "Gaspe",
+    "province": "QC",
+    "address": "39, Montee de Sandy Beach, Gaspe, QC, G4X 2V5",
+    "slug": "gaspe-qc-0456"
+  },
+  {
+    "store_id": "0095",
+    "label": "Canadian Tire Sault Ste. Marie, ON",
+    "city": "Sault Ste. Marie",
+    "nickname": "Sault Ste. Marie",
+    "province": "ON",
+    "address": "200 McNabb Street, Sault Ste. Marie, ON, P6B 1Y5",
+    "slug": "sault-ste-marie-on-0095"
+  },
+  {
+    "store_id": "0618",
+    "label": "Canadian Tire Tantallon, NS",
+    "city": "Tantallon",
+    "nickname": "Tantallon",
+    "province": "NS",
+    "address": "5130 St. Margarets Bay Road, Upper Tantallon, NS, B3Z 1E6",
+    "slug": "tantallon-ns-0618"
+  },
+  {
+    "store_id": "0055",
+    "label": "Canadian Tire Leamington, ON",
+    "city": "Leamington",
+    "nickname": "Leamington",
+    "province": "ON",
+    "address": "262 Erie Street South, Leamington, ON, N8H 3C5",
+    "slug": "leamington-on-0055"
+  },
+  {
+    "store_id": "0199",
+    "label": "Canadian Tire Windsor East, ON",
+    "city": "Windsor East",
+    "nickname": "Windsor East",
+    "province": "ON",
+    "address": "8505 Tecumseh Road East, Windsor, ON, N8R 1A1",
+    "slug": "windsor-east-on-0199"
+  },
+  {
+    "store_id": "0172",
+    "label": "Canadian Tire Essex, ON",
+    "city": "Essex",
+    "nickname": "Essex",
+    "province": "ON",
+    "address": "300 Maidstone Avenue West, Essex, ON, N8M 3C3",
+    "slug": "essex-on-0172"
+  },
+  {
+    "store_id": "0289",
+    "label": "Canadian Tire Halifax - Lwr. Sackville, NS",
+    "city": "Halifax - Lwr. Sackville",
+    "nickname": "Halifax - Lwr. Sackville",
+    "province": "NS",
+    "address": "796 Sackville Drive, Lower Sackville, NS, B4E 1R7",
+    "slug": "halifax-lwr-sackville-ns-0289"
+  },
+  {
+    "store_id": "0236",
+    "label": "Canadian Tire Windsor South, ON",
+    "city": "Windsor South",
+    "nickname": "Windsor South",
+    "province": "ON",
+    "address": "4150 Walker Road, Windsor, ON, N8W 3T6",
+    "slug": "windsor-south-on-0236"
+  },
+  {
+    "store_id": "0224",
+    "label": "Canadian Tire Halifax - Bedford, NS",
+    "city": "Halifax - Bedford",
+    "nickname": "Halifax - Bedford",
+    "province": "NS",
+    "address": "150 Damascus Road, Bedford, NS, B4A 0E5",
+    "slug": "halifax-bedford-ns-0224"
+  },
+  {
+    "store_id": "0465",
+    "label": "Canadian Tire Halifax - Bayers Lake, NS",
+    "city": "Halifax - Bayers Lake",
+    "nickname": "Halifax - Bayers Lake",
+    "province": "NS",
+    "address": "194 Chain Lake Drive, Halifax, NS, B3S 1C5",
+    "slug": "halifax-bayers-lake-ns-0465"
+  },
+  {
+    "store_id": "0121",
+    "label": "Canadian Tire Windsor University Plaza, ON",
+    "city": "Windsor University Plaza",
+    "nickname": "Windsor University Plaza",
+    "province": "ON",
+    "address": "2650 Tecumseh Road West, Windsor, ON, N9B 3R1",
+    "slug": "windsor-university-plaza-on-0121"
+  },
+  {
+    "store_id": "0186",
+    "label": "Canadian Tire Halifax - Spryfield, NS",
+    "city": "Halifax - Spryfield",
+    "nickname": "Halifax - Spryfield",
+    "province": "NS",
+    "address": "16 Dentith Road, Halifax, NS, B3R 2H9",
+    "slug": "halifax-spryfield-ns-0186"
+  },
+  {
+    "store_id": "0619",
+    "label": "Canadian Tire Elmsdale, NS",
+    "city": "Elmsdale",
+    "nickname": "Elmsdale",
+    "province": "NS",
+    "address": "269 Highway 214, Unit 100, Elmsdale, NS, B2S 1K1",
+    "slug": "elmsdale-ns-0619"
+  },
+  {
+    "store_id": "0044",
+    "label": "Canadian Tire Halifax, NS",
+    "city": "Halifax",
+    "nickname": "Halifax",
+    "province": "NS",
+    "address": "6203 Quinpool Road, Halifax, NS, B3L 4P6",
+    "slug": "halifax-ns-0044"
+  },
+  {
+    "store_id": "0041",
+    "label": "Canadian Tire Dartmouth Crossing, NS",
+    "city": "Dartmouth Crossing",
+    "nickname": "Dartmouth Crossing",
+    "province": "NS",
+    "address": "30 Lamont Terrace, Dartmouth, NS, B3B 0E3",
+    "slug": "dartmouth-crossing-ns-0041"
+  },
+  {
+    "store_id": "0436",
+    "label": "Canadian Tire Halifax - Cole Harbour, NS",
+    "city": "Halifax - Cole Harbour",
+    "nickname": "Halifax - Cole Harbour",
+    "province": "NS",
+    "address": "24 Forest Hills Parkway, Dartmouth, NS, B2W 5G7",
+    "slug": "halifax-cole-harbour-ns-0436"
+  },
+  {
+    "store_id": "0113",
+    "label": "Canadian Tire Truro, NS",
+    "city": "Truro",
+    "nickname": "Truro",
+    "province": "NS",
+    "address": "90 Robie Street, Truro, NS, B2N 1L1",
+    "slug": "truro-ns-0113"
+  },
+  {
+    "store_id": "0281",
+    "label": "Canadian Tire Amherstburg, ON",
+    "city": "Amherstburg",
+    "nickname": "Amherstburg",
+    "province": "ON",
+    "address": "380 Sandwich Street South, Amherstburg, ON, N9V 3B5",
+    "slug": "amherstburg-on-0281"
+  },
+  {
+    "store_id": "0020",
+    "label": "Canadian Tire Charlottetown, PE",
+    "city": "Charlottetown",
+    "nickname": "Charlottetown",
+    "province": "PE",
+    "address": "20 Babineau Avenue, Charlottetown, PE, C1A 0G2",
+    "slug": "charlottetown-pe-0020"
+  },
+  {
+    "store_id": "0406",
+    "label": "Canadian Tire Hearst, ON",
+    "city": "Hearst",
+    "nickname": "Hearst",
+    "province": "ON",
+    "address": "1330 Front Street, Hearst, ON, P0L 1N0",
+    "slug": "hearst-on-0406"
+  },
+  {
+    "store_id": "0279",
+    "label": "Canadian Tire Wawa, ON",
+    "city": "Wawa",
+    "nickname": "Wawa",
+    "province": "ON",
+    "address": "54 Broadway Avenue, Wawa, ON, P0S 1K0",
+    "slug": "wawa-on-0279"
+  },
+  {
+    "store_id": "0067",
+    "label": "Canadian Tire New Glasgow, NS",
+    "city": "New Glasgow",
+    "nickname": "New Glasgow",
+    "province": "NS",
+    "address": "699 Westville Road, New Glasgow, NS, B2H 2J6",
+    "slug": "new-glasgow-ns-0067"
+  },
+  {
+    "store_id": "0002",
+    "label": "Canadian Tire Antigonish, NS",
+    "city": "Antigonish",
+    "nickname": "Antigonish",
+    "province": "NS",
+    "address": "133 Church Street, Antigonish, NS, B2G 2G3",
+    "slug": "antigonish-ns-0002"
+  },
+  {
+    "store_id": "0901",
+    "label": "Canadian Tire Labrador City, NL",
+    "city": "Labrador City",
+    "nickname": "Labrador City",
+    "province": "NL",
+    "address": "500 Vanier Avenue, Labrador City, NL, A2V 2W8",
+    "slug": "labrador-city-nl-0901"
+  },
+  {
+    "store_id": "0213",
+    "label": "Canadian Tire Port Hawkesbury, NS",
+    "city": "Port Hawkesbury",
+    "nickname": "Port Hawkesbury",
+    "province": "NS",
+    "address": "625 Reeves Street, Port Hawkesbury, NS, B9A 2R7",
+    "slug": "port-hawkesbury-ns-0213"
+  },
+  {
+    "store_id": "0451",
+    "label": "Canadian Tire Marathon, ON",
+    "city": "Marathon",
+    "nickname": "Marathon",
+    "province": "ON",
+    "address": "3 Peninsula Road, PO Box 1660, Marathon, ON, P0T 2G0",
+    "slug": "marathon-on-0451"
+  },
+  {
+    "store_id": "0202",
+    "label": "Canadian Tire North Sydney, NS",
+    "city": "North Sydney",
+    "nickname": "North Sydney",
+    "province": "NS",
+    "address": "21 Blowers Street, North Sydney, NS, B2A 3N7",
+    "slug": "north-sydney-ns-0202"
+  },
+  {
+    "store_id": "0107",
+    "label": "Canadian Tire Sydney, NS",
+    "city": "Sydney",
+    "nickname": "Sydney",
+    "province": "NS",
+    "address": "49 Sydney Port Access Road, Sydney, NS, B1P 7H3",
+    "slug": "sydney-ns-0107"
+  },
+  {
+    "store_id": "0229",
+    "label": "Canadian Tire Glace Bay, NS",
+    "city": "Glace Bay",
+    "nickname": "Glace Bay",
+    "province": "NS",
+    "address": "130 Reserve Street, Glace Bay, NS, B1A 4W4",
+    "slug": "glace-bay-ns-0229"
+  },
+  {
+    "store_id": "0201",
+    "label": "Canadian Tire Nipigon, ON",
+    "city": "Nipigon",
+    "nickname": "Nipigon",
+    "province": "ON",
+    "address": "191 First Street, Nipigon, ON, P0T 2J0",
+    "slug": "nipigon-on-0201"
+  },
+  {
+    "store_id": "0319",
+    "label": "Canadian Tire Port aux Basques, NL",
+    "city": "Port aux Basques",
+    "nickname": "Port aux Basques",
+    "province": "NL",
+    "address": "2 High Street, Channel-Port-aux-Basques, NL, A0M 1C0",
+    "slug": "port-aux-basques-nl-0319"
+  },
+  {
+    "store_id": "0083",
+    "label": "Canadian Tire Thunder Bay Center, ON",
+    "city": "Thunder Bay Center",
+    "nickname": "Thunder Bay Center",
+    "province": "ON",
+    "address": "939 Fort William Road, Thunder Bay, ON, P7B 3A6",
+    "slug": "thunder-bay-center-on-0083"
+  },
+  {
+    "store_id": "0034",
+    "label": "Canadian Tire Thunder Bay South, ON",
+    "city": "Thunder Bay South",
+    "nickname": "Thunder Bay South",
+    "province": "ON",
+    "address": "1221 Arthur Street West, Thunder Bay, ON, P7K 1E6",
+    "slug": "thunder-bay-south-on-0034"
+  },
+  {
+    "store_id": "0325",
+    "label": "Canadian Tire Stephenville, NL",
+    "city": "Stephenville",
+    "nickname": "Stephenville",
+    "province": "NL",
+    "address": "54 Prince Rupert Drive, Stephenville, NL, A2N 3X6",
+    "slug": "stephenville-nl-0325"
+  },
+  {
+    "store_id": "0185",
+    "label": "Canadian Tire Corner Brook, NL",
+    "city": "Corner Brook",
+    "nickname": "Corner Brook",
+    "province": "NL",
+    "address": "4 Murphy Square, Corner Brook, NL, A2H 1R8",
+    "slug": "corner-brook-nl-0185"
+  },
+  {
+    "store_id": "0205",
+    "label": "Canadian Tire Grand Falls-Windsor, NL",
+    "city": "Grand Falls-Windsor",
+    "nickname": "Grand Falls-Windsor",
+    "province": "NL",
+    "address": "1 Cohen Place, Grand Falls-Windsor, NL, A2A 2C7",
+    "slug": "grand-falls-windsor-nl-0205"
+  },
+  {
+    "store_id": "0468",
+    "label": "Canadian Tire Marystown, NL",
+    "city": "Marystown",
+    "nickname": "Marystown",
+    "province": "NL",
+    "address": "25 - 49 Columbia Drive, Marystown, NL, A0E 2M0",
+    "slug": "marystown-nl-0468"
+  },
+  {
+    "store_id": "0188",
+    "label": "Canadian Tire Dryden, ON",
+    "city": "Dryden",
+    "nickname": "Dryden",
+    "province": "ON",
+    "address": "409 Government Street, Dryden, ON, P8N 2Z1",
+    "slug": "dryden-on-0188"
+  },
+  {
+    "store_id": "0291",
+    "label": "Canadian Tire Lewisporte, NL",
+    "city": "Lewisporte",
+    "nickname": "Lewisporte",
+    "province": "NL",
+    "address": "425 Main Street West, Lewisporte, NL, A0G 3A0",
+    "slug": "lewisporte-nl-0291"
+  },
+  {
+    "store_id": "0179",
+    "label": "Canadian Tire Fort Frances, ON",
+    "city": "Fort Frances",
+    "nickname": "Fort Frances",
+    "province": "ON",
+    "address": "1000 King's Highway, Fort Frances, ON, P9A 2X6",
+    "slug": "fort-frances-on-0179"
+  },
+  {
+    "store_id": "0259",
+    "label": "Canadian Tire Gander, NL",
+    "city": "Gander",
+    "nickname": "Gander",
+    "province": "NL",
+    "address": "132 Bennett Drive, Gander, NL, A1V 1S8",
+    "slug": "gander-nl-0259"
+  },
+  {
+    "store_id": "0650",
+    "label": "Canadian Tire Clarenville, NL",
+    "city": "Clarenville",
+    "nickname": "Clarenville",
+    "province": "NL",
+    "address": "27 Manitoba Drive, Clarenville, NL, A5A 1J8",
+    "slug": "clarenville-nl-0650"
+  },
+  {
+    "store_id": "0204",
+    "label": "Canadian Tire Kenora, ON",
+    "city": "Kenora",
+    "nickname": "Kenora",
+    "province": "ON",
+    "address": "1229 Highway 17 East, Kenora, ON, P9N 1L9",
+    "slug": "kenora-on-0204"
+  },
+  {
+    "store_id": "0217",
+    "label": "Canadian Tire Carbonear, NL",
+    "city": "Carbonear",
+    "nickname": "Carbonear",
+    "province": "NL",
+    "address": "95 Columbus Drive, Carbonear, NL, A1Y 1B3",
+    "slug": "carbonear-nl-0217"
+  },
+  {
+    "store_id": "0333",
+    "label": "Canadian Tire Mount Pearl, NL",
+    "city": "Mount Pearl",
+    "nickname": "Mount Pearl",
+    "province": "NL",
+    "address": "26 Merchant Drive, Mount Pearl, NL, A1N 5B7",
+    "slug": "mount-pearl-nl-0333"
+  },
+  {
+    "store_id": "0216",
+    "label": "Canadian Tire St. John's West, NL",
+    "city": "St. John's West",
+    "nickname": "St. John's West",
+    "province": "NL",
+    "address": "50 Kelsey Drive, St. John's, NL, A1B 5C8",
+    "slug": "st-john-s-west-nl-0216"
+  },
+  {
+    "store_id": "0144",
+    "label": "Canadian Tire St. John's Hebron Way, NL",
+    "city": "St. John's Hebron Way",
+    "nickname": "St. John's Hebron Way",
+    "province": "NL",
+    "address": "40 Hebron Way, St. John's, NL, A1A 0L9",
+    "slug": "st-john-s-hebron-way-nl-0144"
+  },
+  {
+    "store_id": "0203",
+    "label": "Canadian Tire Steinbach, MB",
+    "city": "Steinbach",
+    "nickname": "Steinbach",
+    "province": "MB",
+    "address": "131 PTH 12 North, Steinbach, MB, R5G 1T7",
+    "slug": "steinbach-mb-0203"
+  },
+  {
+    "store_id": "0447",
+    "label": "Canadian Tire Selkirk, MB",
+    "city": "Selkirk",
+    "nickname": "Selkirk",
+    "province": "MB",
+    "address": "1041 Manitoba Avenue, Selkirk, MB, R1A 3T8",
+    "slug": "selkirk-mb-0447"
+  },
+  {
+    "store_id": "0270",
+    "label": "Canadian Tire Winnipeg Regent, MB",
+    "city": "Winnipeg Regent",
+    "nickname": "Winnipeg Regent",
+    "province": "MB",
+    "address": "1519 Regent Avenue West, Winnipeg, MB, R2C 4H9",
+    "slug": "winnipeg-regent-mb-0270"
+  },
+  {
+    "store_id": "0266",
+    "label": "Canadian Tire Winnipeg St. Boniface, MB",
+    "city": "Winnipeg St. Boniface",
+    "nickname": "Winnipeg St. Boniface",
+    "province": "MB",
+    "address": "157 Vermillion Road, Winnipeg, MB, R2J 3Z6",
+    "slug": "winnipeg-st-boniface-mb-0266"
+  },
+  {
+    "store_id": "0345",
+    "label": "Canadian Tire Winnipeg McPhillips, MB",
+    "city": "Winnipeg McPhillips",
+    "nickname": "Winnipeg McPhillips",
+    "province": "MB",
+    "address": "2305 McPhillips Street, Winnipeg, MB, R2V 3M7",
+    "slug": "winnipeg-mcphillips-mb-0345"
+  },
+  {
+    "store_id": "0929",
+    "label": "Canadian Tire Winnipeg Grant Park, MB",
+    "city": "Winnipeg Grant Park",
+    "nickname": "Winnipeg Grant Park",
+    "province": "MB",
+    "address": "1080 Grant Avenue, Winnipeg, MB, R3M 2A6",
+    "slug": "winnipeg-grant-park-mb-0929"
+  },
+  {
+    "store_id": "0223",
+    "label": "Canadian Tire Winnipeg Kenaston, MB",
+    "city": "Winnipeg Kenaston",
+    "nickname": "Winnipeg Kenaston",
+    "province": "MB",
+    "address": "1711 Kenaston Blvd., Winnipeg, MB, R3Y 1V5",
+    "slug": "winnipeg-kenaston-mb-0223"
+  },
+  {
+    "store_id": "0248",
+    "label": "Canadian Tire Winnipeg Polo Park, MB",
+    "city": "Winnipeg Polo Park",
+    "nickname": "Winnipeg Polo Park",
+    "province": "MB",
+    "address": "750 St. James Street, Winnipeg, MB, R3G 3H6",
+    "slug": "winnipeg-polo-park-mb-0248"
+  },
+  {
+    "store_id": "0252",
+    "label": "Canadian Tire Winnipeg Unicity Shopping Centre, MB",
+    "city": "Winnipeg Unicity Shopping Centre",
+    "nickname": "Winnipeg Unicity Shopping Centre",
+    "province": "MB",
+    "address": "3615 Portage Avenue, Winnipeg, MB, R3K 2E8",
+    "slug": "winnipeg-unicity-shopping-centre-mb-0252"
+  },
+  {
+    "store_id": "0358",
+    "label": "Canadian Tire Winkler, MB",
+    "city": "Winkler",
+    "nickname": "Winkler",
+    "province": "MB",
+    "address": "781 Norquay Drive, Winkler, MB, R6W 0M5",
+    "slug": "winkler-mb-0358"
+  },
+  {
+    "store_id": "0277",
+    "label": "Canadian Tire Portage La Prairie, MB",
+    "city": "Portage La Prairie",
+    "nickname": "Portage La Prairie",
+    "province": "MB",
+    "address": "2445 Saskatchewan Avenue West, Portage La Prairie, MB, R1N 4A7",
+    "slug": "portage-la-prairie-mb-0277"
+  },
+  {
+    "store_id": "0286",
+    "label": "Canadian Tire Brandon, MB",
+    "city": "Brandon",
+    "nickname": "Brandon",
+    "province": "MB",
+    "address": "1655 - 18th Street, Brandon, MB, R7A 5C8",
+    "slug": "brandon-mb-0286"
+  },
+  {
+    "store_id": "0198",
+    "label": "Canadian Tire Thompson, MB",
+    "city": "Thompson",
+    "nickname": "Thompson",
+    "province": "MB",
+    "address": "60 Selkirk Avenue, Thompson, MB, R8N 0M7",
+    "slug": "thompson-mb-0198"
+  },
+  {
+    "store_id": "0331",
+    "label": "Canadian Tire Dauphin, MB",
+    "city": "Dauphin",
+    "nickname": "Dauphin",
+    "province": "MB",
+    "address": "1500 Main Street South, Dauphin, MB, R7N 2V1",
+    "slug": "dauphin-mb-0331"
+  },
+  {
+    "store_id": "0287",
+    "label": "Canadian Tire Yorkton, SK",
+    "city": "Yorkton",
+    "nickname": "Yorkton",
+    "province": "SK",
+    "address": "277 Broadway Street E, Yorkton, SK, S3N 3G7",
+    "slug": "yorkton-sk-0287"
+  },
+  {
+    "store_id": "0915",
+    "label": "Canadian Tire Melville, SK",
+    "city": "Melville",
+    "nickname": "Melville",
+    "province": "SK",
+    "address": "290 Prince William Drive, Melville, SK, S0A 2P1",
+    "slug": "melville-sk-0915"
+  },
+  {
+    "store_id": "0640",
+    "label": "Canadian Tire Flin Flon, MB",
+    "city": "Flin Flon",
+    "nickname": "Flin Flon",
+    "province": "MB",
+    "address": "170 PTH No. 10-A, Flin Flon, MB, R8A 0C6",
+    "slug": "flin-flon-mb-0640"
+  },
+  {
+    "store_id": "0146",
+    "label": "Canadian Tire Estevan, SK",
+    "city": "Estevan",
+    "nickname": "Estevan",
+    "province": "SK",
+    "address": "200 King Street, Estevan, SK, S4A 2W2",
+    "slug": "estevan-sk-0146"
+  },
+  {
+    "store_id": "0408",
+    "label": "Canadian Tire Weyburn, SK",
+    "city": "Weyburn",
+    "nickname": "Weyburn",
+    "province": "SK",
+    "address": "1240 Sims Avenue, Weyburn, SK, S4H 3B7",
+    "slug": "weyburn-sk-0408"
+  },
+  {
+    "store_id": "0629",
+    "label": "Canadian Tire Regina East, SK",
+    "city": "Regina East",
+    "nickname": "Regina East",
+    "province": "SK",
+    "address": "2325 Prince Of Wales Drive, Regina, SK, S4V 3A7",
+    "slug": "regina-east-sk-0629"
+  },
+  {
+    "store_id": "0275",
+    "label": "Canadian Tire Regina North Albert, SK",
+    "city": "Regina North Albert",
+    "nickname": "Regina North Albert",
+    "province": "SK",
+    "address": "655 Albert Street, Regina, SK, S4R 2P5",
+    "slug": "regina-north-albert-sk-0275"
+  },
+  {
+    "store_id": "0310",
+    "label": "Canadian Tire Regina South, SK",
+    "city": "Regina South",
+    "nickname": "Regina South",
+    "province": "SK",
+    "address": "2965 Gordon Road, Unit 65, Regina, SK, S4S 6H7",
+    "slug": "regina-south-sk-0310"
+  },
+  {
+    "store_id": "0656",
+    "label": "Canadian Tire Melfort, SK",
+    "city": "Melfort",
+    "nickname": "Melfort",
+    "province": "SK",
+    "address": "300 Stonegate, 500 Hwy 6 South, Melfort, SK, S0E 1A0",
+    "slug": "melfort-sk-0656"
+  },
+  {
+    "store_id": "0638",
+    "label": "Canadian Tire Humboldt, SK",
+    "city": "Humboldt",
+    "nickname": "Humboldt",
+    "province": "SK",
+    "address": "2302 - 8th Avenue, Humboldt, SK, S0K 2A0",
+    "slug": "humboldt-sk-0638"
+  },
+  {
+    "store_id": "0263",
+    "label": "Canadian Tire Moose Jaw, SK",
+    "city": "Moose Jaw",
+    "nickname": "Moose Jaw",
+    "province": "SK",
+    "address": "400 Thatcher Drive East, Moose Jaw, SK, S6J 1L7",
+    "slug": "moose-jaw-sk-0263"
+  },
+  {
+    "store_id": "0317",
+    "label": "Canadian Tire Prince Albert, SK",
+    "city": "Prince Albert",
+    "nickname": "Prince Albert",
+    "province": "SK",
+    "address": "3725 - 2nd Avenue West, Prince Albert, SK, S6W 1A3",
+    "slug": "prince-albert-sk-0317"
+  },
+  {
+    "store_id": "0133",
+    "label": "Canadian Tire Saskatoon East, SK",
+    "city": "Saskatoon East",
+    "nickname": "Saskatoon East",
+    "province": "SK",
+    "address": "1731 Preston Avenue North, Saskatoon, SK, S7N 4V2",
+    "slug": "saskatoon-east-sk-0133"
+  },
+  {
+    "store_id": "0912",
+    "label": "Canadian Tire Martensville, SK",
+    "city": "Martensville",
+    "nickname": "Martensville",
+    "province": "SK",
+    "address": "230 Centennial Drive North, Martensville, SK, S0K 2T0",
+    "slug": "martensville-sk-0912"
+  },
+  {
+    "store_id": "0296",
+    "label": "Canadian Tire Saskatoon West, SK",
+    "city": "Saskatoon West",
+    "nickname": "Saskatoon West",
+    "province": "SK",
+    "address": "300 Confederation Drive, Unit 1, Saskatoon, SK, S7L 4R6",
+    "slug": "saskatoon-west-sk-0296"
+  },
+  {
+    "store_id": "0100",
+    "label": "Canadian Tire Swift Current, SK",
+    "city": "Swift Current",
+    "nickname": "Swift Current",
+    "province": "SK",
+    "address": "1811 Memorial Drive, Swift Current, SK, S9H 5N5",
+    "slug": "swift-current-sk-0100"
+  },
+  {
+    "store_id": "0301",
+    "label": "Canadian Tire North Battleford, SK",
+    "city": "North Battleford",
+    "nickname": "North Battleford",
+    "province": "SK",
+    "address": "11802 Railway Avenue East, North Battleford, SK, S9A 3K7",
+    "slug": "north-battleford-sk-0301"
+  },
+  {
+    "store_id": "0341",
+    "label": "Canadian Tire Lloydminster, AB",
+    "city": "Lloydminster",
+    "nickname": "Lloydminster",
+    "province": "AB",
+    "address": "4215 - 70th Avenue, Lloydminster, AB, T9V 2X2",
+    "slug": "lloydminster-ab-0341"
+  },
+  {
+    "store_id": "0450",
+    "label": "Canadian Tire Cold Lake, AB",
+    "city": "Cold Lake",
+    "nickname": "Cold Lake",
+    "province": "AB",
+    "address": "6703 - 51st Street, Cold Lake, AB, T9M 1Z9",
+    "slug": "cold-lake-ab-0450"
+  },
+  {
+    "store_id": "0328",
+    "label": "Canadian Tire Medicine Hat, AB",
+    "city": "Medicine Hat",
+    "nickname": "Medicine Hat",
+    "province": "AB",
+    "address": "1971 Strachan Road SE, Medicine Hat, AB, T1B 0G4",
+    "slug": "medicine-hat-ab-0328"
+  },
+  {
+    "store_id": "0628",
+    "label": "Canadian Tire Wainwright, AB",
+    "city": "Wainwright",
+    "nickname": "Wainwright",
+    "province": "AB",
+    "address": "2801 - 13th Avenue, Wainwright, AB, T9W 0A2",
+    "slug": "wainwright-ab-0628"
+  },
+  {
+    "store_id": "0900",
+    "label": "Canadian Tire St. Paul, AB",
+    "city": "St. Paul",
+    "nickname": "St. Paul",
+    "province": "AB",
+    "address": "3929 - 49th Avenue, St. Paul, AB, T0A 3A2",
+    "slug": "st-paul-ab-0900"
+  },
+  {
+    "store_id": "0339",
+    "label": "Canadian Tire Fort McMurray - Main Store, AB",
+    "city": "Fort McMurray - Main Store",
+    "nickname": "Fort McMurray - Main Store",
+    "province": "AB",
+    "address": "1 Hospital Street, Fort McMurray, AB, T9H 5C1",
+    "slug": "fort-mcmurray-main-store-ab-0339"
+  },
+  {
+    "store_id": "0911",
+    "label": "Canadian Tire Fort McMurray - Outdoor Store, AB",
+    "city": "Fort McMurray - Outdoor Store",
+    "nickname": "Fort McMurray - Outdoor Store",
+    "province": "AB",
+    "address": "19 Riedel Street, Unit 102, Fort McMurray, AB, T9H 5P8",
+    "slug": "fort-mcmurray-outdoor-store-ab-0911"
+  },
+  {
+    "store_id": "0212",
+    "label": "Canadian Tire Brooks, AB",
+    "city": "Brooks",
+    "nickname": "Brooks",
+    "province": "AB",
+    "address": "404 Cassils Road West, Brooks, AB, T1R 0W2",
+    "slug": "brooks-ab-0212"
+  },
+  {
+    "store_id": "0410",
+    "label": "Canadian Tire Vegreville, AB",
+    "city": "Vegreville",
+    "nickname": "Vegreville",
+    "province": "AB",
+    "address": "6623 Highway 16A West, Vegreville, AB, T9C 0A3",
+    "slug": "vegreville-ab-0410"
+  },
+  {
+    "store_id": "0671",
+    "label": "Canadian Tire Stettler, AB",
+    "city": "Stettler",
+    "nickname": "Stettler",
+    "province": "AB",
+    "address": "6607 - 50th Avenue, Stettler, AB, T0C 2L0",
+    "slug": "stettler-ab-0671"
+  },
+  {
+    "store_id": "0439",
+    "label": "Canadian Tire Drumheller, AB",
+    "city": "Drumheller",
+    "nickname": "Drumheller",
+    "province": "AB",
+    "address": "650 South Railway Avenue, Unit 100, Drumheller, AB, T0J 0Y0",
+    "slug": "drumheller-ab-0439"
+  },
+  {
+    "store_id": "0398",
+    "label": "Canadian Tire Camrose, AB",
+    "city": "Camrose",
+    "nickname": "Camrose",
+    "province": "AB",
+    "address": "6601 - 48th Avenue, Unit 16, Camrose, AB, T4V 3K8",
+    "slug": "camrose-ab-0398"
+  },
+  {
+    "store_id": "0634",
+    "label": "Canadian Tire Lethbridge South, AB",
+    "city": "Lethbridge South",
+    "nickname": "Lethbridge South",
+    "province": "AB",
+    "address": "2720 Fairway Road South, Lethbridge, AB, T1K 7A5",
+    "slug": "lethbridge-south-ab-0634"
+  },
+  {
+    "store_id": "0441",
+    "label": "Canadian Tire Lethbridge, AB",
+    "city": "Lethbridge",
+    "nickname": "Lethbridge",
+    "province": "AB",
+    "address": "1240 - 2nd Avenue A North, Lethbridge, AB, T1H 0E4",
+    "slug": "lethbridge-ab-0441"
+  },
+  {
+    "store_id": "0322",
+    "label": "Canadian Tire Fort Saskatchewan, AB",
+    "city": "Fort Saskatchewan",
+    "nickname": "Fort Saskatchewan",
+    "province": "AB",
+    "address": "9510 - 86th Avenue, Fort Saskatchewan, AB, T8L 4P4",
+    "slug": "fort-saskatchewan-ab-0322"
+  },
+  {
+    "store_id": "0916",
+    "label": "Canadian Tire Sherwood Park Emerald Hills, AB",
+    "city": "Sherwood Park Emerald Hills",
+    "nickname": "Sherwood Park Emerald Hills",
+    "province": "AB",
+    "address": "200 - 3000 Emerald Drive, Sherwood Park, AB, T8H 0P5",
+    "slug": "sherwood-park-emerald-hills-ab-0916"
+  },
+  {
+    "store_id": "0428",
+    "label": "Canadian Tire Sherwood Park, AB",
+    "city": "Sherwood Park",
+    "nickname": "Sherwood Park",
+    "province": "AB",
+    "address": "169 Ordze Avenue, Sherwood Park, AB, T8B 1M6",
+    "slug": "sherwood-park-ab-0428"
+  },
+  {
+    "store_id": "0667",
+    "label": "Canadian Tire Athabasca, AB",
+    "city": "Athabasca",
+    "nickname": "Athabasca",
+    "province": "AB",
+    "address": "2913 - 48th Avenue, Athabasca, AB, T9S 0A4",
+    "slug": "athabasca-ab-0667"
+  },
+  {
+    "store_id": "0330",
+    "label": "Canadian Tire Wetaskiwin, AB",
+    "city": "Wetaskiwin",
+    "nickname": "Wetaskiwin",
+    "province": "AB",
+    "address": "3851 - 56th Street, Wetaskiwin, AB, T9A 2B1",
+    "slug": "wetaskiwin-ab-0330"
+  },
+  {
+    "store_id": "0347",
+    "label": "Canadian Tire Edmonton Manning Dr., AB",
+    "city": "Edmonton Manning Dr.",
+    "nickname": "Edmonton Manning Dr.",
+    "province": "AB",
+    "address": "3650 - 158th Avenue NW, Edmonton, AB, T5Y 0S5",
+    "slug": "edmonton-manning-dr-ab-0347"
+  },
+  {
+    "store_id": "0614",
+    "label": "Canadian Tire Edmonton Capilano, AB",
+    "city": "Edmonton Capilano",
+    "nickname": "Edmonton Capilano",
+    "province": "AB",
+    "address": "9847 - 50th Street NW, Edmonton, AB, T6A 3K5",
+    "slug": "edmonton-capilano-ab-0614"
+  },
+  {
+    "store_id": "0478",
+    "label": "Canadian Tire Edmonton Millwoods, AB",
+    "city": "Edmonton Millwoods",
+    "nickname": "Edmonton Millwoods",
+    "province": "AB",
+    "address": "2331 - 66th Street NW, Edmonton, AB, T6K 4B5",
+    "slug": "edmonton-millwoods-ab-0478"
+  },
+  {
+    "store_id": "0304",
+    "label": "Canadian Tire Edmonton South, AB",
+    "city": "Edmonton South",
+    "nickname": "Edmonton South",
+    "province": "AB",
+    "address": "2110 - 101st Street NW, Edmonton, AB, T6N 1J2",
+    "slug": "edmonton-south-ab-0304"
+  },
+  {
+    "store_id": "0397",
+    "label": "Canadian Tire Edmonton North West, AB",
+    "city": "Edmonton North West",
+    "nickname": "Edmonton North West",
+    "province": "AB",
+    "address": "9603 - 162nd Avenue, Edmonton, AB, T5Z 3S8",
+    "slug": "edmonton-north-west-ab-0397"
+  },
+  {
+    "store_id": "0651",
+    "label": "Canadian Tire Strathmore, AB",
+    "city": "Strathmore",
+    "nickname": "Strathmore",
+    "province": "AB",
+    "address": "109 - 900 Pine Road, Strathmore, AB, T1P 0A2",
+    "slug": "strathmore-ab-0651"
+  },
+  {
+    "store_id": "0467",
+    "label": "Canadian Tire Edmonton Downtown, AB",
+    "city": "Edmonton Downtown",
+    "nickname": "Edmonton Downtown",
+    "province": "AB",
+    "address": "11839 Kingsway NW, Edmonton, AB, T5G 3J7",
+    "slug": "edmonton-downtown-ab-0467"
+  },
+  {
+    "store_id": "0448",
+    "label": "Canadian Tire Leduc, AB",
+    "city": "Leduc",
+    "nickname": "Leduc",
+    "province": "AB",
+    "address": "5402 Discovery Way, Leduc, AB, T9E 8L9",
+    "slug": "leduc-ab-0448"
+  },
+  {
+    "store_id": "0676",
+    "label": "Canadian Tire Edmonton Windermere, AB",
+    "city": "Edmonton Windermere",
+    "nickname": "Edmonton Windermere",
+    "province": "AB",
+    "address": "6014 Currents Drive NW, Edmonton, AB, T6W 0L7",
+    "slug": "edmonton-windermere-ab-0676"
+  },
+  {
+    "store_id": "0334",
+    "label": "Canadian Tire Edmonton St.Albert, AB",
+    "city": "Edmonton St.Albert",
+    "nickname": "Edmonton St.Albert",
+    "province": "AB",
+    "address": "40 Bellerose Drive, St. Albert, AB, T8N 6M3",
+    "slug": "edmonton-st-albert-ab-0334"
+  },
+  {
+    "store_id": "0288",
+    "label": "Canadian Tire Edmonton West, AB",
+    "city": "Edmonton West",
+    "nickname": "Edmonton West",
+    "province": "AB",
+    "address": "9909 - 178th Street NW, Edmonton, AB, T5T 6H6",
+    "slug": "edmonton-west-ab-0288"
+  },
+  {
+    "store_id": "0645",
+    "label": "Canadian Tire Red Deer North, AB",
+    "city": "Red Deer North",
+    "nickname": "Red Deer North",
+    "province": "AB",
+    "address": "6380 - 50th Avenue, Unit 300, Red Deer, AB, T4N 4C6",
+    "slug": "red-deer-north-ab-0645"
+  },
+  {
+    "store_id": "0329",
+    "label": "Canadian Tire Red Deer, AB",
+    "city": "Red Deer",
+    "nickname": "Red Deer",
+    "province": "AB",
+    "address": "2510 - 50th Avenue, Red Deer, AB, T4R 1M3",
+    "slug": "red-deer-ab-0329"
+  },
+  {
+    "store_id": "0449",
+    "label": "Canadian Tire Spruce Grove, AB",
+    "city": "Spruce Grove",
+    "nickname": "Spruce Grove",
+    "province": "AB",
+    "address": "38 McLeod Avenue, Spruce Grove, AB, T7X 3E6",
+    "slug": "spruce-grove-ab-0449"
+  },
+  {
+    "store_id": "0909",
+    "label": "Canadian Tire High River, AB",
+    "city": "High River",
+    "nickname": "High River",
+    "province": "AB",
+    "address": "1204 - 5th Street SE, High River, AB, T1V 0J1",
+    "slug": "high-river-ab-0909"
+  },
+  {
+    "store_id": "0655",
+    "label": "Canadian Tire Sylvan Lake, AB",
+    "city": "Sylvan Lake",
+    "nickname": "Sylvan Lake",
+    "province": "AB",
+    "address": "200 - 62 Thevenaz Industrial Trail, Sylvan Lake, AB, T4S 0B6",
+    "slug": "sylvan-lake-ab-0655"
+  },
+  {
+    "store_id": "0407",
+    "label": "Canadian Tire Airdrie, AB",
+    "city": "Airdrie",
+    "nickname": "Airdrie",
+    "province": "AB",
+    "address": "300 - 202 Veteran's Blvd. NE, Airdrie, AB, T4B 3P2",
+    "slug": "airdrie-ab-0407"
+  },
+  {
+    "store_id": "0326",
+    "label": "Canadian Tire Calgary Pacific Place, AB",
+    "city": "Calgary Pacific Place",
+    "nickname": "Calgary Pacific Place",
+    "province": "AB",
+    "address": "3516 - 8th Avenue NE, Calgary, AB, T2A 6K4",
+    "slug": "calgary-pacific-place-ab-0326"
+  },
+  {
+    "store_id": "0637",
+    "label": "Canadian Tire Calgary McKenzie Towne SE, AB",
+    "city": "Calgary McKenzie Towne SE",
+    "nickname": "Calgary McKenzie Towne SE",
+    "province": "AB",
+    "address": "4155 - 126th Avenue SE, Calgary, AB, T2Z 0A9",
+    "slug": "calgary-mckenzie-towne-se-ab-0637"
+  },
+  {
+    "store_id": "0642",
+    "label": "Canadian Tire Okotoks, AB",
+    "city": "Okotoks",
+    "nickname": "Okotoks",
+    "province": "AB",
+    "address": "100 - 201 Southridge Drive, Okotoks, AB, T1S 2C8",
+    "slug": "okotoks-ab-0642"
+  },
+  {
+    "store_id": "0419",
+    "label": "Canadian Tire Calgary Deerfoot City NE, AB",
+    "city": "Calgary Deerfoot City NE",
+    "nickname": "Calgary Deerfoot City NE",
+    "province": "AB",
+    "address": "910 - 57th Avenue NE, Calgary, AB, T2E 9B7",
+    "slug": "calgary-deerfoot-city-ne-ab-0419"
+  },
+  {
+    "store_id": "0496",
+    "label": "Canadian Tire Calgary Country Hills, AB",
+    "city": "Calgary Country Hills",
+    "nickname": "Calgary Country Hills",
+    "province": "AB",
+    "address": "388 Country Hills Blvd. NE, Unit 200, Calgary, AB, T3K 5J4",
+    "slug": "calgary-country-hills-ab-0496"
+  },
+  {
+    "store_id": "0475",
+    "label": "Canadian Tire Olds, AB",
+    "city": "Olds",
+    "nickname": "Olds",
+    "province": "AB",
+    "address": "6900 - 46th Street, Unit 600, Olds, AB, T4H 0A2",
+    "slug": "olds-ab-0475"
+  },
+  {
+    "store_id": "0313",
+    "label": "Canadian Tire Calgary Southland and Macleod, AB",
+    "city": "Calgary Southland and Macleod",
+    "nickname": "Calgary Southland and Macleod",
+    "province": "AB",
+    "address": "9940 Macleod Trail SE, Calgary, AB, T2J 3K9",
+    "slug": "calgary-southland-and-macleod-ab-0313"
+  },
+  {
+    "store_id": "0930",
+    "label": "Canadian Tire Calgary Mount Royal, AB",
+    "city": "Calgary Mount Royal",
+    "nickname": "Calgary Mount Royal",
+    "province": "AB",
+    "address": "201, 906 - 16th Avenue SW, Calgary, AB, T2R 1C6",
+    "slug": "calgary-mount-royal-ab-0930"
+  },
+  {
+    "store_id": "0462",
+    "label": "Canadian Tire Calgary Shawnessy SE, AB",
+    "city": "Calgary Shawnessy SE",
+    "nickname": "Calgary Shawnessy SE",
+    "province": "AB",
+    "address": "250 Shawville Way SE, Calgary, AB, T2Y 3E1",
+    "slug": "calgary-shawnessy-se-ab-0462"
+  },
+  {
+    "store_id": "0299",
+    "label": "Canadian Tire Calgary Dalhousie NW, AB",
+    "city": "Calgary Dalhousie NW",
+    "nickname": "Calgary Dalhousie NW",
+    "province": "AB",
+    "address": "5404 Dalton Drive NW, Calgary, AB, T3A 2C2",
+    "slug": "calgary-dalhousie-nw-ab-0299"
+  },
+  {
+    "store_id": "0611",
+    "label": "Canadian Tire Calgary Beacon Hills NW, AB",
+    "city": "Calgary Beacon Hills NW",
+    "nickname": "Calgary Beacon Hills NW",
+    "province": "AB",
+    "address": "11940 Sarcee Trail NW, Calgary, AB, T3R 0A2",
+    "slug": "calgary-beacon-hills-nw-ab-0611"
+  },
+  {
+    "store_id": "0302",
+    "label": "Canadian Tire Calgary Westhills, AB",
+    "city": "Calgary Westhills",
+    "nickname": "Calgary Westhills",
+    "province": "AB",
+    "address": "5200 Richmond Road SW, Calgary, AB, T3E 6M9",
+    "slug": "calgary-westhills-ab-0302"
+  },
+  {
+    "store_id": "0493",
+    "label": "Canadian Tire Cochrane, AB",
+    "city": "Cochrane",
+    "nickname": "Cochrane",
+    "province": "AB",
+    "address": "55 Quarry Street East, Cochrane, AB, T4C 0W6",
+    "slug": "cochrane-ab-0493"
+  },
+  {
+    "store_id": "0699",
+    "label": "Canadian Tire Slave Lake, AB",
+    "city": "Slave Lake",
+    "nickname": "Slave Lake",
+    "province": "AB",
+    "address": "101 Cornerstone, 1500 Main Street SW, Slave Lake, AB, T0G 2A4",
+    "slug": "slave-lake-ab-0699"
+  },
+  {
+    "store_id": "0613",
+    "label": "Canadian Tire Rocky Mountain House, AB",
+    "city": "Rocky Mountain House",
+    "nickname": "Rocky Mountain House",
+    "province": "AB",
+    "address": "5440 - 46th Street, Rocky Mountain House, AB, T4T 1A5",
+    "slug": "rocky-mountain-house-ab-0613"
+  },
+  {
+    "store_id": "0615",
+    "label": "Canadian Tire Drayton Valley, AB",
+    "city": "Drayton Valley",
+    "nickname": "Drayton Valley",
+    "province": "AB",
+    "address": "5201 Power Centre Blvd., Drayton Valley, AB, T7A 0A5",
+    "slug": "drayton-valley-ab-0615"
+  },
+  {
+    "store_id": "0635",
+    "label": "Canadian Tire Fernie, BC",
+    "city": "Fernie",
+    "nickname": "Fernie",
+    "province": "BC",
+    "address": "1791 - 9th Avenue, Fernie, BC, V0B 1M0",
+    "slug": "fernie-bc-0635"
+  },
+  {
+    "store_id": "0469",
+    "label": "Canadian Tire Canmore, AB",
+    "city": "Canmore",
+    "nickname": "Canmore",
+    "province": "AB",
+    "address": "1110 Gateway Avenue, Canmore, AB, T1W 0J8",
+    "slug": "canmore-ab-0469"
+  },
+  {
+    "store_id": "0695",
+    "label": "Canadian Tire Whitecourt, AB",
+    "city": "Whitecourt",
+    "nickname": "Whitecourt",
+    "province": "AB",
+    "address": "4721 - 51st Street, Whitecourt, AB, T7S 0E8",
+    "slug": "whitecourt-ab-0695"
+  },
+  {
+    "store_id": "0395",
+    "label": "Canadian Tire Cranbrook, BC",
+    "city": "Cranbrook",
+    "nickname": "Cranbrook",
+    "province": "BC",
+    "address": "120 - 1500 Cranbrook Street North, Cranbrook, BC, V1C 3S8",
+    "slug": "cranbrook-bc-0395"
+  },
+  {
+    "store_id": "0658",
+    "label": "Canadian Tire Invermere, BC",
+    "city": "Invermere",
+    "nickname": "Invermere",
+    "province": "BC",
+    "address": "480 Sarah Road, Invermere, BC, V0A 1K3",
+    "slug": "invermere-bc-0658"
+  },
+  {
+    "store_id": "0477",
+    "label": "Canadian Tire Edson, AB",
+    "city": "Edson",
+    "nickname": "Edson",
+    "province": "AB",
+    "address": "5919 - 2nd Avenue, Edson, AB, T7E 1L9",
+    "slug": "edson-ab-0477"
+  },
+  {
+    "store_id": "0453",
+    "label": "Canadian Tire Yellowknife, NT",
+    "city": "Yellowknife",
+    "nickname": "Yellowknife",
+    "province": "NT",
+    "address": "328 Old Airport Road, Yellowknife, NT, X1A 3T3",
+    "slug": "yellowknife-nt-0453"
+  },
+  {
+    "store_id": "0474",
+    "label": "Canadian Tire Peace River, AB",
+    "city": "Peace River",
+    "nickname": "Peace River",
+    "province": "AB",
+    "address": "7713 - 100th Avenue, Peace River, AB, T8S 1M5",
+    "slug": "peace-river-ab-0474"
+  },
+  {
+    "store_id": "0908",
+    "label": "Canadian Tire High Level, AB",
+    "city": "High Level",
+    "nickname": "High Level",
+    "province": "AB",
+    "address": "1 Gateway Boulevard, High Level, AB, T0H 1Z0",
+    "slug": "high-level-ab-0908"
+  },
+  {
+    "store_id": "0455",
+    "label": "Canadian Tire Hinton, AB",
+    "city": "Hinton",
+    "nickname": "Hinton",
+    "province": "AB",
+    "address": "868 Carmichael Lane, Hinton, AB, T7V 1Y6",
+    "slug": "hinton-ab-0455"
+  },
+  {
+    "store_id": "0492",
+    "label": "Canadian Tire Castlegar, BC",
+    "city": "Castlegar",
+    "nickname": "Castlegar",
+    "province": "BC",
+    "address": "2000 Columbia Avenue, Castlegar, BC, V1N 2W8",
+    "slug": "castlegar-bc-0492"
+  },
+  {
+    "store_id": "0665",
+    "label": "Canadian Tire Trail, BC",
+    "city": "Trail",
+    "nickname": "Trail",
+    "province": "BC",
+    "address": "8238 Highway 3B, Trail, BC, V1R 4W6",
+    "slug": "trail-bc-0665"
+  },
+  {
+    "store_id": "0344",
+    "label": "Canadian Tire Grande Prairie, AB",
+    "city": "Grande Prairie",
+    "nickname": "Grande Prairie",
+    "province": "AB",
+    "address": "11601 - 104th Avenue, Grande Prairie, AB, T8V 3M7",
+    "slug": "grande-prairie-ab-0344"
+  },
+  {
+    "store_id": "0482",
+    "label": "Canadian Tire Salmon Arm, BC",
+    "city": "Salmon Arm",
+    "nickname": "Salmon Arm",
+    "province": "BC",
+    "address": "300, 1151 - 10th Avenue SW, Salmon Arm, BC, V1E 1T3",
+    "slug": "salmon-arm-bc-0482"
+  },
+  {
+    "store_id": "0361",
+    "label": "Canadian Tire Vernon, BC",
+    "city": "Vernon",
+    "nickname": "Vernon",
+    "province": "BC",
+    "address": "4900 - 27th Street, Unit 345, Vernon, BC, V1T 7G7",
+    "slug": "vernon-bc-0361"
+  },
+  {
+    "store_id": "0661",
+    "label": "Canadian Tire Dawson Creek, BC",
+    "city": "Dawson Creek",
+    "nickname": "Dawson Creek",
+    "province": "BC",
+    "address": "11628 - 8th Street, Dawson Creek, BC, V1G 4R7",
+    "slug": "dawson-creek-bc-0661"
+  },
+  {
+    "store_id": "0353",
+    "label": "Canadian Tire Kelowna, BC",
+    "city": "Kelowna",
+    "nickname": "Kelowna",
+    "province": "BC",
+    "address": "1655 Leckie Road, Kelowna, BC, V1X 6E4",
+    "slug": "kelowna-bc-0353"
+  },
+  {
+    "store_id": "0612",
+    "label": "Canadian Tire Westbank, BC",
+    "city": "Westbank",
+    "nickname": "Westbank",
+    "province": "BC",
+    "address": "101-3550 Carrington Road, Westbank, BC, V4T 2Z8",
+    "slug": "westbank-bc-0612"
+  },
+  {
+    "store_id": "0351",
+    "label": "Canadian Tire Penticton, BC",
+    "city": "Penticton",
+    "nickname": "Penticton",
+    "province": "BC",
+    "address": "960 Railway Street, Penticton, BC, V2A 8C3",
+    "slug": "penticton-bc-0351"
+  },
+  {
+    "store_id": "0698",
+    "label": "Canadian Tire Oliver, BC",
+    "city": "Oliver",
+    "nickname": "Oliver",
+    "province": "BC",
+    "address": "5717 Main Street, Unit 175, Oliver, BC, V0H 1T9",
+    "slug": "oliver-bc-0698"
+  },
+  {
+    "store_id": "0363",
+    "label": "Canadian Tire Fort St. John, BC",
+    "city": "Fort St. John",
+    "nickname": "Fort St. John",
+    "province": "BC",
+    "address": "9716 Old Fort Road, Fort St. John, BC, V1J 0P1",
+    "slug": "fort-st-john-bc-0363"
+  },
+  {
+    "store_id": "0356",
+    "label": "Canadian Tire Kamloops North, BC",
+    "city": "Kamloops North",
+    "nickname": "Kamloops North",
+    "province": "BC",
+    "address": "944 - 8th Street, Kamloops, BC, V2B 2X5",
+    "slug": "kamloops-north-bc-0356"
+  },
+  {
+    "store_id": "0355",
+    "label": "Canadian Tire Kamloops South, BC",
+    "city": "Kamloops South",
+    "nickname": "Kamloops South",
+    "province": "BC",
+    "address": "1441 Hillside Drive, Kamloops, BC, V2E 1A9",
+    "slug": "kamloops-south-bc-0355"
+  },
+  {
+    "store_id": "0696",
+    "label": "Canadian Tire Merritt, BC",
+    "city": "Merritt",
+    "nickname": "Merritt",
+    "province": "BC",
+    "address": "2761 Forksdale Avenue, Merritt, BC, V1K 1R9",
+    "slug": "merritt-bc-0696"
+  },
+  {
+    "store_id": "0438",
+    "label": "Canadian Tire Williams Lake, BC",
+    "city": "Williams Lake",
+    "nickname": "Williams Lake",
+    "province": "BC",
+    "address": "1050 South Lakeside Drive, Williams Lake, BC, V2G 3A6",
+    "slug": "williams-lake-bc-0438"
+  },
+  {
+    "store_id": "0487",
+    "label": "Canadian Tire Quesnel, BC",
+    "city": "Quesnel",
+    "nickname": "Quesnel",
+    "province": "BC",
+    "address": "570 Newman Road, Quesnel, BC, V2J 6X8",
+    "slug": "quesnel-bc-0487"
+  },
+  {
+    "store_id": "0360",
+    "label": "Canadian Tire Prince George, BC",
+    "city": "Prince George",
+    "nickname": "Prince George",
+    "province": "BC",
+    "address": "5008 Domano Blvd., Prince George, BC, V2N 4P6",
+    "slug": "prince-george-bc-0360"
+  },
+  {
+    "store_id": "0433",
+    "label": "Canadian Tire Chilliwack, BC",
+    "city": "Chilliwack",
+    "nickname": "Chilliwack",
+    "province": "BC",
+    "address": "7560 Vedder Road, Chilliwack, BC, V2R 4G7",
+    "slug": "chilliwack-bc-0433"
+  },
+  {
+    "store_id": "0479",
+    "label": "Canadian Tire Mission, BC",
+    "city": "Mission",
+    "nickname": "Mission",
+    "province": "BC",
+    "address": "32545 London Avenue, Mission, BC, V2V 6M7",
+    "slug": "mission-bc-0479"
+  },
+  {
+    "store_id": "0434",
+    "label": "Canadian Tire Abbotsford, BC",
+    "city": "Abbotsford",
+    "nickname": "Abbotsford",
+    "province": "BC",
+    "address": "32513 South Fraser Way, Abbotsford, BC, V2T 4W1",
+    "slug": "abbotsford-bc-0434"
+  },
+  {
+    "store_id": "0481",
+    "label": "Canadian Tire Maple Ridge, BC",
+    "city": "Maple Ridge",
+    "nickname": "Maple Ridge",
+    "province": "BC",
+    "address": "11969 - 200th Street, Maple Ridge, BC, V2X 3M7",
+    "slug": "maple-ridge-bc-0481"
+  },
+  {
+    "store_id": "0426",
+    "label": "Canadian Tire Langley, BC",
+    "city": "Langley",
+    "nickname": "Langley",
+    "province": "BC",
+    "address": "6312 - 200th Street, Langley, BC, V2Y 1A1",
+    "slug": "langley-bc-0426"
+  },
+  {
+    "store_id": "0609",
+    "label": "Canadian Tire Port Coquitlam, BC",
+    "city": "Port Coquitlam",
+    "nickname": "Port Coquitlam",
+    "province": "BC",
+    "address": "2125 Hawkins Street, Port Coquitlam, BC, V3B 0G6",
+    "slug": "port-coquitlam-bc-0609"
+  },
+  {
+    "store_id": "0489",
+    "label": "Canadian Tire Surrey (Whalley), BC",
+    "city": "Surrey (Whalley)",
+    "nickname": "Surrey (Whalley)",
+    "province": "BC",
+    "address": "13665 - 102nd Avenue, Surrey, BC, V3T 1N7",
+    "slug": "surrey-whalley-bc-0489"
+  },
+  {
+    "store_id": "0608",
+    "label": "Canadian Tire Coquitlam, BC",
+    "city": "Coquitlam",
+    "nickname": "Coquitlam",
+    "province": "BC",
+    "address": "1200 Seguin Drive, Coquitlam, BC, V3K 6W8",
+    "slug": "coquitlam-bc-0608"
+  },
+  {
+    "store_id": "0622",
+    "label": "Canadian Tire White Rock, BC",
+    "city": "White Rock",
+    "nickname": "White Rock",
+    "province": "BC",
+    "address": "3059 - 152nd Street, White Rock, BC, V4P 3K1",
+    "slug": "white-rock-bc-0622"
+  },
+  {
+    "store_id": "0443",
+    "label": "Canadian Tire Surrey (Newton), BC",
+    "city": "Surrey (Newton)",
+    "nickname": "Surrey (Newton)",
+    "province": "BC",
+    "address": "7599 King George Blvd., Surrey, BC, V3W 5B1",
+    "slug": "surrey-newton-bc-0443"
+  },
+  {
+    "store_id": "0678",
+    "label": "Canadian Tire Surrey (Scott Road), BC",
+    "city": "Surrey (Scott Road)",
+    "nickname": "Surrey (Scott Road)",
+    "province": "BC",
+    "address": "7878 - 120th Street, Surrey, BC, V3W 3N3",
+    "slug": "surrey-scott-road-bc-0678"
+  },
+  {
+    "store_id": "0483",
+    "label": "Canadian Tire Squamish, BC",
+    "city": "Squamish",
+    "nickname": "Squamish",
+    "province": "BC",
+    "address": "1851 Mamquam Road, Squamish, BC, V8B 0H5",
+    "slug": "squamish-bc-0483"
+  },
+  {
+    "store_id": "0603",
+    "label": "Canadian Tire Burnaby South, BC",
+    "city": "Burnaby South",
+    "nickname": "Burnaby South",
+    "province": "BC",
+    "address": "7200 Market Crossing, Burnaby, BC, V5J 0A2",
+    "slug": "burnaby-south-bc-0603"
+  },
+  {
+    "store_id": "0601",
+    "label": "Canadian Tire North Vancouver Main, BC",
+    "city": "North Vancouver Main",
+    "nickname": "North Vancouver Main",
+    "province": "BC",
+    "address": "1350 Main Street, North Vancouver, BC, V7J 1C6",
+    "slug": "north-vancouver-main-bc-0601"
+  },
+  {
+    "store_id": "0604",
+    "label": "Canadian Tire Vancouver, Grandview & Boundary, BC",
+    "city": "Vancouver, Grandview & Boundary",
+    "nickname": "Vancouver, Grandview & Boundary",
+    "province": "BC",
+    "address": "2830 Bentall Street, Vancouver, BC, V5M 4H4",
+    "slug": "vancouver-grandview-boundary-bc-0604"
+  },
+  {
+    "store_id": "0389",
+    "label": "Canadian Tire Cambie & 7th, BC",
+    "city": "Cambie & 7th",
+    "nickname": "Cambie & 7th",
+    "province": "BC",
+    "address": "2290 Cambie Street, Vancouver, BC, V5Z 2T7",
+    "slug": "cambie-7th-bc-0389"
+  },
+  {
+    "store_id": "0605",
+    "label": "Canadian Tire Vancouver, SW Marine, BC",
+    "city": "Vancouver, SW Marine",
+    "nickname": "Vancouver, SW Marine",
+    "province": "BC",
+    "address": "8277 Ontario Street, Vancouver, BC, V5X 0A7",
+    "slug": "vancouver-sw-marine-bc-0605"
+  },
+  {
+    "store_id": "0610",
+    "label": "Canadian Tire S. Richmond, BC",
+    "city": "S. Richmond",
+    "nickname": "S. Richmond",
+    "province": "BC",
+    "address": "11388 Steveston Hwy, Richmond, BC, V7A 5J5",
+    "slug": "s-richmond-bc-0610"
+  },
+  {
+    "store_id": "0606",
+    "label": "Canadian Tire Richmond, BC",
+    "city": "Richmond",
+    "nickname": "Richmond",
+    "province": "BC",
+    "address": "3500 No. 3 Road, Richmond, BC, V6X 2C1",
+    "slug": "richmond-bc-0606"
+  },
+  {
+    "store_id": "0910",
+    "label": "Canadian Tire Tsawwassen, BC",
+    "city": "Tsawwassen",
+    "nickname": "Tsawwassen",
+    "province": "BC",
+    "address": "4949 Canoe Pass Way, Unit 200, Tsawwassen, BC, V4M 0B2",
+    "slug": "tsawwassen-bc-0910"
+  },
+  {
+    "store_id": "0935",
+    "label": "Canadian Tire Victoria Service Centre, BC",
+    "city": "Victoria Service Centre",
+    "nickname": "Victoria Service Centre",
+    "province": "BC",
+    "address": "3993 Cedar Hill Road, Victoria, BC, V8N 4M9",
+    "slug": "victoria-service-centre-bc-0935"
+  },
+  {
+    "store_id": "0932",
+    "label": "Canadian Tire North Saanich, BC",
+    "city": "North Saanich",
+    "nickname": "North Saanich",
+    "province": "BC",
+    "address": "10300 McDonald Park Road, North Saanich, BC, V8L 5X7",
+    "slug": "north-saanich-bc-0932"
+  },
+  {
+    "store_id": "0365",
+    "label": "Canadian Tire Victoria Hillside Centre, BC",
+    "city": "Victoria Hillside Centre",
+    "nickname": "Victoria Hillside Centre",
+    "province": "BC",
+    "address": "1610 Hillside Avenue, Victoria, BC, V8T 2C5",
+    "slug": "victoria-hillside-centre-bc-0365"
+  },
+  {
+    "store_id": "0636",
+    "label": "Canadian Tire Sechelt, BC",
+    "city": "Sechelt",
+    "nickname": "Sechelt",
+    "province": "BC",
+    "address": "4380 Sunshine Coast Highway, Sechelt, BC, V7Z 0B1",
+    "slug": "sechelt-bc-0636"
+  },
+  {
+    "store_id": "0369",
+    "label": "Canadian Tire Victoria Royal Oak, BC",
+    "city": "Victoria Royal Oak",
+    "nickname": "Victoria Royal Oak",
+    "province": "BC",
+    "address": "801 Royal Oak Drive, Victoria, BC, V8X 4V1",
+    "slug": "victoria-royal-oak-bc-0369"
+  },
+  {
+    "store_id": "0368",
+    "label": "Canadian Tire Victoria View Royal, BC",
+    "city": "Victoria View Royal",
+    "nickname": "Victoria View Royal",
+    "province": "BC",
+    "address": "1519 Admirals Road, Victoria, BC, V9A 2P8",
+    "slug": "victoria-view-royal-bc-0368"
+  },
+  {
+    "store_id": "0366",
+    "label": "Canadian Tire Victoria Langford, BC",
+    "city": "Victoria Langford",
+    "nickname": "Victoria Langford",
+    "province": "BC",
+    "address": "855 Langford Parkway, Victoria, BC, V9B 4V5",
+    "slug": "victoria-langford-bc-0366"
+  },
+  {
+    "store_id": "0466",
+    "label": "Canadian Tire Duncan, BC",
+    "city": "Duncan",
+    "nickname": "Duncan",
+    "province": "BC",
+    "address": "2929 Green Road, Duncan, BC, V9L 0C1",
+    "slug": "duncan-bc-0466"
+  },
+  {
+    "store_id": "0362",
+    "label": "Canadian Tire Nanaimo, BC",
+    "city": "Nanaimo",
+    "nickname": "Nanaimo",
+    "province": "BC",
+    "address": "4585 Uplands Drive, Nanaimo, BC, V9T 6M8",
+    "slug": "nanaimo-bc-0362"
+  },
+  {
+    "store_id": "0480",
+    "label": "Canadian Tire Powell River, BC",
+    "city": "Powell River",
+    "nickname": "Powell River",
+    "province": "BC",
+    "address": "4720 Joyce Avenue, Powell River, BC, V8A 3B5",
+    "slug": "powell-river-bc-0480"
+  },
+  {
+    "store_id": "0490",
+    "label": "Canadian Tire Parksville, BC",
+    "city": "Parksville",
+    "nickname": "Parksville",
+    "province": "BC",
+    "address": "822 Island Highway West, Parksville, BC, V9P 2B7",
+    "slug": "parksville-bc-0490"
+  },
+  {
+    "store_id": "0488",
+    "label": "Canadian Tire Port Alberni, BC",
+    "city": "Port Alberni",
+    "nickname": "Port Alberni",
+    "province": "BC",
+    "address": "3550 Johnston Road, Unit 51, Port Alberni, BC, V9Y 7W8",
+    "slug": "port-alberni-bc-0488"
+  },
+  {
+    "store_id": "0350",
+    "label": "Canadian Tire Courtenay, BC",
+    "city": "Courtenay",
+    "nickname": "Courtenay",
+    "province": "BC",
+    "address": "2801 Cliffe Avenue, Courtenay, BC, V9N 2L8",
+    "slug": "courtenay-bc-0350"
+  },
+  {
+    "store_id": "0437",
+    "label": "Canadian Tire Campbell River, BC",
+    "city": "Campbell River",
+    "nickname": "Campbell River",
+    "province": "BC",
+    "address": "1444 Island Hwy, Campbell River, BC, V9W 8C9",
+    "slug": "campbell-river-bc-0437"
+  },
+  {
+    "store_id": "0631",
+    "label": "Canadian Tire Smithers, BC",
+    "city": "Smithers",
+    "nickname": "Smithers",
+    "province": "BC",
+    "address": "3221 Hwy 16, PO Box 669, Smithers, BC, V0J 2N0",
+    "slug": "smithers-bc-0631"
+  },
+  {
+    "store_id": "0486",
+    "label": "Canadian Tire Terrace, BC",
+    "city": "Terrace",
+    "nickname": "Terrace",
+    "province": "BC",
+    "address": "5100 Highway 16 West, Terrace, BC, V8G 5S5",
+    "slug": "terrace-bc-0486"
   }
 ]


### PR DESCRIPTION
## Summary
- replace the Canadian Tire store directory with a complete list of 505 Canadian locations including store IDs, addresses, and per-branch slugs for the location selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0035a5110832e9137c27c918aaf13