### PR TITLE
Add nationwide RONA directory support

### DIFF
--- a/best-deals.html
+++ b/best-deals.html
@@ -573,6 +573,45 @@
         return `data/${s}/${c}.json`;
       }
 
+      async function loadRonaDirectory(){
+        const store = STORES.find(entry => entry.slug === 'rona');
+        if(!store) return;
+        try{
+          const res = await fetch('data/rona/stores.json', {cache:'no-store'});
+          if(!res.ok) return;
+          const json = await res.json();
+          if(!Array.isArray(json)) return;
+          const seen = new Map();
+          for(const branch of store.branches ?? []){
+            if(!branch?.slug) continue;
+            seen.set(branch.slug, {...branch, hasData: branch.hasData !== false});
+          }
+          for(const entry of json){
+            if(!entry || typeof entry !== 'object') continue;
+            const rawSlug = typeof entry.slug === 'string' && entry.slug ? entry.slug : slugify(entry.label || entry.city || entry.storeNumber);
+            if(!rawSlug) continue;
+            const label = (entry.label || entry.city || rawSlug).trim();
+            const city = (entry.city || label).trim();
+            const province = entry.province || '';
+            const storeNumber = entry.storeNumber || '';
+            const hasData = entry.hasData === true;
+            const previous = seen.get(rawSlug) || {};
+            seen.set(rawSlug, {
+              ...previous,
+              label,
+              slug: rawSlug,
+              city,
+              province,
+              storeNumber,
+              hasData: previous.hasData === true || hasData
+            });
+          }
+          store.branches = Array.from(seen.values()).sort((a,b)=>a.label.localeCompare(b.label,'fr'));
+        }catch(err){
+          console.warn('Impossible de charger les succursales Rona', err);
+        }
+      }
+
       async function loadCanadianTireDirectory(){
         const store = STORES.find(entry => entry.slug === 'canadian-tire');
         if(!store) return;
@@ -660,6 +699,7 @@
         for(const store of STORES){
           const branches = store.branches ?? [];
           for(const branch of branches){
+            if(branch?.hasData === false) continue;
             const path = filePathFor(store, branch);
             if(path) tasks.push({store, branch, path});
           }
@@ -688,6 +728,7 @@
       populateStoreFilter();
       storeFilter.addEventListener('change', render);
 
+      await loadRonaDirectory();
       await loadCanadianTireDirectory();
       try{
         const result = await fetchAllDeals();

--- a/data/rona/stores.json
+++ b/data/rona/stores.json
@@ -1,0 +1,3242 @@
+[
+  {
+    "storeNumber": "41320",
+    "label": "RONA Saint-Jérôme",
+    "city": "Saint-Jérôme",
+    "province": "Québec",
+    "slug": "saint-jerome",
+    "hasData": true
+  },
+  {
+    "storeNumber": "1877",
+    "label": "RONA Ferronnerie St-Janvier Inc. / Mirabel",
+    "city": "Mirabel",
+    "province": "Québec",
+    "slug": "rona-ferronnerie-st-janvier-inc-mirabel-1877",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43390",
+    "label": "RONA Blainville",
+    "city": "Blainville",
+    "province": "Québec",
+    "slug": "rona-blainville-43390",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3655",
+    "label": "RONA Centre de Rénovation Sainte-Thérèse",
+    "city": "Sainte-Thérèse",
+    "province": "Québec",
+    "slug": "rona-centre-de-renovation-sainte-therese-3655",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76090",
+    "label": "RONA+ Rosemère",
+    "city": "Rosemère",
+    "province": "Québec",
+    "slug": "rona-rosemere-76090",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7869",
+    "label": "RONA Bois-des-Filion",
+    "city": "Bois-des-Filion",
+    "province": "Québec",
+    "slug": "rona-bois-des-filion-7869",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41340",
+    "label": "L'entrepôt RONA Saint-Eustache",
+    "city": "Saint-Eustache",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-saint-eustache-41340",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1270",
+    "label": "Marchand propriétaire Arthur Rivest Inc.",
+    "city": "Sainte-Julienne",
+    "province": "Québec",
+    "slug": "marchand-proprietaire-arthur-rivest-inc-1270",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7611",
+    "label": "RONA Vimont / Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "rona-vimont-laval-7611",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41090",
+    "label": "L'entrepôt RONA Mascouche",
+    "city": "Mascouche",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-mascouche-41090",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8815",
+    "label": "Matériaux Godin et Fils Lachute",
+    "city": "Lachute",
+    "province": "Québec",
+    "slug": "materiaux-godin-et-fils-lachute-8815",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41010",
+    "label": "L'entrepôt RONA Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "laval",
+    "hasData": true
+  },
+  {
+    "storeNumber": "1868",
+    "label": "RONA Centre de rénovation Réal Riopel Inc. / Entrelacs",
+    "city": "Entrelacs",
+    "province": "Québec",
+    "slug": "rona-centre-de-renovation-real-riopel-inc-entrelacs-1868",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76030",
+    "label": "RONA+ Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "rona-laval-76030",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76140",
+    "label": "RONA+",
+    "city": "Ste-Dorothée Laval",
+    "province": "Québec",
+    "slug": "rona-76140",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3425",
+    "label": "RONA Quincaillerie Benoit Inc. / Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-benoit-inc-laval-3425",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4921",
+    "label": "RONA Quincaillerie Métro / Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-metro-laval-4921",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4117",
+    "label": "RONA Quincaillerie Guy Racine / Laval",
+    "city": "Laval",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-guy-racine-laval-4117",
+    "hasData": false
+  },
+  {
+    "storeNumber": "44020",
+    "label": "RONA",
+    "city": "Pont-Viau Laval",
+    "province": "Québec",
+    "slug": "rona-44020",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7995",
+    "label": "RONA Tinsco / Rawdon",
+    "city": "Rawdon",
+    "province": "Québec",
+    "slug": "rona-tinsco-rawdon-7995",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6460",
+    "label": "Centre de rénovation Oka",
+    "city": "Oka",
+    "province": "Québec",
+    "slug": "centre-de-renovation-oka-6460",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1008",
+    "label": "RONA Major & Major Inc. / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-major-amp-major-inc-montreal-1008",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76020",
+    "label": "RONA+ Anjou",
+    "city": "Anjou",
+    "province": "Québec",
+    "slug": "rona-anjou-76020",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41450",
+    "label": "RONA Pierrefonds",
+    "city": "Pierrefonds",
+    "province": "Québec",
+    "slug": "rona-pierrefonds-41450",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76040",
+    "label": "RONA+ Pointe-Claire",
+    "city": "Pointe-Claire",
+    "province": "Québec",
+    "slug": "rona-pointe-claire-76040",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76050",
+    "label": "RONA+ Marché",
+    "city": "Central Montréal",
+    "province": "Québec",
+    "slug": "montreal",
+    "hasData": true
+  },
+  {
+    "storeNumber": "41440",
+    "label": "RONA+ Charlemagne",
+    "city": "Charlemagne",
+    "province": "Québec",
+    "slug": "rona-charlemagne-41440",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41020",
+    "label": "L'entrepôt RONA Saint-Laurent",
+    "city": "Saint-Laurent",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-saint-laurent-41020",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1166",
+    "label": "RONA Villeray / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-villeray-montreal-1166",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41110",
+    "label": "L'entrepôt RONA Anjou",
+    "city": "Anjou",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-anjou-41110",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1705",
+    "label": "RONA Quincaillerie Beaubien / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-beaubien-montreal-1705",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6465",
+    "label": "RONA Des Ormeaux / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-des-ormeaux-montreal-6465",
+    "hasData": false
+  },
+  {
+    "storeNumber": "42480",
+    "label": "RONA Repentigny",
+    "city": "Repentigny",
+    "province": "Québec",
+    "slug": "rona-repentigny-42480",
+    "hasData": false
+  },
+  {
+    "storeNumber": "781",
+    "label": "RONA Quincaillerie C. Bélanger Ltée / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-c-belanger-ltee-montreal-781",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7430",
+    "label": "RONA Quincaillerie",
+    "city": "du Plateau Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-7430",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76190",
+    "label": "RONA+",
+    "city": "Vaudreuil Vaudreuil-Dorion",
+    "province": "Québec",
+    "slug": "rona-76190",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4761",
+    "label": "RONA Quincaillerie Delorimier Inc. / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-delorimier-inc-montreal-4761",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1296",
+    "label": "RONA Quincaillerie Jean Hebert Inc. / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-jean-hebert-inc-montreal-1296",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7590",
+    "label": "Quincaillerie",
+    "city": "Rachel Montréal",
+    "province": "Québec",
+    "slug": "quincaillerie-7590",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7271",
+    "label": "RONA Bois Idéal Inc. / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-bois-ideal-inc-montreal-7271",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3414",
+    "label": "RONA Pincourt",
+    "city": "Pincourt",
+    "province": "Québec",
+    "slug": "rona-pincourt-3414",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2892",
+    "label": "RONA Quincaillerie Maisonneuve / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-maisonneuve-montreal-2892",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2885",
+    "label": "Quincaillerie",
+    "city": "Moussette Montréal",
+    "province": "Québec",
+    "slug": "quincaillerie-2885",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6363",
+    "label": "Roch Gauthier & Fils (Les Cèdres)",
+    "city": "Les Cedres",
+    "province": "Québec",
+    "slug": "roch-gauthier-amp-fils-les-cedres-6363",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76100",
+    "label": "RONA+",
+    "city": "NDG Montréal",
+    "province": "Québec",
+    "slug": "rona-76100",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43200",
+    "label": "RONA Montréal (Réno",
+    "city": "DG) Montréal",
+    "province": "Québec",
+    "slug": "rona-montreal-reno-43200",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1849",
+    "label": "RONA Centre du bricoleur Lachine / Lachine",
+    "city": "Lachine",
+    "province": "Québec",
+    "slug": "rona-centre-du-bricoleur-lachine-lachine-1849",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43370",
+    "label": "RONA Boucherville",
+    "city": "Boucherville",
+    "province": "Québec",
+    "slug": "rona-boucherville-43370",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2909",
+    "label": "RONA Quincaillerie Notre-Dame St-Henri / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-notre-dame-st-henri-montreal-2909",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8805",
+    "label": "Matériaux Godin et Fils Grenville",
+    "city": "Grenville",
+    "province": "Québec",
+    "slug": "materiaux-godin-et-fils-grenville-8805",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6098",
+    "label": "RONA Centre de Rénovation St-Patrick / Montréal",
+    "city": "Montréal",
+    "province": "Québec",
+    "slug": "rona-centre-de-renovation-st-patrick-montreal-6098",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76220",
+    "label": "RONA+ LaSalle",
+    "city": "LaSalle",
+    "province": "Québec",
+    "slug": "rona-lasalle-76220",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5203",
+    "label": "RONA Quincaillerie de la Promenade / Verdun",
+    "city": "Verdun",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-de-la-promenade-verdun-5203",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76250",
+    "label": "RONA+ Boucherville",
+    "city": "Boucherville",
+    "province": "Québec",
+    "slug": "rona-boucherville-76250",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1429",
+    "label": "RONA Ferronnerie A. Leduc Inc. / Longueuil",
+    "city": "Longueuil",
+    "province": "Québec",
+    "slug": "rona-ferronnerie-a-leduc-inc-longueuil-1429",
+    "hasData": false
+  },
+  {
+    "storeNumber": "42420",
+    "label": "RONA Longueuil",
+    "city": "(Roland-Therrien) Longueuil",
+    "province": "Québec",
+    "slug": "rona-longueuil-42420",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8760",
+    "label": "Groupe Matériaux Godin L'Orignal",
+    "city": "L'Orignal",
+    "province": "Ontario",
+    "slug": "groupe-materiaux-godin-l-orignal-8760",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43020",
+    "label": "RONA Longueuil",
+    "city": "(Jacques-Cartier) Longueuil",
+    "province": "Québec",
+    "slug": "rona-longueuil-43020",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43360",
+    "label": "RONA Boucherville",
+    "city": "Boucherville",
+    "province": "Québec",
+    "slug": "rona-boucherville-43360",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41330",
+    "label": "L'entrepôt RONA",
+    "city": "Joliette Notre-Dame-des-Prairies",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-41330",
+    "hasData": false
+  },
+  {
+    "storeNumber": "44280",
+    "label": "RONA Châteauguay",
+    "city": "Principale Châteauguay",
+    "province": "Québec",
+    "slug": "rona-chateauguay-44280",
+    "hasData": false
+  },
+  {
+    "storeNumber": "42310",
+    "label": "RONA Châteauguay",
+    "city": "Châteauguay",
+    "province": "Québec",
+    "slug": "rona-chateauguay-42310",
+    "hasData": false
+  },
+  {
+    "storeNumber": "16332",
+    "label": "RONA Forget / Mont-Tremblant",
+    "city": "Mont-Tremblant",
+    "province": "Québec",
+    "slug": "rona-forget-mont-tremblant-16332",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2090",
+    "label": "RONA Quincaillerie A. Pouliot Beauharnois",
+    "city": "Beauharnois",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-a-pouliot-beauharnois-2090",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76070",
+    "label": "RONA+",
+    "city": "St-Hubert Saint-Hubert",
+    "province": "Québec",
+    "slug": "rona-76070",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76010",
+    "label": "RONA+ Brossard",
+    "city": "Brossard",
+    "province": "Québec",
+    "slug": "rona-brossard-76010",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43030",
+    "label": "RONA Sainte-Julie",
+    "city": "Sainte-Julie",
+    "province": "Québec",
+    "slug": "rona-sainte-julie-43030",
+    "hasData": false
+  },
+  {
+    "storeNumber": "44050",
+    "label": "RONA Saint-Constant",
+    "city": "Saint-Constant",
+    "province": "Québec",
+    "slug": "rona-saint-constant-44050",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41040",
+    "label": "L'entrepôt RONA",
+    "city": "Saint-Bruno-de-Montarville Saint-Bruno",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-41040",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41460",
+    "label": "L'entrepôt RONA Brossard",
+    "city": "(Dix/30) Brossard",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-brossard-41460",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6354",
+    "label": "RONA Roch Gauthier & Fils / Saint-Polycarpe",
+    "city": "Saint-Polycarpe",
+    "province": "Québec",
+    "slug": "rona-roch-gauthier-amp-fils-saint-polycarpe-6354",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76180",
+    "label": "RONA+ Candiac",
+    "city": "Candiac",
+    "province": "Québec",
+    "slug": "rona-candiac-76180",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2091",
+    "label": "RONA Quincaillerie A. Pouliot Sainte-Martine",
+    "city": "Sainte-Martine",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-a-pouliot-sainte-martine-2091",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7751",
+    "label": "RONA Quincaillerie Larocque / Salaberry-de-Valleyfield",
+    "city": "Salaberry-de-Valleyfield",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-larocque-salaberry-de-valleyfield-7751",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41520",
+    "label": "RONA Beloeil",
+    "city": "Beloeil",
+    "province": "Québec",
+    "slug": "rona-beloeil-41520",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2092",
+    "label": "RONA Quincaillerie A. Pouliot Saint-Rémi",
+    "city": "Saint-Rémi",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-a-pouliot-saint-remi-2092",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8825",
+    "label": "Matériaux Godin et Fils Namur",
+    "city": "Namur",
+    "province": "Québec",
+    "slug": "materiaux-godin-et-fils-namur-8825",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43050",
+    "label": "RONA",
+    "city": "Tracy Sorel-Tracy",
+    "province": "Québec",
+    "slug": "rona-43050",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7807",
+    "label": "RONA Quincaillerie Piette / Saint-Gabriel-de-Brandon",
+    "city": "Saint-Gabriel-de-Brandon",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-piette-saint-gabriel-de-brandon-7807",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7100",
+    "label": "RONA R.S. D'Amour & Fils Inc. / Ormstown",
+    "city": "Ormstown",
+    "province": "Québec",
+    "slug": "rona-r-s-d-amour-amp-fils-inc-ormstown-7100",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41350",
+    "label": "L'entrepôt RONA Saint-Jean-sur-Richelieu",
+    "city": "Saint-Jean-sur-Richelieu",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-saint-jean-sur-richelieu-41350",
+    "hasData": false
+  },
+  {
+    "storeNumber": "397",
+    "label": "RONA",
+    "city": "Iberville Saint-Jean-sur-Richelieu",
+    "province": "Québec",
+    "slug": "rona-397",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5179",
+    "label": "RONA Quincaillerie André Laberge Inc. / Huntingdon",
+    "city": "Huntingdon",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-andre-laberge-inc-huntingdon-5179",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41400",
+    "label": "L'entrepôt RONA Saint-Hyacinthe",
+    "city": "Saint-Hyacinthe",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-saint-hyacinthe-41400",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8336",
+    "label": "RONA Outaouais Papineauville",
+    "city": "Papineauville",
+    "province": "Québec",
+    "slug": "rona-outaouais-papineauville-8336",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2360",
+    "label": "RONA de la Haute Matawinie / Saint-Zénon",
+    "city": "Saint-Zénon",
+    "province": "Québec",
+    "slug": "rona-de-la-haute-matawinie-saint-zenon-2360",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6775",
+    "label": "RONA Ducharme & Frère /",
+    "city": "Saint-Césaire Saint-Cesaire",
+    "province": "Québec",
+    "slug": "rona-ducharme-amp-frere-6775",
+    "hasData": false
+  },
+  {
+    "storeNumber": "10035",
+    "label": "RONA Quincaillerie Hemmingford",
+    "city": "Inc Hemmingford",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-hemmingford-10035",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2742",
+    "label": "RONA Ducharme & Frère / Saint-Pie",
+    "city": "Saint-Pie",
+    "province": "Québec",
+    "slug": "rona-ducharme-amp-frere-saint-pie-2742",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1326",
+    "label": "RONA Deslongchamps / Rivière-Rouge",
+    "city": "Rivière-Rouge",
+    "province": "Québec",
+    "slug": "rona-deslongchamps-riviere-rouge-1326",
+    "hasData": false
+  },
+  {
+    "storeNumber": "11050",
+    "label": "RONA Quincaillerie de Lacolle Inc.",
+    "city": "Lacolle",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-de-lacolle-inc-11050",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1930",
+    "label": "RONA de la Haute Matawinie / Saint-Michel-des-Saints",
+    "city": "Saint-Michel-des-Saints",
+    "province": "Québec",
+    "slug": "rona-de-la-haute-matawinie-saint-michel-des-saints-1930",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3850",
+    "label": "RONA Ducharme & Frère / Farnham",
+    "city": "Farnham",
+    "province": "Québec",
+    "slug": "rona-ducharme-amp-frere-farnham-3850",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2228",
+    "label": "RONA J.Lalonde & Fils / Hammond",
+    "city": "Hammond",
+    "province": "Ontario",
+    "slug": "rona-j-lalonde-amp-fils-hammond-2228",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2444",
+    "label": "RONA J.Lalonde & Fils / Rockland",
+    "city": "Rockland",
+    "province": "Ontario",
+    "slug": "rona-j-lalonde-amp-fils-rockland-2444",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41380",
+    "label": "L'entrepôt RONA Granby",
+    "city": "Granby",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-granby-41380",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8335",
+    "label": "RONA Outaouais",
+    "city": "Buckingham Gatineau",
+    "province": "Québec",
+    "slug": "rona-outaouais-8335",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43190",
+    "label": "RONA Gatineau",
+    "city": "(BSRB) Gatineau",
+    "province": "Québec",
+    "slug": "rona-gatineau-43190",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76230",
+    "label": "RONA+ Drummondville",
+    "city": "Drummondville",
+    "province": "Québec",
+    "slug": "rona-drummondville-76230",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6944",
+    "label": "RONA La Coop Agricole d'Embrun",
+    "city": "Ltd Embrun",
+    "province": "Ontario",
+    "slug": "rona-la-coop-agricole-d-embrun-6944",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2570",
+    "label": "RONA Rosaire Mathieu Inc. / Wickham",
+    "city": "Wickham",
+    "province": "Québec",
+    "slug": "rona-rosaire-mathieu-inc-wickham-2570",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43100",
+    "label": "RONA Cowansville",
+    "city": "Cowansville",
+    "province": "Québec",
+    "slug": "rona-cowansville-43100",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43090",
+    "label": "RONA Bromont",
+    "city": "Bromont",
+    "province": "Québec",
+    "slug": "rona-bromont-43090",
+    "hasData": false
+  },
+  {
+    "storeNumber": "88009",
+    "label": "RONA+",
+    "city": "Orléans Orleans",
+    "province": "Ontario",
+    "slug": "rona-88009",
+    "hasData": false
+  },
+  {
+    "storeNumber": "13466",
+    "label": "RONA Marché Bouvette Inc. / Saint-Cyrille-de-Wendover",
+    "city": "Saint-Cyrille-de-Wendover",
+    "province": "Québec",
+    "slug": "rona-marche-bouvette-inc-saint-cyrille-de-wendover-13466",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41050",
+    "label": "L'entrepôt RONA Trois-Rivières",
+    "city": "Trois-Rivières",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-trois-rivieres-41050",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8333",
+    "label": "RONA Outaouais Val-des-Monts",
+    "city": "Val-des-Monts",
+    "province": "Québec",
+    "slug": "rona-outaouais-val-des-monts-8333",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6711",
+    "label": "RONA J. St-Cyr & Frères Ltée / Notre-Dame-du-Mont-Carmel",
+    "city": "Notre-Dame-du-Mont-Carmel",
+    "province": "Québec",
+    "slug": "rona-j-st-cyr-amp-freres-ltee-notre-dame-du-mont-carmel-6711",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43160",
+    "label": "RONA Shawinigan",
+    "city": "Shawinigan",
+    "province": "Québec",
+    "slug": "rona-shawinigan-43160",
+    "hasData": false
+  },
+  {
+    "storeNumber": "10888",
+    "label": "RONA",
+    "city": "Maloney Gatineau",
+    "province": "Québec",
+    "slug": "rona-10888",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83708",
+    "label": "RONA+ Gloucester",
+    "city": "Gloucester",
+    "province": "Ontario",
+    "slug": "rona-gloucester-83708",
+    "hasData": false
+  },
+  {
+    "storeNumber": "17053",
+    "label": "RONA Thomas Caya Inc. / Bon-Conseil",
+    "city": "Bon-Conseil",
+    "province": "Québec",
+    "slug": "rona-thomas-caya-inc-bon-conseil-17053",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43120",
+    "label": "RONA Knowlton",
+    "city": "Knowlton",
+    "province": "Québec",
+    "slug": "rona-knowlton-43120",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41070",
+    "label": "L'entrepôt RONA Gatineau",
+    "city": "Gatineau",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-gatineau-41070",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8035",
+    "label": "RONA Les Matériaux Laverdure Inc. / Maricourt",
+    "city": "Maricourt",
+    "province": "Québec",
+    "slug": "rona-les-materiaux-laverdure-inc-maricourt-8035",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43140",
+    "label": "RONA",
+    "city": "Grand-Mere Shawinigan",
+    "province": "Québec",
+    "slug": "rona-43140",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76080",
+    "label": "RONA+",
+    "city": "Hull Gatineau",
+    "province": "Québec",
+    "slug": "rona-76080",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7671",
+    "label": "RONA Deslongchamps / Mont-Laurier",
+    "city": "Mont-Laurier",
+    "province": "Québec",
+    "slug": "rona-deslongchamps-mont-laurier-7671",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83089",
+    "label": "RONA+ Nepean",
+    "city": "Nepean",
+    "province": "Ontario",
+    "slug": "rona-nepean-83089",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41180",
+    "label": "L'entrepôt RONA Gatineau (Le",
+    "city": "Plateau) Gatineau",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-gatineau-le-41180",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55550",
+    "label": "Home & Garden RONA / Nepean",
+    "city": "Nepean",
+    "province": "Ontario",
+    "slug": "home-amp-garden-rona-nepean-55550",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2300",
+    "label": "RONA Manotick",
+    "city": "Manotick",
+    "province": "Ontario",
+    "slug": "rona-manotick-2300",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41190",
+    "label": "RONA Gatineau",
+    "city": "(Aylmer) Gatineau",
+    "province": "Québec",
+    "slug": "rona-gatineau-41190",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12871",
+    "label": "RONA Quincaillerie R-Cube Inc. / Wakefield",
+    "city": "Wakefield",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-r-cube-inc-wakefield-12871",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2032",
+    "label": "RONA Giroux & Giroux / Mansonville",
+    "city": "Mansonville",
+    "province": "Québec",
+    "slug": "rona-giroux-amp-giroux-mansonville-2032",
+    "hasData": false
+  },
+  {
+    "storeNumber": "88008",
+    "label": "RONA+",
+    "city": "Kanata Stittsville",
+    "province": "Ontario",
+    "slug": "rona-88008",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1470",
+    "label": "RONA Deslongchamps Maniwaki",
+    "city": "Maniwaki",
+    "province": "Québec",
+    "slug": "rona-deslongchamps-maniwaki-1470",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6270",
+    "label": "RONA Woodlawn",
+    "city": "Woodlawn",
+    "province": "Ontario",
+    "slug": "rona-woodlawn-6270",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41100",
+    "label": "RONA+ Sherbrooke",
+    "city": "Sherbrooke",
+    "province": "Québec",
+    "slug": "rona-sherbrooke-41100",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6260",
+    "label": "RONA Carp",
+    "city": "Carp",
+    "province": "Ontario",
+    "slug": "rona-carp-6260",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33690",
+    "label": "RONA Carleton Place",
+    "city": "Carleton Place",
+    "province": "Ontario",
+    "slug": "rona-carleton-place-33690",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6917",
+    "label": "RONA M. Sullivan & Son Limited / Arnprior",
+    "city": "Arnprior",
+    "province": "Ontario",
+    "slug": "rona-m-sullivan-amp-son-limited-arnprior-6917",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33520",
+    "label": "RONA Smiths Falls",
+    "city": "Smiths Falls",
+    "province": "Ontario",
+    "slug": "rona-smiths-falls-33520",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8464",
+    "label": "RONA Matériaux Prévost / Cookshire",
+    "city": "Cookshire",
+    "province": "Québec",
+    "slug": "rona-materiaux-prevost-cookshire-8464",
+    "hasData": false
+  },
+  {
+    "storeNumber": "121",
+    "label": "Placide Martineau Inc.",
+    "city": "(Saint-Flavien) Saint-Flavien",
+    "province": "Québec",
+    "slug": "placide-martineau-inc-121",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43320",
+    "label": "RONA Thetford Mines",
+    "city": "Thetford Mines",
+    "province": "Québec",
+    "slug": "rona-thetford-mines-43320",
+    "hasData": false
+  },
+  {
+    "storeNumber": "124",
+    "label": "Placide Martineau Inc. (centre",
+    "city": "village) Saint-Apollinaire",
+    "province": "Québec",
+    "slug": "placide-martineau-inc-centre-124",
+    "hasData": false
+  },
+  {
+    "storeNumber": "120",
+    "label": "Placide Martineau Inc.",
+    "city": "(Saint-Apollinaire) Saint-Apollinaire",
+    "province": "Québec",
+    "slug": "placide-martineau-inc-120",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5099",
+    "label": "RONA Bernard Breton Inc. / Saint-Narcisse-de-Beaurivage",
+    "city": "Saint-Narcisse-de-Beaurivage",
+    "province": "Québec",
+    "slug": "rona-bernard-breton-inc-saint-narcisse-de-beaurivage-5099",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76210",
+    "label": "RONA+",
+    "city": "Ste-Foy Québec",
+    "province": "Québec",
+    "slug": "rona-76210",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43210",
+    "label": "RONA Québec",
+    "city": "Québec",
+    "province": "Québec",
+    "slug": "rona-quebec-43210",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2710",
+    "label": "Quincaillerie S.C.",
+    "city": "Roy Saint-Ephrem-de-Beauce",
+    "province": "Québec",
+    "slug": "quincaillerie-s-c-2710",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41030",
+    "label": "RONA+ Québec",
+    "city": "Québec",
+    "province": "Québec",
+    "slug": "rona-quebec-41030",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7895",
+    "label": "RONA Quincaillerie Corriveau Inc. / Québec",
+    "city": "Québec",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-corriveau-inc-quebec-7895",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1498",
+    "label": "RONA Quincaillerie St-Sacrement Inc. / Québec",
+    "city": "Québec",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-st-sacrement-inc-quebec-1498",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43300",
+    "label": "RONA",
+    "city": "Ste-Marie Sainte-Marie",
+    "province": "Québec",
+    "slug": "rona-43300",
+    "hasData": false
+  },
+  {
+    "storeNumber": "10385",
+    "label": "Quincaillerie",
+    "city": "Crémazie Québec",
+    "province": "Québec",
+    "slug": "quincaillerie-10385",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7685",
+    "label": "Quincaillerie",
+    "city": "St-Jean-Baptiste Québec",
+    "province": "Québec",
+    "slug": "quincaillerie-7685",
+    "hasData": false
+  },
+  {
+    "storeNumber": "42390",
+    "label": "RONA Lévis",
+    "city": "Lévis",
+    "province": "Québec",
+    "slug": "rona-levis-42390",
+    "hasData": false
+  },
+  {
+    "storeNumber": "76120",
+    "label": "RONA+",
+    "city": "Beauport Québec",
+    "province": "Québec",
+    "slug": "rona-76120",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8280",
+    "label": "RONA Petawawa",
+    "city": "Petawawa",
+    "province": "Ontario",
+    "slug": "rona-petawawa-8280",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2851",
+    "label": "RONA Verona Hardware",
+    "city": "Limited Verona",
+    "province": "Ontario",
+    "slug": "rona-verona-hardware-2851",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43310",
+    "label": "RONA Saint-Georges",
+    "city": "Saint-Georges",
+    "province": "Québec",
+    "slug": "rona-saint-georges-43310",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55300",
+    "label": "Home & Garden / Kingston",
+    "city": "Kingston",
+    "province": "Ontario",
+    "slug": "home-amp-garden-kingston-55300",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82922",
+    "label": "RONA+ Kingston",
+    "city": "Kingston",
+    "province": "Ontario",
+    "slug": "rona-kingston-82922",
+    "hasData": false
+  },
+  {
+    "storeNumber": "137",
+    "label": "RONA Quincaillerie Saint-Camille-de-Lellis",
+    "city": "Saint-Camille-de-Lellis",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-saint-camille-de-lellis-137",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1641",
+    "label": "RONA Bancroft",
+    "city": "Bancroft",
+    "province": "Ontario",
+    "slug": "rona-bancroft-1641",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5240",
+    "label": "RONA Jos Proulx Inc. / L'Islet",
+    "city": "L'Islet",
+    "province": "Québec",
+    "slug": "rona-jos-proulx-inc-l-islet-5240",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82872",
+    "label": "RONA+ Belleville",
+    "city": "Belleville",
+    "province": "Ontario",
+    "slug": "rona-belleville-82872",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8133",
+    "label": "RONA Rollins Building Supplies / Stirling",
+    "city": "Stirling",
+    "province": "Ontario",
+    "slug": "rona-rollins-building-supplies-stirling-8133",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7370",
+    "label": "RONA Roberval",
+    "city": "Roberval",
+    "province": "Québec",
+    "slug": "rona-roberval-7370",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33240",
+    "label": "RONA Trenton",
+    "city": "Trenton",
+    "province": "Ontario",
+    "slug": "rona-trenton-33240",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1812",
+    "label": "RONA Ferlac Inc. /",
+    "city": "Saint-Félicien Saint-Felicien",
+    "province": "Québec",
+    "slug": "rona-ferlac-inc-1812",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33320",
+    "label": "RONA Campbellford",
+    "city": "Campbellford",
+    "province": "Ontario",
+    "slug": "rona-campbellford-33320",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12454",
+    "label": "RONA La Pocatière",
+    "city": "La Pocatière",
+    "province": "Québec",
+    "slug": "rona-la-pocatiere-12454",
+    "hasData": false
+  },
+  {
+    "storeNumber": "42360",
+    "label": "RONA Alma",
+    "city": "Alma",
+    "province": "Québec",
+    "slug": "rona-alma-42360",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12988",
+    "label": "RONA Normandin",
+    "city": "Normandin",
+    "province": "Québec",
+    "slug": "rona-normandin-12988",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41060",
+    "label": "L'entrepôt RONA Chicoutimi",
+    "city": "Chicoutimi",
+    "province": "Québec",
+    "slug": "l-entrepot-rona-chicoutimi-41060",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6766",
+    "label": "RONA Dolbeau-Mistassini",
+    "city": "Dolbeau-Mistassini",
+    "province": "Québec",
+    "slug": "rona-dolbeau-mistassini-6766",
+    "hasData": false
+  },
+  {
+    "storeNumber": "11443",
+    "label": "RONA Quincaillerie",
+    "city": "L'Ascension L'Ascension-de-Notre-Seigneur",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-11443",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1338",
+    "label": "RONA Bois Turcotte Ltée / Val-d'Or",
+    "city": "Val-d'Or",
+    "province": "Québec",
+    "slug": "rona-bois-turcotte-ltee-val-d-or-1338",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8569",
+    "label": "RONA Cobourg Building",
+    "city": "Supplies Cobourg",
+    "province": "Ontario",
+    "slug": "rona-cobourg-building-8569",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8669",
+    "label": "RONA Port Hope Building Supplies",
+    "city": "Port Hope",
+    "province": "Ontario",
+    "slug": "rona-port-hope-building-supplies-8669",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7020",
+    "label": "RONA Centre de Renovation Barraute",
+    "city": "Barraute",
+    "province": "Québec",
+    "slug": "rona-centre-de-renovation-barraute-7020",
+    "hasData": false
+  },
+  {
+    "storeNumber": "810",
+    "label": "RONA Bois Turcotte Ltée / Malartic",
+    "city": "Malartic",
+    "province": "Québec",
+    "slug": "rona-bois-turcotte-ltee-malartic-810",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33180",
+    "label": "RONA Lindsay",
+    "city": "Lindsay",
+    "province": "Ontario",
+    "slug": "rona-lindsay-33180",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12453",
+    "label": "RONA Rivière-du-Loup",
+    "city": "Rivière-Du-Loup",
+    "province": "Québec",
+    "slug": "rona-riviere-du-loup-12453",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2131",
+    "label": "RONA The Hardware Store Inc. / Newcastle",
+    "city": "Newcastle",
+    "province": "Ontario",
+    "slug": "rona-the-hardware-store-inc-newcastle-2131",
+    "hasData": false
+  },
+  {
+    "storeNumber": "16397",
+    "label": "RONA Dufour Laurian / Sacre-Coeur-Saguenay",
+    "city": "Sacre-Coeur-Saguenay",
+    "province": "Québec",
+    "slug": "rona-dufour-laurian-sacre-coeur-saguenay-16397",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4930",
+    "label": "Bracebridge RONA",
+    "city": "Bracebridge",
+    "province": "Ontario",
+    "slug": "bracebridge-rona-4930",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8885",
+    "label": "RONA Lakeview Builders Supplies / North Bay North",
+    "city": "Bay",
+    "province": "Ontario",
+    "slug": "rona-lakeview-builders-supplies-north-bay-north-8885",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4733",
+    "label": "RONA Matériaux Dubreuil / Lebel-sur-Quevillon",
+    "city": "Lebel-sur-Quevillon",
+    "province": "Québec",
+    "slug": "rona-materiaux-dubreuil-lebel-sur-quevillon-4733",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8963",
+    "label": "RONA North Bay Lakeview",
+    "city": "North Bay",
+    "province": "Ontario",
+    "slug": "rona-north-bay-lakeview-8963",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4945",
+    "label": "Port Perry RONA",
+    "city": "Port Perry",
+    "province": "Ontario",
+    "slug": "port-perry-rona-4945",
+    "hasData": false
+  },
+  {
+    "storeNumber": "924",
+    "label": "RONA Bois Turcotte Ltée / Amos",
+    "city": "Amos",
+    "province": "Québec",
+    "slug": "rona-bois-turcotte-ltee-amos-924",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82888",
+    "label": "RONA+ Whitby",
+    "city": "Whitby",
+    "province": "Ontario",
+    "slug": "rona-whitby-82888",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82741",
+    "label": "RONA+ S. Oshawa",
+    "city": "Oshawa",
+    "province": "Ontario",
+    "slug": "rona-s-oshawa-82741",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33220",
+    "label": "RONA Uxbridge",
+    "city": "Uxbridge",
+    "province": "Ontario",
+    "slug": "rona-uxbridge-33220",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83201",
+    "label": "RONA+ Pickering",
+    "city": "Pickering",
+    "province": "Ontario",
+    "slug": "rona-pickering-83201",
+    "hasData": false
+  },
+  {
+    "storeNumber": "904",
+    "label": "RONA / Chibougamau",
+    "city": "Chibougamau",
+    "province": "Québec",
+    "slug": "rona-chibougamau-904",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43340",
+    "label": "RONA Rouyn-Noranda",
+    "city": "Rouyn-Noranda",
+    "province": "Québec",
+    "slug": "rona-rouyn-noranda-43340",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82494",
+    "label": "RONA+ N. Scarborough",
+    "city": "Scarborough",
+    "province": "Ontario",
+    "slug": "rona-n-scarborough-82494",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55050",
+    "label": "RONA",
+    "city": "Markham Unionville",
+    "province": "Ontario",
+    "slug": "rona-55050",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43230",
+    "label": "RONA Edmundston",
+    "city": "Edmundston",
+    "province": "New Brunswick",
+    "slug": "rona-edmundston-43230",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2179",
+    "label": "RONA Parry Sound",
+    "city": "PARRY SOUND",
+    "province": "Ontario",
+    "slug": "rona-parry-sound-2179",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82642",
+    "label": "RONA+ East Gwillimbury East",
+    "city": "Gwillimbury",
+    "province": "Ontario",
+    "slug": "rona-east-gwillimbury-east-82642",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55340",
+    "label": "Home & Garden RONA / Scarborough",
+    "city": "Midland Scarborough",
+    "province": "Ontario",
+    "slug": "home-amp-garden-rona-scarborough-55340",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33270",
+    "label": "RONA New Liskeard",
+    "city": "New Liskeard",
+    "province": "Ontario",
+    "slug": "rona-new-liskeard-33270",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55200",
+    "label": "Home & Garden RONA / Barrie",
+    "city": "Barrie",
+    "province": "Ontario",
+    "slug": "home-amp-garden-rona-barrie-55200",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82934",
+    "label": "RONA+ S. Barrie",
+    "city": "Barrie",
+    "province": "Ontario",
+    "slug": "rona-s-barrie-82934",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4925",
+    "label": "Bradford RONA",
+    "city": "Bradford",
+    "province": "Ontario",
+    "slug": "bradford-rona-4925",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82633",
+    "label": "RONA+ Golden",
+    "city": "Mile Scarborough",
+    "province": "Ontario",
+    "slug": "rona-golden-82633",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33290",
+    "label": "RONA Midland",
+    "city": "Midland",
+    "province": "Ontario",
+    "slug": "rona-midland-33290",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55030",
+    "label": "RONA North York (Sheppard)",
+    "city": "North York",
+    "province": "Ontario",
+    "slug": "rona-north-york-sheppard-55030",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82632",
+    "label": "RONA+ Maple",
+    "city": "Maple",
+    "province": "Ontario",
+    "slug": "rona-maple-82632",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33880",
+    "label": "RONA Schomberg",
+    "city": "Schomberg",
+    "province": "Ontario",
+    "slug": "rona-schomberg-33880",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82640",
+    "label": "RONA+ York",
+    "city": "York",
+    "province": "Ontario",
+    "slug": "rona-york-82640",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55130",
+    "label": "Home & Garden RONA / Toronto",
+    "city": "Stockyards Toronto",
+    "province": "Ontario",
+    "slug": "home-amp-garden-rona-toronto-55130",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55090",
+    "label": "RONA Etobicoke (Martin",
+    "city": "Grove) Etobicoke",
+    "province": "Ontario",
+    "slug": "rona-etobicoke-martin-55090",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83096",
+    "label": "RONA+ Etobicoke",
+    "city": "Etobicoke",
+    "province": "Ontario",
+    "slug": "rona-etobicoke-83096",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55010",
+    "label": "RONA Mississauga",
+    "city": "(Dundas) Mississauga",
+    "province": "Ontario",
+    "slug": "rona-mississauga-55010",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33740",
+    "label": "RONA",
+    "city": "St-Catharines St Catharines",
+    "province": "Ontario",
+    "slug": "rona-33740",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4910",
+    "label": "Fort Erie RONA",
+    "city": "Fort Erie",
+    "province": "Ontario",
+    "slug": "fort-erie-rona-4910",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83092",
+    "label": "RONA+ Niagara Falls",
+    "city": "Niagara Falls",
+    "province": "Ontario",
+    "slug": "rona-niagara-falls-83092",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82631",
+    "label": "RONA+ S. Brampton",
+    "city": "Brampton",
+    "province": "Ontario",
+    "slug": "rona-s-brampton-82631",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82493",
+    "label": "RONA+ N. Brampton",
+    "city": "Brampton",
+    "province": "Ontario",
+    "slug": "rona-n-brampton-82493",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83162",
+    "label": "RONA+ Central Mississauga",
+    "city": "Mississauga",
+    "province": "Ontario",
+    "slug": "rona-central-mississauga-83162",
+    "hasData": false
+  },
+  {
+    "storeNumber": "41680",
+    "label": "RONA Rimouski",
+    "city": "Rimouski",
+    "province": "Québec",
+    "slug": "rona-rimouski-41680",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55460",
+    "label": "RONA Oakville (Windsor",
+    "city": "Drive) Oakville",
+    "province": "Ontario",
+    "slug": "rona-oakville-windsor-55460",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55120",
+    "label": "RONA Mississauga (Erin",
+    "city": "Mills) Mississauga",
+    "province": "Ontario",
+    "slug": "rona-mississauga-erin-55120",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7549",
+    "label": "RONA Matagami",
+    "city": "Matagami",
+    "province": "Québec",
+    "slug": "rona-matagami-7549",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33730",
+    "label": "Welland RONA",
+    "city": "Welland",
+    "province": "Ontario",
+    "slug": "welland-rona-33730",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4915",
+    "label": "Welland RONA Building Centre",
+    "city": "Welland",
+    "province": "Ontario",
+    "slug": "welland-rona-building-centre-4915",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55070",
+    "label": "RONA Oakville (Speers",
+    "city": "Road) Oakville",
+    "province": "Ontario",
+    "slug": "rona-oakville-speers-55070",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55250",
+    "label": "RONA Georgetown",
+    "city": "Georgetown",
+    "province": "Ontario",
+    "slug": "rona-georgetown-55250",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6507",
+    "label": "RONA Joël Builders Supplies Ltd. / Wahnapitae",
+    "city": "Wahnapitae",
+    "province": "Ontario",
+    "slug": "rona-joel-builders-supplies-ltd-wahnapitae-6507",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33780",
+    "label": "RONA Grimsby",
+    "city": "Grimsby",
+    "province": "Ontario",
+    "slug": "rona-grimsby-33780",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83327",
+    "label": "RONA+ Milton",
+    "city": "Milton",
+    "province": "Ontario",
+    "slug": "rona-milton-83327",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83062",
+    "label": "RONA+ N. Burlington",
+    "city": "Burlington",
+    "province": "Ontario",
+    "slug": "rona-n-burlington-83062",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33560",
+    "label": "RONA Hamilton",
+    "city": "(Parkdale) Hamilton",
+    "province": "Ontario",
+    "slug": "rona-hamilton-33560",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82413",
+    "label": "RONA+ Hamilton N.E.",
+    "city": "Hamilton",
+    "province": "Ontario",
+    "slug": "rona-hamilton-n-e-82413",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83085",
+    "label": "RONA+ N. Sudbury",
+    "city": "Sudbury",
+    "province": "Ontario",
+    "slug": "rona-n-sudbury-83085",
+    "hasData": false
+  },
+  {
+    "storeNumber": "55330",
+    "label": "RONA+",
+    "city": "Waterdown Dundas",
+    "province": "Ontario",
+    "slug": "rona-55330",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33040",
+    "label": "RONA Hamilton (Rymal",
+    "city": "Road) Hamilton",
+    "province": "Ontario",
+    "slug": "rona-hamilton-rymal-33040",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33080",
+    "label": "RONA Val Caron",
+    "city": "Val Caron",
+    "province": "Ontario",
+    "slug": "rona-val-caron-33080",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8281",
+    "label": "RONA Dawson Building",
+    "city": "Centres Guelph",
+    "province": "Ontario",
+    "slug": "rona-dawson-building-8281",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82971",
+    "label": "RONA+ Ancaster",
+    "city": "Ancaster",
+    "province": "Ontario",
+    "slug": "rona-ancaster-82971",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8290",
+    "label": "RONA Elora Building",
+    "city": "Supplies Elora",
+    "province": "Ontario",
+    "slug": "rona-elora-building-8290",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83224",
+    "label": "RONA+ Cambridge",
+    "city": "Cambridge",
+    "province": "Ontario",
+    "slug": "rona-cambridge-83224",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4261",
+    "label": "RONA Roland Tremblay & Fils Inc. / Baie-Comeau",
+    "city": "Baie-Comeau",
+    "province": "Québec",
+    "slug": "rona-roland-tremblay-amp-fils-inc-baie-comeau-4261",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82492",
+    "label": "RONA+ Brantford",
+    "city": "Brantford",
+    "province": "Ontario",
+    "slug": "rona-brantford-82492",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83710",
+    "label": "RONA+ Kitchener",
+    "city": "Kitchener",
+    "province": "Ontario",
+    "slug": "rona-kitchener-83710",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12930",
+    "label": "RONA Moffatt & Powell / Hanover",
+    "city": "Hanover",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-hanover-12930",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82889",
+    "label": "RONA+ Waterloo West",
+    "city": "Waterloo",
+    "province": "Ontario",
+    "slug": "rona-waterloo-west-82889",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4920",
+    "label": "Miller Lake RONA Miller",
+    "city": "Lake",
+    "province": "Ontario",
+    "slug": "miller-lake-rona-miller-4920",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4171",
+    "label": "RONA Quincaillerie Grégoire & Fils Inc. / Matane",
+    "city": "Matane",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-gregoire-amp-fils-inc-matane-4171",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4935",
+    "label": "Southampton RONA",
+    "city": "Southampton",
+    "province": "Ontario",
+    "slug": "southampton-rona-4935",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33420",
+    "label": "RONA Simcoe",
+    "city": "Simcoe",
+    "province": "Ontario",
+    "slug": "rona-simcoe-33420",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8315",
+    "label": "RONA Tim's And Co.Home Centre / Little Current",
+    "city": "Little Current",
+    "province": "Ontario",
+    "slug": "rona-tim-s-and-co-home-centre-little-current-8315",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4850",
+    "label": "Kincardine RONA",
+    "city": "Kincardine",
+    "province": "Ontario",
+    "slug": "kincardine-rona-4850",
+    "hasData": false
+  },
+  {
+    "storeNumber": "117",
+    "label": "RONA Sonnenburg Hardware Ltd / Massey",
+    "city": "Massey",
+    "province": "Ontario",
+    "slug": "rona-sonnenburg-hardware-ltd-massey-117",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12830",
+    "label": "RONA Moffatt & Powell / Mitchell",
+    "city": "Mitchell",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-mitchell-12830",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12870",
+    "label": "RONA Moffatt & Powell / Tillsonburg",
+    "city": "Tillsonburg",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-tillsonburg-12870",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7940",
+    "label": "RONA Timmins",
+    "city": "Timmins",
+    "province": "Ontario",
+    "slug": "rona-timmins-7940",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12950",
+    "label": "RONA Moffatt & Powell / Seaforth",
+    "city": "Seaforth",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-seaforth-12950",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1155",
+    "label": "Springfield RONA",
+    "city": "Springfield",
+    "province": "Ontario",
+    "slug": "springfield-rona-1155",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12910",
+    "label": "RONA Moffatt & Powell / Exeter",
+    "city": "Exeter",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-exeter-12910",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82641",
+    "label": "RONA+ N.W. London",
+    "city": "London",
+    "province": "Ontario",
+    "slug": "rona-n-w-london-82641",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12820",
+    "label": "RONA Moffatt & Powell / London",
+    "city": "London",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-london-12820",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83063",
+    "label": "RONA+ S.W. London",
+    "city": "London",
+    "province": "Ontario",
+    "slug": "rona-s-w-london-83063",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33430",
+    "label": "RONA",
+    "city": "St-Thomas St Thomas",
+    "province": "Ontario",
+    "slug": "rona-33430",
+    "hasData": false
+  },
+  {
+    "storeNumber": "13177",
+    "label": "RONA Algoma Builders Supply / Elliot Lake",
+    "city": "Elliot Lake",
+    "province": "Ontario",
+    "slug": "rona-algoma-builders-supply-elliot-lake-13177",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12970",
+    "label": "RONA Moffatt & Powell / Grand Bend",
+    "city": "Grand Bend",
+    "province": "Ontario",
+    "slug": "rona-moffatt-amp-powell-grand-bend-12970",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1608",
+    "label": "Store Mag",
+    "city": "New Richmond",
+    "province": "Québec",
+    "slug": "store-mag-1608",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12920",
+    "label": "Moffatt & Powell RONA Strathroy",
+    "city": "Strathroy",
+    "province": "Ontario",
+    "slug": "moffatt-amp-powell-rona-strathroy-12920",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1165",
+    "label": "Dutton RONA",
+    "city": "Dutton",
+    "province": "Ontario",
+    "slug": "dutton-rona-1165",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3340",
+    "label": "RONA Moncton",
+    "city": "Moncton",
+    "province": "New Brunswick",
+    "slug": "rona-moncton-3340",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7730",
+    "label": "RONA MSJ Building Supplies",
+    "city": "Barrington Passage",
+    "province": "Nova Scotia",
+    "slug": "rona-msj-building-supplies-7730",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1145",
+    "label": "Rodney RONA",
+    "city": "Rodney",
+    "province": "Ontario",
+    "slug": "rodney-rona-1145",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43220",
+    "label": "RONA Bois de construction",
+    "city": "Sept-Iles Cartier Port-Cartier",
+    "province": "Québec",
+    "slug": "rona-bois-de-construction-43220",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3595",
+    "label": "RONA Eudore A Melanson et Fils Ltée / Cocagne",
+    "city": "Cocagne",
+    "province": "New Brunswick",
+    "slug": "rona-eudore-a-melanson-et-fils-ltee-cocagne-3595",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83066",
+    "label": "RONA+ Sarnia",
+    "city": "Sarnia",
+    "province": "Ontario",
+    "slug": "rona-sarnia-83066",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3070",
+    "label": "RONA Kapuskasing",
+    "city": "Kapuskasing",
+    "province": "Ontario",
+    "slug": "rona-kapuskasing-3070",
+    "hasData": false
+  },
+  {
+    "storeNumber": "43280",
+    "label": "RONA Bois de construction",
+    "city": "Sept-Iles Cartier Sept-Iles",
+    "province": "Québec",
+    "slug": "rona-bois-de-construction-43280",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33570",
+    "label": "RONA Chatham",
+    "city": "Chatham",
+    "province": "Ontario",
+    "slug": "rona-chatham-33570",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33610",
+    "label": "RONA Wallaceburg",
+    "city": "Wallaceburg",
+    "province": "Ontario",
+    "slug": "rona-wallaceburg-33610",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6970",
+    "label": "RONA Maurice Goupil Inc. / Chandler",
+    "city": "Chandler",
+    "province": "Québec",
+    "slug": "rona-maurice-goupil-inc-chandler-6970",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6240",
+    "label": "RONA GG'S Building Centre (Moose Factory)",
+    "city": "Moose Factory",
+    "province": "Ontario",
+    "slug": "rona-gg-s-building-centre-moose-factory-6240",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1855",
+    "label": "RONA Sauve's Home Centre / Tilbury",
+    "city": "Tilbury",
+    "province": "Ontario",
+    "slug": "rona-sauve-s-home-centre-tilbury-1855",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6245",
+    "label": "RONA GG'S Building Centre",
+    "city": "(Moosonee) Moosonee",
+    "province": "Ontario",
+    "slug": "rona-gg-s-building-centre-6245",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1860",
+    "label": "RONA Sauve's Home Centre / Comber",
+    "city": "Comber",
+    "province": "Ontario",
+    "slug": "rona-sauve-s-home-centre-comber-1860",
+    "hasData": false
+  },
+  {
+    "storeNumber": "243",
+    "label": "RONA Laurent Roy Gaspé Ltée / Gaspé",
+    "city": "Gaspé",
+    "province": "Québec",
+    "slug": "rona-laurent-roy-gaspe-ltee-gaspe-243",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1850",
+    "label": "RONA Sauve's Home Centre Ltd / Belle River",
+    "city": "Belle River",
+    "province": "Ontario",
+    "slug": "rona-sauve-s-home-centre-ltd-belle-river-1850",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1075",
+    "label": "RONA Tantallon",
+    "city": "Upper Tantallon",
+    "province": "Nova Scotia",
+    "slug": "rona-tantallon-1075",
+    "hasData": false
+  },
+  {
+    "storeNumber": "33150",
+    "label": "RONA Leamington",
+    "city": "Leamington",
+    "province": "Ontario",
+    "slug": "rona-leamington-33150",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5600",
+    "label": "RONA Matériaux Armand",
+    "city": "Dumaresq Gaspé",
+    "province": "Québec",
+    "slug": "rona-materiaux-armand-5600",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83712",
+    "label": "RONA+ Windsor East",
+    "city": "Windsor",
+    "province": "Ontario",
+    "slug": "rona-windsor-east-83712",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83010",
+    "label": "RONA+ Windsor South",
+    "city": "Windsor",
+    "province": "Ontario",
+    "slug": "rona-windsor-south-83010",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1065",
+    "label": "RONA Halifax",
+    "city": "Halifax",
+    "province": "Nova Scotia",
+    "slug": "rona-halifax-1065",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1070",
+    "label": "RONA Elmsdale",
+    "city": "Elmsdale",
+    "province": "Nova Scotia",
+    "slug": "rona-elmsdale-1070",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3330",
+    "label": "RONA Charlottetown",
+    "city": "Charlottetown",
+    "province": "Prince Edward Island",
+    "slug": "rona-charlottetown-3330",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5380",
+    "label": "RONA Le Quincaillier Fermont",
+    "city": "Fermont",
+    "province": "Québec",
+    "slug": "rona-le-quincaillier-fermont-5380",
+    "hasData": false
+  },
+  {
+    "storeNumber": "3021",
+    "label": "RONA Quincaillerie Turbo Inc. / Cap-aux-Meules",
+    "city": "Cap-aux-Meules",
+    "province": "Québec",
+    "slug": "rona-quincaillerie-turbo-inc-cap-aux-meules-3021",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4505",
+    "label": "RONA Fitz's Enterprises Limited / Wabush",
+    "city": "Wabush",
+    "province": "Newfoundland and Labrador",
+    "slug": "rona-fitz-s-enterprises-limited-wabush-4505",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8175",
+    "label": "RONA Family First",
+    "city": "Hardware Arichat",
+    "province": "Nova Scotia",
+    "slug": "rona-family-first-8175",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8949",
+    "label": "RONA Don Ray Lumber / Sydney Mines",
+    "city": "Sydney Mines",
+    "province": "Nova Scotia",
+    "slug": "rona-don-ray-lumber-sydney-mines-8949",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8989",
+    "label": "RONA Stephen's Home Centre / Sydney",
+    "city": "Sydney",
+    "province": "Nova Scotia",
+    "slug": "rona-stephen-s-home-centre-sydney-8989",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2201",
+    "label": "Derrible",
+    "city": "SPM",
+    "province": "Saint-Pierre et Miquelon",
+    "slug": "derrible-2201",
+    "hasData": false
+  },
+  {
+    "storeNumber": "630",
+    "label": "Rona Dryden",
+    "city": "Dryden",
+    "province": "Ontario",
+    "slug": "rona-dryden-630",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6208",
+    "label": "RONA Lac du Bonnet",
+    "city": "Lac du Bonnet",
+    "province": "Manitoba",
+    "slug": "rona-lac-du-bonnet-6208",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1629",
+    "label": "RONA La Broquerie Lumber / La Broquerie",
+    "city": "La Broquerie",
+    "province": "Manitoba",
+    "slug": "rona-la-broquerie-lumber-la-broquerie-1629",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83718",
+    "label": "RONA+ Winnipeg East",
+    "city": "Winnipeg",
+    "province": "Manitoba",
+    "slug": "rona-winnipeg-east-83718",
+    "hasData": false
+  },
+  {
+    "storeNumber": "620",
+    "label": "RONA Gimli",
+    "city": "Gimli",
+    "province": "Manitoba",
+    "slug": "rona-gimli-620",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83285",
+    "label": "RONA+ South Winnipeg",
+    "city": "Winnipeg",
+    "province": "Manitoba",
+    "slug": "rona-south-winnipeg-83285",
+    "hasData": false
+  },
+  {
+    "storeNumber": "64890",
+    "label": "RONA+ Winnipeg Central",
+    "city": "Winnipeg",
+    "province": "Manitoba",
+    "slug": "rona-winnipeg-central-64890",
+    "hasData": false
+  },
+  {
+    "storeNumber": "625",
+    "label": "RONA Teulon",
+    "city": "Teulon",
+    "province": "Manitoba",
+    "slug": "rona-teulon-625",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8824",
+    "label": "RONA Valley Enterprises Ltd. / Rosenort",
+    "city": "Rosenort",
+    "province": "Manitoba",
+    "slug": "rona-valley-enterprises-ltd-rosenort-8824",
+    "hasData": false
+  },
+  {
+    "storeNumber": "64670",
+    "label": "RONA Winkler",
+    "city": "Winkler",
+    "province": "Manitoba",
+    "slug": "rona-winkler-64670",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5688",
+    "label": "RONA Portage La Prairie",
+    "city": "Portage la Prairie",
+    "province": "Manitoba",
+    "slug": "rona-portage-la-prairie-5688",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2235",
+    "label": "RONA J&G Supply / Brandon",
+    "city": "Brandon",
+    "province": "Manitoba",
+    "slug": "rona-j-g-supply-brandon-2235",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2027",
+    "label": "RONA Delmar's Hardware Ltd / Melita",
+    "city": "Melita",
+    "province": "Manitoba",
+    "slug": "rona-delmar-s-hardware-ltd-melita-2027",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6075",
+    "label": "RONA Weyburn",
+    "city": "Weyburn",
+    "province": "Saskatchewan",
+    "slug": "rona-weyburn-6075",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8622",
+    "label": "RONA Pinecrest Lumber Ltd. / Nipawin",
+    "city": "Nipawin",
+    "province": "Saskatchewan",
+    "slug": "rona-pinecrest-lumber-ltd-nipawin-8622",
+    "hasData": false
+  },
+  {
+    "storeNumber": "63840",
+    "label": "Home & Garden RONA / Regina",
+    "city": "Regina",
+    "province": "Saskatchewan",
+    "slug": "home-amp-garden-rona-regina-63840",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83208",
+    "label": "RONA+ S. Regina",
+    "city": "Regina",
+    "province": "Saskatchewan",
+    "slug": "rona-s-regina-83208",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2527",
+    "label": "RONA Humboldt Lumber Mart",
+    "city": "Ltd Humboldt",
+    "province": "Saskatchewan",
+    "slug": "rona-humboldt-lumber-mart-2527",
+    "hasData": false
+  },
+  {
+    "storeNumber": "63670",
+    "label": "RONA Moose Jaw",
+    "city": "Moose Jaw",
+    "province": "Saskatchewan",
+    "slug": "rona-moose-jaw-63670",
+    "hasData": false
+  },
+  {
+    "storeNumber": "63600",
+    "label": "RONA Prince Albert",
+    "city": "Prince Albert",
+    "province": "Saskatchewan",
+    "slug": "rona-prince-albert-63600",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6285",
+    "label": "RONA La Ronge",
+    "city": "La Ronge",
+    "province": "Saskatchewan",
+    "slug": "rona-la-ronge-6285",
+    "hasData": false
+  },
+  {
+    "storeNumber": "63650",
+    "label": "Home & Garden RONA / Saskatoon",
+    "city": "Saskatoon",
+    "province": "Saskatchewan",
+    "slug": "home-amp-garden-rona-saskatoon-63650",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83163",
+    "label": "RONA+ W. Saskatoon",
+    "city": "Saskatoon",
+    "province": "Saskatchewan",
+    "slug": "rona-w-saskatoon-83163",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4470",
+    "label": "Goodsoil",
+    "city": "Lumber Goodsoil",
+    "province": "Saskatchewan",
+    "slug": "goodsoil-4470",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6680",
+    "label": "RONA Macklin",
+    "city": "Macklin",
+    "province": "Saskatchewan",
+    "slug": "rona-macklin-6680",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66200",
+    "label": "RONA Lloydminster",
+    "city": "Lloydminster",
+    "province": "Alberta",
+    "slug": "rona-lloydminster-66200",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8122",
+    "label": "RONA Cold Lake",
+    "city": "Cold Lake",
+    "province": "Alberta",
+    "slug": "rona-cold-lake-8122",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66210",
+    "label": "RONA Medicine Hat",
+    "city": "Medicine Hat",
+    "province": "Alberta",
+    "slug": "rona-medicine-hat-66210",
+    "hasData": false
+  },
+  {
+    "storeNumber": "4359",
+    "label": "Vermilion RONA",
+    "city": "Vermilion",
+    "province": "Alberta",
+    "slug": "vermilion-rona-4359",
+    "hasData": false
+  },
+  {
+    "storeNumber": "6733",
+    "label": "RONA Cal's Hardware Ltd / Elk Point",
+    "city": "ELK POINT",
+    "province": "Alberta",
+    "slug": "rona-cal-s-hardware-ltd-elk-point-6733",
+    "hasData": false
+  },
+  {
+    "storeNumber": "62450",
+    "label": "RONA Fort McMurray",
+    "city": "Fort McMurray",
+    "province": "Alberta",
+    "slug": "rona-fort-mcmurray-62450",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7645",
+    "label": "RONA Vegreville",
+    "city": "Vegreville",
+    "province": "Alberta",
+    "slug": "rona-vegreville-7645",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66150",
+    "label": "RONA Camrose",
+    "city": "Camrose",
+    "province": "Alberta",
+    "slug": "rona-camrose-66150",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83230",
+    "label": "RONA+ Lethbridge",
+    "city": "Lethbridge",
+    "province": "Alberta",
+    "slug": "rona-lethbridge-83230",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66190",
+    "label": "RONA Lethbridge",
+    "city": "Lethbridge",
+    "province": "Alberta",
+    "slug": "rona-lethbridge-66190",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66390",
+    "label": "RONA Sherwood Park (Wye Road)",
+    "city": "Sherwood Park",
+    "province": "Alberta",
+    "slug": "rona-sherwood-park-wye-road-66390",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83309",
+    "label": "RONA+ Sherwood Park",
+    "city": "Sherwood Park",
+    "province": "Alberta",
+    "slug": "rona-sherwood-park-83309",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83158",
+    "label": "RONA+ N.E. Edmonton",
+    "city": "Edmonton",
+    "province": "Alberta",
+    "slug": "rona-n-e-edmonton-83158",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66160",
+    "label": "RONA Edmonton",
+    "city": "(Southside) Edmonton",
+    "province": "Alberta",
+    "slug": "rona-edmonton-66160",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82952",
+    "label": "RONA+ Edmonton",
+    "city": "- South Common Edmonton",
+    "province": "Alberta",
+    "slug": "rona-edmonton-82952",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66320",
+    "label": "RONA Strathmore",
+    "city": "Strathmore",
+    "province": "Alberta",
+    "slug": "rona-strathmore-66320",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66470",
+    "label": "RONA Leduc",
+    "city": "Leduc",
+    "province": "Alberta",
+    "slug": "rona-leduc-66470",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83313",
+    "label": "RONA+ St. Albert St.",
+    "city": "Albert",
+    "province": "Alberta",
+    "slug": "rona-st-albert-st-83313",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83211",
+    "label": "RONA+",
+    "city": "Edmonton-West Edmonton",
+    "province": "Alberta",
+    "slug": "rona-83211",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66220",
+    "label": "RONA Red Deer (North)",
+    "city": "Red Deer",
+    "province": "Alberta",
+    "slug": "rona-red-deer-north-66220",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83105",
+    "label": "RONA+ Red Deer",
+    "city": "Red Deer",
+    "province": "Alberta",
+    "slug": "rona-red-deer-83105",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66460",
+    "label": "RONA Spruce Grove",
+    "city": "Spruce Grove",
+    "province": "Alberta",
+    "slug": "rona-spruce-grove-66460",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66110",
+    "label": "RONA Calgary (Forest",
+    "city": "Lawn) Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-forest-66110",
+    "hasData": false
+  },
+  {
+    "storeNumber": "88007",
+    "label": "RONA+ Calgary - Crossiron",
+    "city": "Rocky View County",
+    "province": "Alberta",
+    "slug": "rona-calgary-crossiron-88007",
+    "hasData": false
+  },
+  {
+    "storeNumber": "82953",
+    "label": "RONA+ Calgary",
+    "city": "- McKenzie Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-82953",
+    "hasData": false
+  },
+  {
+    "storeNumber": "62860",
+    "label": "Home & Garden RONA / Calgary",
+    "city": "(Sunridge) Calgary",
+    "province": "Alberta",
+    "slug": "home-amp-garden-rona-calgary-62860",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83059",
+    "label": "RONA+ Calgary",
+    "city": "- Sunridge Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-83059",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8080",
+    "label": "RONA OLDS",
+    "city": "Olds",
+    "province": "Alberta",
+    "slug": "rona-olds-8080",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83714",
+    "label": "RONA+ Calgary",
+    "city": "(MacLeod) Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-83714",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83318",
+    "label": "RONA+ S.W. Calgary (Signal",
+    "city": "Hill) Calgary",
+    "province": "Alberta",
+    "slug": "rona-s-w-calgary-signal-83318",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66120",
+    "label": "RONA Calgary",
+    "city": "(Bowness) Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-66120",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2695",
+    "label": "RONA Pincher Creek",
+    "city": "Pincher Creek",
+    "province": "Alberta",
+    "slug": "rona-pincher-creek-2695",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83706",
+    "label": "RONA+ Calgary",
+    "city": "(Crowfoot) Calgary",
+    "province": "Alberta",
+    "slug": "rona-calgary-83706",
+    "hasData": false
+  },
+  {
+    "storeNumber": "214",
+    "label": "RONA Black Diamond",
+    "city": "Black Diamond",
+    "province": "Alberta",
+    "slug": "rona-black-diamond-214",
+    "hasData": false
+  },
+  {
+    "storeNumber": "12110",
+    "label": "RONA Cranbrook Building Centre Ltd. / Cranbrook",
+    "city": "Cranbrook",
+    "province": "British Columbia",
+    "slug": "rona-cranbrook-building-centre-ltd-cranbrook-12110",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8999",
+    "label": "RONA Invermere",
+    "city": "Invermere",
+    "province": "British Columbia",
+    "slug": "rona-invermere-8999",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2585",
+    "label": "La Crete RONA Building Centre",
+    "city": "La Crete",
+    "province": "Alberta",
+    "slug": "la-crete-rona-building-centre-2585",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61830",
+    "label": "RONA Golden",
+    "city": "Golden",
+    "province": "British Columbia",
+    "slug": "rona-golden-61830",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8550",
+    "label": "Maglio Building Centre, Nelson",
+    "city": "Nelson",
+    "province": "British Columbia",
+    "slug": "maglio-building-centre-nelson-8550",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8560",
+    "label": "Maglio Building Centre, Trail",
+    "city": "Trail",
+    "province": "British Columbia",
+    "slug": "maglio-building-centre-trail-8560",
+    "hasData": false
+  },
+  {
+    "storeNumber": "66180",
+    "label": "RONA Grande Prairie",
+    "city": "Grande Prairie",
+    "province": "Alberta",
+    "slug": "rona-grande-prairie-66180",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2930",
+    "label": "RONA Salmon Arm",
+    "city": "Salmon Arm",
+    "province": "British Columbia",
+    "slug": "rona-salmon-arm-2930",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61300",
+    "label": "RONA Vernon",
+    "city": "Vernon",
+    "province": "British Columbia",
+    "slug": "rona-vernon-61300",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61700",
+    "label": "Home & Garden RONA / Kelowna",
+    "city": "Kelowna",
+    "province": "British Columbia",
+    "slug": "home-amp-garden-rona-kelowna-61700",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61490",
+    "label": "RONA Penticton",
+    "city": "Penticton",
+    "province": "British Columbia",
+    "slug": "rona-penticton-61490",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8444",
+    "label": "RONA",
+    "city": "Fort St-John Fort St John",
+    "province": "British Columbia",
+    "slug": "rona-8444",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61310",
+    "label": "RONA Kamloops",
+    "city": "Kamloops",
+    "province": "British Columbia",
+    "slug": "rona-kamloops-61310",
+    "hasData": false
+  },
+  {
+    "storeNumber": "7240",
+    "label": "RONA Interlakes Building Supplies Ltd / Lone Butte",
+    "city": "Lone Butte",
+    "province": "British Columbia",
+    "slug": "rona-interlakes-building-supplies-ltd-lone-butte-7240",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61340",
+    "label": "RONA Williams Lake",
+    "city": "Williams Lake",
+    "province": "British Columbia",
+    "slug": "rona-williams-lake-61340",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8530",
+    "label": "FVBS Hope",
+    "city": "Hope",
+    "province": "British Columbia",
+    "slug": "fvbs-hope-8530",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61320",
+    "label": "RONA Quesnel",
+    "city": "Quesnel",
+    "province": "British Columbia",
+    "slug": "rona-quesnel-61320",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1890",
+    "label": "RONA Prince George",
+    "city": "Prince George",
+    "province": "British Columbia",
+    "slug": "rona-prince-george-1890",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61390",
+    "label": "RONA Chilliwack",
+    "city": "Chilliwack",
+    "province": "British Columbia",
+    "slug": "rona-chilliwack-61390",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83322",
+    "label": "RONA+ Abbotsford",
+    "city": "Abbotsford",
+    "province": "British Columbia",
+    "slug": "rona-abbotsford-83322",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8470",
+    "label": "RONA Fraser Valley / Mission",
+    "city": "Mission",
+    "province": "British Columbia",
+    "slug": "rona-fraser-valley-mission-8470",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61220",
+    "label": "RONA Abbotsford",
+    "city": "Abbotsford",
+    "province": "British Columbia",
+    "slug": "rona-abbotsford-61220",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8570",
+    "label": "FVBS Abbotsford",
+    "city": "Abbotsford",
+    "province": "British Columbia",
+    "slug": "fvbs-abbotsford-8570",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61190",
+    "label": "RONA Maple Ridge",
+    "city": "Maple Ridge",
+    "province": "British Columbia",
+    "slug": "rona-maple-ridge-61190",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8345",
+    "label": "RONA Walnut Grove",
+    "city": "Urban Langley",
+    "province": "British Columbia",
+    "slug": "rona-walnut-grove-8345",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61810",
+    "label": "RONA Langley",
+    "city": "Bypass Langley",
+    "province": "British Columbia",
+    "slug": "rona-langley-61810",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61460",
+    "label": "RONA Whistler",
+    "city": "Whistler",
+    "province": "British Columbia",
+    "slug": "rona-whistler-61460",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61260",
+    "label": "RONA Coquitlam",
+    "city": "Coquitlam",
+    "province": "British Columbia",
+    "slug": "rona-coquitlam-61260",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61720",
+    "label": "RONA Surrey",
+    "city": "(Fleetwood) Surrey",
+    "province": "British Columbia",
+    "slug": "rona-surrey-61720",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61290",
+    "label": "RONA Coquitlam",
+    "city": "(Austin) Coquitlam",
+    "province": "British Columbia",
+    "slug": "rona-coquitlam-61290",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61240",
+    "label": "RONA Surrey (South",
+    "city": "Surrey) Surrey",
+    "province": "British Columbia",
+    "slug": "rona-surrey-south-61240",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61270",
+    "label": "RONA Burnaby",
+    "city": "Burnaby",
+    "province": "British Columbia",
+    "slug": "rona-burnaby-61270",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61450",
+    "label": "RONA Squamish",
+    "city": "Squamish",
+    "province": "British Columbia",
+    "slug": "rona-squamish-61450",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61740",
+    "label": "RONA North Vancouver (Park & Tilford)",
+    "city": "North Vancouver",
+    "province": "British Columbia",
+    "slug": "rona-north-vancouver-park-amp-tilford-61740",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83704",
+    "label": "RONA+ Vancouver",
+    "city": "- Grandview Vancouver",
+    "province": "British Columbia",
+    "slug": "rona-vancouver-83704",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8140",
+    "label": "RONA North Vancouver North",
+    "city": "Vancouver",
+    "province": "British Columbia",
+    "slug": "rona-north-vancouver-north-8140",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8880",
+    "label": "RONA Tsawwassen",
+    "city": "Commons Tsawwassen",
+    "province": "British Columbia",
+    "slug": "rona-tsawwassen-8880",
+    "hasData": false
+  },
+  {
+    "storeNumber": "8040",
+    "label": "RONA Richmond",
+    "city": "Richmond",
+    "province": "British Columbia",
+    "slug": "rona-richmond-8040",
+    "hasData": false
+  },
+  {
+    "storeNumber": "5818",
+    "label": "RONA Coast Builders / Sechelt",
+    "city": "Sechelt",
+    "province": "British Columbia",
+    "slug": "rona-coast-builders-sechelt-5818",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83330",
+    "label": "RONA+ Victoria",
+    "city": "(Tillicum) Victoria",
+    "province": "British Columbia",
+    "slug": "rona-victoria-83330",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61040",
+    "label": "RONA Cobble Hill",
+    "city": "Cobble Hill",
+    "province": "British Columbia",
+    "slug": "rona-cobble-hill-61040",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83702",
+    "label": "RONA+",
+    "city": "Langford Victoria",
+    "province": "British Columbia",
+    "slug": "rona-83702",
+    "hasData": false
+  },
+  {
+    "storeNumber": "9551",
+    "label": "RONA Coast Builders / Madeira Park",
+    "city": "Madeira Park",
+    "province": "British Columbia",
+    "slug": "rona-coast-builders-madeira-park-9551",
+    "hasData": false
+  },
+  {
+    "storeNumber": "61030",
+    "label": "RONA Nanaimo",
+    "city": "Nanaimo",
+    "province": "British Columbia",
+    "slug": "rona-nanaimo-61030",
+    "hasData": false
+  },
+  {
+    "storeNumber": "83323",
+    "label": "RONA+ Nanaimo",
+    "city": "Nanaimo",
+    "province": "British Columbia",
+    "slug": "rona-nanaimo-83323",
+    "hasData": false
+  },
+  {
+    "storeNumber": "2791",
+    "label": "RONA Powell River",
+    "city": "Powell River",
+    "province": "British Columbia",
+    "slug": "rona-powell-river-2791",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1215",
+    "label": "RONA / Alert Bay",
+    "city": "Alert Bay",
+    "province": "British Columbia",
+    "slug": "rona-alert-bay-1215",
+    "hasData": false
+  },
+  {
+    "storeNumber": "1195",
+    "label": "RONA / Port McNeill",
+    "city": "Port McNeill",
+    "province": "British Columbia",
+    "slug": "rona-port-mcneill-1195",
+    "hasData": false
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1840,6 +1840,49 @@
       }
     }
 
+    async function loadRonaDirectory(){
+      const store = STORES.find(entry => entry.slug === 'rona');
+      if(!store) return;
+      try{
+        const res = await fetch('data/rona/stores.json', {cache:'no-store'});
+        if(!res.ok) return;
+        const json = await res.json();
+        if(!Array.isArray(json)) return;
+        const seen = new Map();
+        for(const branch of store.branches ?? []){
+          if(!branch?.slug) continue;
+          seen.set(branch.slug, {...branch, hasData: branch.hasData !== false});
+        }
+        for(const entry of json){
+          if(!entry || typeof entry !== 'object') continue;
+          const rawSlug = typeof entry.slug === 'string' && entry.slug ? entry.slug : slugify(entry.label || entry.city || entry.storeNumber);
+          if(!rawSlug) continue;
+          const label = (entry.label || entry.city || rawSlug).trim();
+          const city = (entry.city || label).trim();
+          const province = entry.province || '';
+          const storeNumber = entry.storeNumber || '';
+          const hasData = entry.hasData === true;
+          const previous = seen.get(rawSlug) || {};
+          seen.set(rawSlug, {
+            ...previous,
+            label,
+            slug: rawSlug,
+            city,
+            province,
+            storeNumber,
+            hasData: previous.hasData === true || hasData
+          });
+        }
+        store.branches = Array.from(seen.values()).sort((a,b)=>a.label.localeCompare(b.label,'fr'));
+        renderStoreAds();
+        if(storeSelect && storeSelect.value === 'rona'){
+          setCityOptions('rona', true);
+        }
+      }catch(err){
+        console.warn('Impossible de charger les succursales Rona', err);
+      }
+    }
+
     async function loadCanadianTireDirectory(){
       const store = STORES.find(entry => entry.slug === 'canadian-tire');
       if(!store) return;
@@ -2003,6 +2046,7 @@
     });
 
     // Démarrage
+    await loadRonaDirectory();
     await loadCanadianTireDirectory();
     const defaultStore = getStoreByIdentifier(DEFAULT_FILTERS.store);
     const defaultStoreValue = defaultStore?.slug || '';


### PR DESCRIPTION
## Summary
- load the new nationwide RONA branch directory on the home page and best deals view
- rely on the hasData flag to skip empty branches during fetches
- add the generated 405-branch data/rona/stores.json dataset including the corrected Portage la Prairie metadata

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e004a20428832eb1cc80e9df03736a