### PR TITLE
Add Walmart store dataset and require JSON-driven loaders

### DIFF
--- a/incoming/README.md
+++ b/incoming/README.md
@@ -48,7 +48,7 @@ Les options (`--store`, `--output-dir`, `--aggregated-path`, etc.) sont identiqu
 Une action GitHub (`.github/workflows/walmart-scraper.yml`) planifie l'exécution chaque jour à 21h UTC. Pour l'activer :
 
 1. Ajoutez un secret `WALMART_PROXIES` contenant une liste JSON de proxies résidentiels.
-2. Personnalisez `incoming/walmart_stores.json` ou la constante `magasins` dans le script.
+2. Mettez à jour `incoming/walmart_stores.json` (via `incoming/walmart_stores_raw.tsv`).
 3. Déclenchez manuellement le workflow via l'onglet **Actions** si nécessaire (`Run workflow`).
 
 Chaque exécution met à jour les JSON par magasin dans `data/walmart/` et attache un artefact `liquidations_walmart_qc.json` téléchargeable depuis GitHub Actions.

--- a/incoming/walmart_stores.json
+++ b/incoming/walmart_stores.json
@@ -1,0 +1,2420 @@
+[
+  {
+    "id_store": "7146",
+    "ville": "Montreal",
+    "adresse": "1000, rue Sauve Ouest, Montreal, QC, H4N 3L5",
+    "slug": "montreal"
+  },
+  {
+    "id_store": "7147",
+    "ville": "St. Jerome",
+    "adresse": "1045 boul du grand heron, St. Jerome, QC, J7Y 3P2",
+    "slug": "saint-jerome"
+  },
+  {
+    "id_store": "1185",
+    "ville": "Blainville",
+    "adresse": "1333 Michele-bohec Blvd, Blainville, QC, J7C 0M4",
+    "slug": "blainville"
+  },
+  {
+    "id_store": "3080",
+    "ville": "Rosemere",
+    "adresse": "401 Boul Labelle, Rosemere, QC, J7A 3T2",
+    "slug": "rosemere-quebec"
+  },
+  {
+    "id_store": "3089",
+    "ville": "Saint-eustache",
+    "adresse": "764 Arthur Sauve Boul, Saint-eustache, QC, J7R 4K3",
+    "slug": "st-eustache-quebec"
+  },
+  {
+    "id_store": "3132",
+    "ville": "Lachute",
+    "adresse": "480 Av Bethany, Lachute, QC, J8H 4H5",
+    "slug": "lachute-quebec"
+  },
+  {
+    "id_store": "3149",
+    "ville": "Mascouche",
+    "adresse": "155 Montee Masson, Mascouche, QC, J7K 3B4",
+    "slug": "mascouche-supercentre"
+  },
+  {
+    "id_store": "1032",
+    "ville": "Laval",
+    "adresse": "5205 Blvd Robert Bourassa, Laval, QC, H7E 0A3",
+    "slug": "laval-qc"
+  },
+  {
+    "id_store": "1020",
+    "ville": "Sainte-agathe-des-monts",
+    "adresse": "400 Rue Laverdure, Sainte-agathe-des-monts, QC, J8C 0A2",
+    "slug": "sainte-agathe-des-monts"
+  },
+  {
+    "id_store": "3047",
+    "ville": "Laval",
+    "adresse": "2075 Boul Chomedey, Laval, QC, H7T 0G5",
+    "slug": "c-laval-centre-laval-qc"
+  },
+  {
+    "id_store": "3189",
+    "ville": "Laval",
+    "adresse": "700 Autoroute Chomedey Ouest, Laval, QC, H7X 3S9",
+    "slug": "w-laval-quebec"
+  },
+  {
+    "id_store": "3656",
+    "ville": "Montreal-nord",
+    "adresse": "6140 Boul Henri-bourassa E, Montreal-nord, QC, H1G 5X3",
+    "slug": "montreal-north-quebec"
+  },
+  {
+    "id_store": "1085",
+    "ville": "Terrebonne",
+    "adresse": "1001 Rue Des Migrateurs, Terrebonne, QC, J6V 0A8",
+    "slug": "lachenaie-qc"
+  },
+  {
+    "id_store": "1202",
+    "ville": "Pointe-claire",
+    "adresse": "195 Boul Hymus, Pointe-claire, QC, H9R 1E9",
+    "slug": "pointe-claire"
+  },
+  {
+    "id_store": "3044",
+    "ville": "Kirkland",
+    "adresse": "17000 Rte Transcanadienne, Kirkland, QC, H9J 2M5",
+    "slug": "kirkland-quebec"
+  },
+  {
+    "id_store": "1183",
+    "ville": "Saint-leonard",
+    "adresse": "7600 Boul Viau, RC 101, Saint-leonard, QC, H1S 2P3",
+    "slug": "st-leonard-w"
+  },
+  {
+    "id_store": "3094",
+    "ville": "Saint-leonard",
+    "adresse": "7445 Boul Langelier, Saint-leonard, QC, H1S 1V6",
+    "slug": "st-leonard-quebec"
+  },
+  {
+    "id_store": "1189",
+    "ville": "St-laurent",
+    "adresse": "3820 De La Cote Vertu Blvd, St-laurent, QC, H4R 1P8",
+    "slug": "montreal-st-laurent"
+  },
+  {
+    "id_store": "1169",
+    "ville": "Pointe-aux-trembles",
+    "adresse": "12675 Rue Sherbrooke E, Pointe-aux-trembles, QC, H1A 3W7",
+    "slug": "pointe-aux-trembles"
+  },
+  {
+    "id_store": "3079",
+    "ville": "Repentigny",
+    "adresse": "100 Boul Brien, SUITE 66, Repentigny, QC, J6A 5N4",
+    "slug": "repentigny-quebec"
+  },
+  {
+    "id_store": "1168",
+    "ville": "Montreal",
+    "adresse": "3121 Ave De Granby, Montreal, QC, H1N 2Z7",
+    "slug": "montreal-hochelaga"
+  },
+  {
+    "id_store": "3165",
+    "ville": "Montreal",
+    "adresse": "5400 Rue Jean-talon O, Montreal, QC, H4P 2T5",
+    "slug": "cote-st-luc-qc"
+  },
+  {
+    "id_store": "1170",
+    "ville": "Montreal",
+    "adresse": "6700 Ch De La Cote-des-neiges, Montreal, QC, H3S 2B2",
+    "slug": "montreal-cote-des-neiges"
+  },
+  {
+    "id_store": "1140",
+    "ville": "Dorval",
+    "adresse": "400 Dorval Ave, Dorval, QC, H9S 3H7",
+    "slug": "montreal-dorval"
+  },
+  {
+    "id_store": "1057",
+    "ville": "Vaudreuil-dorion",
+    "adresse": "3050 Boul De La Gare, Vaudreuil-dorion, QC, J7V 0H1",
+    "slug": "vaudreuil-qc"
+  },
+  {
+    "id_store": "3046",
+    "ville": "Lasalle",
+    "adresse": "6797 Blvd Newman, Lasalle, QC, H8N 3E4",
+    "slug": "lasalle-quebec"
+  },
+  {
+    "id_store": "3052",
+    "ville": "Longueuil",
+    "adresse": "1999 Boul Roland-therrien, Longueuil, QC, J4N 1A3",
+    "slug": "longueuil-quebec"
+  },
+  {
+    "id_store": "1159",
+    "ville": "Hawkesbury",
+    "adresse": "1550 Cameron St, Hawkesbury, ON, K6A 3S5",
+    "slug": "hawkesbury"
+  },
+  {
+    "id_store": "3039",
+    "ville": "Joliette",
+    "adresse": "1505 Boul Firestone, Joliette, QC, J6E 9E5",
+    "slug": "joliette-quebec"
+  },
+  {
+    "id_store": "1167",
+    "ville": "Longueuil",
+    "adresse": "2877 Ch De Chambly, Longueuil, QC, J4L 1M8",
+    "slug": "longueuil-s"
+  },
+  {
+    "id_store": "1132",
+    "ville": "Chateauguay",
+    "adresse": "250 Boul Briseboise, Chateauguay, QC, J6K 0H5",
+    "slug": "chateauguay"
+  },
+  {
+    "id_store": "3642",
+    "ville": "Saint-constant",
+    "adresse": "500 Voie De La Desserte De La Route 132, Saint-constant, QC, J5A 2S5",
+    "slug": "st-constants-quebec"
+  },
+  {
+    "id_store": "3140",
+    "ville": "Saint-bruno",
+    "adresse": "1475 Boul St Bruno, Saint-bruno, QC, J3V 6J1",
+    "slug": "st-bruno-quebec"
+  },
+  {
+    "id_store": "3007",
+    "ville": "Brossard",
+    "adresse": "9000 Blvd Leduc, Brossard, QC, J4Y 0E6",
+    "slug": "brossard-quebec"
+  },
+  {
+    "id_store": "3639",
+    "ville": "Salaberry-de-valleyfield",
+    "adresse": "2050 Boul Monseigneur Langlois, Salaberry-de-valleyfield, QC, J6S 5R1",
+    "slug": "valleyfield-qc"
+  },
+  {
+    "id_store": "1203",
+    "ville": "Candiac",
+    "adresse": "201 Rue Strasbourg, Candiac, QC, J5R 0B4",
+    "slug": "candiac"
+  },
+  {
+    "id_store": "1174",
+    "ville": "Sorel-tracy",
+    "adresse": "450 Boul Poliquin, Sorel-tracy, QC, J3P 7R5",
+    "slug": "sorel-tracy"
+  },
+  {
+    "id_store": "3090",
+    "ville": "St-jean-sur-richelieu",
+    "adresse": "100 Boul Omer-marcil, St-jean-sur-richelieu, QC, J2W 2X2",
+    "slug": "st-jean-quebec"
+  },
+  {
+    "id_store": "3137",
+    "ville": "Saint-hyacinthe",
+    "adresse": "5950 Rue Martineau, Saint-hyacinthe, QC, J2R 2H6",
+    "slug": "ste-hyacinthe"
+  },
+  {
+    "id_store": "3020",
+    "ville": "Cornwall",
+    "adresse": "420 Ninth St W, Cornwall, ON, K6J 0B3",
+    "slug": "cornwall-ontario"
+  },
+  {
+    "id_store": "1060",
+    "ville": "Rockland",
+    "adresse": "3001 Richelieu St, Rockland, ON, K4K 0B5",
+    "slug": "rockland-on"
+  },
+  {
+    "id_store": "3035",
+    "ville": "Granby",
+    "adresse": "75 Simonds St N, Granby, QC, J2J 2S3",
+    "slug": "granby-quebec"
+  },
+  {
+    "id_store": "3023",
+    "ville": "Drummondville",
+    "adresse": "1205 Boul Rene-levesque, Drummondville, QC, J2C 7V4",
+    "slug": "drummondville-quebec"
+  },
+  {
+    "id_store": "5839",
+    "ville": "Cowansville",
+    "adresse": "1770 Rue Du Sud, Cowansville, QC, J2K 3G8",
+    "slug": "cowansville-quebec"
+  },
+  {
+    "id_store": "3065",
+    "ville": "Orleans",
+    "adresse": "3900 Innes Rd, Orleans, ON, K1W 1K9",
+    "slug": "orleans-ottawa-on"
+  },
+  {
+    "id_store": "3108",
+    "ville": "Trois-rivieres",
+    "adresse": "4520 Boul Des Recollets, SUITE 820, Trois-rivieres, QC, G9A 4N2",
+    "slug": "trois-riveres-quebec"
+  },
+  {
+    "id_store": "3647",
+    "ville": "Shawinigan",
+    "adresse": "1600 Blvd Royal, Shawinigan, QC, G9N 8S8",
+    "slug": "shawinigan-qc"
+  },
+  {
+    "id_store": "3014",
+    "ville": "Cap-de-la-madeleine",
+    "adresse": "300 Rue Barkoff, Cap-de-la-madeleine, QC, G8T 2A3",
+    "slug": "cap-de-la-madeleine-qc"
+  },
+  {
+    "id_store": "1158",
+    "ville": "Gloucester",
+    "adresse": "1980 Ogilvie Rd, GLOUCESTER CENTRE, Gloucester, ON, K1J 9L3",
+    "slug": "gloucester"
+  },
+  {
+    "id_store": "3125",
+    "ville": "Gatineau",
+    "adresse": "640 Blvd Maloney W, Gatineau, QC, J8T 8K7",
+    "slug": "gatineau-qc"
+  },
+  {
+    "id_store": "1031",
+    "ville": "Ottawa",
+    "adresse": "450 Terminal Ave, Ottawa, ON, K1G 0Z3",
+    "slug": "ottawa-east-on"
+  },
+  {
+    "id_store": "3131",
+    "ville": "Ottawa",
+    "adresse": "2210 Bank St, Ottawa, ON, K1V 1J5",
+    "slug": "s-ottawa-on"
+  },
+  {
+    "id_store": "1200",
+    "ville": "Ottawa",
+    "adresse": "2277 Riverside Dr, Ottawa, ON, K1H 7X6",
+    "slug": "ottawa-c"
+  },
+  {
+    "id_store": "1086",
+    "ville": "Gatineau",
+    "adresse": "51 De La Gappe Blvd, Gatineau, QC, J8T 0B5",
+    "slug": "gatineau-west-qc"
+  },
+  {
+    "id_store": "1190",
+    "ville": "Hull",
+    "adresse": "1-425 Boul Saint Joseph, Hull, QC, J8Y 3Z9",
+    "slug": "hull-e"
+  },
+  {
+    "id_store": "3143",
+    "ville": "Hull",
+    "adresse": "35 Boul Du Plateau, Hull, QC, J9A 3G1",
+    "slug": "hull-qc"
+  },
+  {
+    "id_store": "1110",
+    "ville": "Ottawa",
+    "adresse": "1375 Baseline Rd, Ottawa, ON, K2C 3G1",
+    "slug": "ottawa-sw-on"
+  },
+  {
+    "id_store": "3638",
+    "ville": "Barrhaven",
+    "adresse": "3651 Strandherd Dr, Barrhaven, ON, K2J 4G8",
+    "slug": "barrhaven-ont"
+  },
+  {
+    "id_store": "3066",
+    "ville": "Ottawa",
+    "adresse": "100 Bayshore Dr, UNIT 10, Ottawa, ON, K2B 8C1",
+    "slug": "bayshore-shopping-centre-ottawa"
+  },
+  {
+    "id_store": "1047",
+    "ville": "Kemptville",
+    "adresse": "340 Colonnade Dr, Kemptville, ON, K0G 1J0",
+    "slug": "kemptville-on"
+  },
+  {
+    "id_store": "1118",
+    "ville": "Stittsville",
+    "adresse": "5357 Fernbank Rd, Stittsville, ON, K2S 0T7",
+    "slug": "kanata-south-on"
+  },
+  {
+    "id_store": "3134",
+    "ville": "Kanata",
+    "adresse": "500 Earl Grey Dr, Kanata, ON, K2T 1B6",
+    "slug": "kanata-ontario"
+  },
+  {
+    "id_store": "1076",
+    "ville": "Magog",
+    "adresse": "1935 Sherbrooke St, Magog, QC, J1X 2T5",
+    "slug": "magog-qc"
+  },
+  {
+    "id_store": "3739",
+    "ville": "Victoriaville",
+    "adresse": "110 Blvd Arthabaska O, Victoriaville, QC, G6S 0P2",
+    "slug": "victoriaville-quebec"
+  },
+  {
+    "id_store": "3086",
+    "ville": "Sherbrooke",
+    "adresse": "4050 Boul Josaphat-rancourt, Sherbrooke, QC, J1L 3C6",
+    "slug": "sherbrooke-quebec"
+  },
+  {
+    "id_store": "1172",
+    "ville": "Sherbrooke",
+    "adresse": "940 13e Av N, Sherbrooke, QC, J1E 3J7",
+    "slug": "sherbrooke-e"
+  },
+  {
+    "id_store": "1075",
+    "ville": "Carleton Place",
+    "adresse": "450 Mcneely Ave, Carleton Place, ON, K7C 0A6",
+    "slug": "carleton-place-on"
+  },
+  {
+    "id_store": "3006",
+    "ville": "Brockville",
+    "adresse": "1942 Parkedale Ave, Brockville, ON, K6V 7N4",
+    "slug": "brockville-ontario"
+  },
+  {
+    "id_store": "5811",
+    "ville": "Smiths Falls",
+    "adresse": "114 Lombard St, Smiths Falls, ON, K7A 5B8",
+    "slug": "smiths-falls-ont"
+  },
+  {
+    "id_store": "3078",
+    "ville": "Renfrew",
+    "adresse": "980 O'brien Rd, Renfrew, ON, K7V 0B4",
+    "slug": "renfrew-ontario"
+  },
+  {
+    "id_store": "5832",
+    "ville": "Thetford Mines",
+    "adresse": "1025 Boul Frontenac E, Thetford Mines, QC, G6G 6S7",
+    "slug": "thetford-mines-quebec"
+  },
+  {
+    "id_store": "3146",
+    "ville": "Sainte-foy",
+    "adresse": "1470 Av Jules-verne, Sainte-foy, QC, G2G 2R5",
+    "slug": "st-foy-qc"
+  },
+  {
+    "id_store": "1045",
+    "ville": "Saint-romuald",
+    "adresse": "700 Rue De La Concorde, Saint-romuald, QC, G6W 8A8",
+    "slug": "st-romuald-qc"
+  },
+  {
+    "id_store": "1212",
+    "ville": "Quebec City",
+    "adresse": "2700 Boul Laurier, Quebec City, QC, G1V 2L8",
+    "slug": "quebec-city-downtown"
+  },
+  {
+    "id_store": "3074",
+    "ville": "Quebec City",
+    "adresse": "1700 Boul Lebourgneuf, Quebec City, QC, G2K 2M4",
+    "slug": "quebec-city-capitale"
+  },
+  {
+    "id_store": "3171",
+    "ville": "Pembroke",
+    "adresse": "1108 Pembroke St E, Pembroke, ON, K8A 8P7",
+    "slug": "pembroke-on"
+  },
+  {
+    "id_store": "1201",
+    "ville": "Quebec City",
+    "adresse": "550 Boul Wilfrid-hamel, Quebec City, QC, G1M 2S6",
+    "slug": "quebec-city-e"
+  },
+  {
+    "id_store": "1019",
+    "ville": "Lac-megantic",
+    "adresse": "3130 Rue Laval, Lac-megantic, QC, G6B 1A4",
+    "slug": "lac-megantic-qc"
+  },
+  {
+    "id_store": "3148",
+    "ville": "Levis",
+    "adresse": "1200 Boul Alphonse-desjardins, Levis, QC, G6V 6Y8",
+    "slug": "levis-qc"
+  },
+  {
+    "id_store": "3646",
+    "ville": "Quebec City",
+    "adresse": "224 Joseph Casavant Ave, Quebec City, QC, G1C 7Z3",
+    "slug": "beauport-qc"
+  },
+  {
+    "id_store": "1040",
+    "ville": "Saint-georges",
+    "adresse": "750 107e Rue, Saint-georges, QC, G5Y 0A1",
+    "slug": "st-georges-de-beauce-qc"
+  },
+  {
+    "id_store": "3043",
+    "ville": "Kingston",
+    "adresse": "1130 Midland Ave, Kingston, ON, K7P 2X9",
+    "slug": "kingston-ontario"
+  },
+  {
+    "id_store": "1041",
+    "ville": "Napanee",
+    "adresse": "89 Jim Kimmett Blvd, Napanee, ON, K7R 3L1",
+    "slug": "napanee-on"
+  },
+  {
+    "id_store": "3122",
+    "ville": "Belleville",
+    "adresse": "274 Millennium Pky, Belleville, ON, K8N 4Z5",
+    "slug": "belleville-on"
+  },
+  {
+    "id_store": "3178",
+    "ville": "Trenton",
+    "adresse": "470 2nd Dug Hill Rd, RR 4, Trenton, ON, K8V 5P7",
+    "slug": "trenton-on"
+  },
+  {
+    "id_store": "1173",
+    "ville": "La Pocatiere",
+    "adresse": "161 Route 230 Ouest Unit 400, UNIT 400, La Pocatiere, QC, G0R 1Z0",
+    "slug": "la-pocatiere"
+  },
+  {
+    "id_store": "5795",
+    "ville": "Alma",
+    "adresse": "1755 Ave Du Pont S, Alma, QC, G8B 7W7",
+    "slug": "alma-qc"
+  },
+  {
+    "id_store": "3017",
+    "ville": "Chicoutimi",
+    "adresse": "1451 Boul Talbot, SUITE 1, Chicoutimi, QC, G7H 5N8",
+    "slug": "chicoutimi-quebec"
+  },
+  {
+    "id_store": "3071",
+    "ville": "Peterborough",
+    "adresse": "1002 Chemong Rd, Peterborough, ON, K9H 7E2",
+    "slug": "peterborough-ontario"
+  },
+  {
+    "id_store": "1162",
+    "ville": "Peterborough",
+    "adresse": "950 Lansdowne St W, Peterborough, ON, K9J 1Z9",
+    "slug": "peterbourough-s"
+  },
+  {
+    "id_store": "3139",
+    "ville": "Val-d'or",
+    "adresse": "1855 3e Av, Val-d'or, QC, J9P 7A9",
+    "slug": "val-d-or-quebec"
+  },
+  {
+    "id_store": "3133",
+    "ville": "Cobourg",
+    "adresse": "73 Strathy Rd, Cobourg, ON, K9A 5W8",
+    "slug": "coburg-ontario"
+  },
+  {
+    "id_store": "3655",
+    "ville": "Riviere-du-loup",
+    "adresse": "100 Rue Des Cerisiers, Riviere-du-loup, QC, G5R 6E8",
+    "slug": "riviere-du-loup-qc"
+  },
+  {
+    "id_store": "5743",
+    "ville": "Huntsville",
+    "adresse": "111 Howland Dr, Huntsville, ON, P1H 2P4",
+    "slug": "huntsville-ont"
+  },
+  {
+    "id_store": "1054",
+    "ville": "Bracebridge",
+    "adresse": "40 Depot Dr Rr7, Bracebridge, ON, P1L 0H1",
+    "slug": "bracebridge-on"
+  },
+  {
+    "id_store": "3063",
+    "ville": "North Bay",
+    "adresse": "1500 Fisher St, UNIT 102, North Bay, ON, P1B 2H3",
+    "slug": "north-bay-ontario"
+  },
+  {
+    "id_store": "1001",
+    "ville": "Bowmanville",
+    "adresse": "2320 Highway 2, Bowmanville, ON, L1C 3K7",
+    "slug": "bowmanville-on"
+  },
+  {
+    "id_store": "3161",
+    "ville": "Oshawa",
+    "adresse": "1471 Harmony Rd N, Oshawa, ON, L1H 7K5",
+    "slug": "oshawa-n-on"
+  },
+  {
+    "id_store": "1069",
+    "ville": "Port Perry",
+    "adresse": "1535 Hwy 7a, BLDG A, Port Perry, ON, L9L 1B5",
+    "slug": "port-perry-on"
+  },
+  {
+    "id_store": "1056",
+    "ville": "Oshawa",
+    "adresse": "680 Laval Dr, Oshawa, ON, L1J 0B5",
+    "slug": "oshawa-east-on"
+  },
+  {
+    "id_store": "3113",
+    "ville": "Whitby",
+    "adresse": "4100 Baldwin St S, Whitby, ON, L1R 3H8",
+    "slug": "whitby-ontario"
+  },
+  {
+    "id_store": "3153",
+    "ville": "Orillia",
+    "adresse": "175 Murphy Rd, 8000 HWY # 12, Orillia, ON, L3V 0B5",
+    "slug": "orillia-ontario"
+  },
+  {
+    "id_store": "3653",
+    "ville": "Uxbridge",
+    "adresse": "6 Welwood Dr, Uxbridge, ON, L9P 1Z7",
+    "slug": "uxbridge-ontario"
+  },
+  {
+    "id_store": "3001",
+    "ville": "Ajax",
+    "adresse": "270 Kingston Rd E R R # 1, Ajax, ON, L1Z 1G1",
+    "slug": "ajax-ontario"
+  },
+  {
+    "id_store": "3186",
+    "ville": "Pickering",
+    "adresse": "1899 Brock Rd, Pickering, ON, L1V 4H7",
+    "slug": "pickering-ontario"
+  },
+  {
+    "id_store": "1012",
+    "ville": "Keswick",
+    "adresse": "23550 Woodbine Ave, Keswick, ON, L4P 0E2",
+    "slug": "keswick"
+  },
+  {
+    "id_store": "1029",
+    "ville": "Stouffville",
+    "adresse": "1050 Hoover Pk Dr, Stouffville, ON, L4A 0K2",
+    "slug": "stouffville-on"
+  },
+  {
+    "id_store": "1109",
+    "ville": "Markham",
+    "adresse": "500 Copper Creek Dr, Markham, ON, L6B 0S1",
+    "slug": "markham-east"
+  },
+  {
+    "id_store": "3111",
+    "ville": "Scarborough",
+    "adresse": "799 Milner Ave, Scarborough, ON, M1B 3C3",
+    "slug": "scarborough-east-on"
+  },
+  {
+    "id_store": "1033",
+    "ville": "Edmundston",
+    "adresse": "805 Victoria St, Edmundston, NB, E3V 3T3",
+    "slug": "edmundston-nb"
+  },
+  {
+    "id_store": "3136",
+    "ville": "Rouyn-noranda",
+    "adresse": "275 Blvd Rideau, Rouyn-noranda, QC, J9X 5Y6",
+    "slug": "rouyn-noranda"
+  },
+  {
+    "id_store": "1080",
+    "ville": "Scarborough",
+    "adresse": "5995 Steeles Ave E, Scarborough, ON, M1V 5P7",
+    "slug": "scarborough-on"
+  },
+  {
+    "id_store": "1161",
+    "ville": "Newmarket",
+    "adresse": "1111 Davis Dr, Newmarket, ON, L3Y 8X2",
+    "slug": "newmarket-east"
+  },
+  {
+    "id_store": "3053",
+    "ville": "Markham",
+    "adresse": "5000 Hwy 7, UNIT # Y006A, Markham, ON, L3R 4M9",
+    "slug": "markham-ontario"
+  },
+  {
+    "id_store": "5778",
+    "ville": "Aurora",
+    "adresse": "135 First Commerce Dr, Aurora, ON, L4G 0G2",
+    "slug": "aurora-on"
+  },
+  {
+    "id_store": "1023",
+    "ville": "Parry Sound",
+    "adresse": "1 Pine Dr, Parry Sound, ON, P2A 3C3",
+    "slug": "parry-sound-on"
+  },
+  {
+    "id_store": "1117",
+    "ville": "Scarborough",
+    "adresse": "3132 Eglinton Ave E, Scarborough, ON, M1J 2H1",
+    "slug": "scarborough-south"
+  },
+  {
+    "id_store": "3635",
+    "ville": "Scarborough",
+    "adresse": "300 Borough Dr, Scarborough, ON, M1P 4P5",
+    "slug": "c-scarborough-ontario"
+  },
+  {
+    "id_store": "3062",
+    "ville": "Newmarket",
+    "adresse": "17940 Yonge St, Newmarket, ON, L3Y 8S4",
+    "slug": "newmarket-ontario"
+  },
+  {
+    "id_store": "3128",
+    "ville": "Temiskaming Shores",
+    "adresse": "133 Hwy # 11, Temiskaming Shores, ON, P0J 1P0",
+    "slug": "temiskaming-shores-on"
+  },
+  {
+    "id_store": "3166",
+    "ville": "Barrie",
+    "adresse": "450 Bayfield St, Barrie, ON, L4M 5A2",
+    "slug": "barrie-north-on"
+  },
+  {
+    "id_store": "3000",
+    "ville": "Scarborough",
+    "adresse": "3850 Sheppard Ave E, SUITE 360, Scarborough, ON, M1T 3L3",
+    "slug": "agincourt-ontario"
+  },
+  {
+    "id_store": "3645",
+    "ville": "Midland",
+    "adresse": "16845 Hwy # 12, Midland, ON, L4R 0A9",
+    "slug": "midland-ontario"
+  },
+  {
+    "id_store": "3123",
+    "ville": "Barrie",
+    "adresse": "35 Mapleview Dr W, Barrie, ON, L4N 9H5",
+    "slug": "s-barrie-on"
+  },
+  {
+    "id_store": "3195",
+    "ville": "Richmond Hill",
+    "adresse": "1070 Major Mackenzie Dr E, UNIT A, Richmond Hill, ON, L4S 1P3",
+    "slug": "richmond-hill-on"
+  },
+  {
+    "id_store": "3159",
+    "ville": "Scarborough",
+    "adresse": "1900 Eglinton Ave E, Scarborough, ON, M1L 2L9",
+    "slug": "w-scarborough-on"
+  },
+  {
+    "id_store": "1101",
+    "ville": "Bradford",
+    "adresse": "545 Holland St W, Bradford, ON, L3Z 0C1",
+    "slug": "bradford-on"
+  },
+  {
+    "id_store": "1116",
+    "ville": "Richmond Hill",
+    "adresse": "255 Silver Linden Dr, Richmond Hill, ON, L4B 4V5",
+    "slug": "richmond-hill-south"
+  },
+  {
+    "id_store": "5831",
+    "ville": "Thornhill",
+    "adresse": "700 Centre St, Thornhill, ON, L4J 0A7",
+    "slug": "thornhill-on"
+  },
+  {
+    "id_store": "1150",
+    "ville": "Toronto",
+    "adresse": "1000 Gerrard St E, Toronto, ON, M4M 3G6",
+    "slug": "toronto-downtown-e"
+  },
+  {
+    "id_store": "1115",
+    "ville": "Vaughan",
+    "adresse": "1900 Major Mackenzie Dr, Vaughan, ON, L6A 4R9",
+    "slug": "vaughan-maple-on"
+  },
+  {
+    "id_store": "1095",
+    "ville": "Vaughan",
+    "adresse": "3600 Major Mackenzie Dr W, Vaughan, ON, L4H 3T6",
+    "slug": "vaughan-nw-on"
+  },
+  {
+    "id_store": "1139",
+    "ville": "Toronto",
+    "adresse": "3757 Keele St, Toronto, ON, M3J 1N4",
+    "slug": "toronto-downsview"
+  },
+  {
+    "id_store": "3174",
+    "ville": "Vaughan",
+    "adresse": "670 Applewood Crescent, Vaughan, ON, L4K 4B4",
+    "slug": "vaughan-on"
+  },
+  {
+    "id_store": "3105",
+    "ville": "Toronto",
+    "adresse": "1305 Lawrence Ave W, N PK SC, Toronto, ON, M6L 1A5",
+    "slug": "toronto-north-park"
+  },
+  {
+    "id_store": "3106",
+    "ville": "Toronto",
+    "adresse": "900 Dufferin St, Toronto, ON, M6H 4A9",
+    "slug": "toronto-dufferin-mall"
+  },
+  {
+    "id_store": "1087",
+    "ville": "Wasaga Beach",
+    "adresse": "100 Stonebridge Blvd, Wasaga Beach, ON, L9Z 0C1",
+    "slug": "wasaga-beach-on"
+  },
+  {
+    "id_store": "1083",
+    "ville": "Alliston",
+    "adresse": "30 Dunham Dr, Alliston, ON, L9R 0G1",
+    "slug": "alliston-on"
+  },
+  {
+    "id_store": "1151",
+    "ville": "North York",
+    "adresse": "2202 Jane St, North York, ON, M3M 1A4",
+    "slug": "toronto-sheridan"
+  },
+  {
+    "id_store": "1004",
+    "ville": "Toronto",
+    "adresse": "2525 St Clair Ave W, Toronto, ON, M6N 4Z5",
+    "slug": "toronto-stockyards-on"
+  },
+  {
+    "id_store": "3740",
+    "ville": "Toronto",
+    "adresse": "2245 Islington Ave, Toronto, ON, M9W 3W6",
+    "slug": "rexdale-on"
+  },
+  {
+    "id_store": "1081",
+    "ville": "Woodbridge",
+    "adresse": "8300 Hwy 27, Woodbridge, ON, L4H 0R9",
+    "slug": "vaughan-w-on"
+  },
+  {
+    "id_store": "1043",
+    "ville": "Woodstock",
+    "adresse": "430 Connell St, Woodstock, NB, E7M 5R5",
+    "slug": "woodstock-nb"
+  },
+  {
+    "id_store": "5742",
+    "ville": "Bolton",
+    "adresse": "150 Mcewan Dr E, Bolton, ON, L7E 2Y3",
+    "slug": "bolton-ont"
+  },
+  {
+    "id_store": "1013",
+    "ville": "Grand Falls",
+    "adresse": "494 Ch Madawaska, Grand Falls, NB, E3Y 1A3",
+    "slug": "grand-falls-nb"
+  },
+  {
+    "id_store": "3031",
+    "ville": "Etobicoke",
+    "adresse": "165 N Queen St, Etobicoke, ON, M9C 1A7",
+    "slug": "etobicoke-ontario"
+  },
+  {
+    "id_store": "1126",
+    "ville": "Mississauga",
+    "adresse": "1500 Dundas St E, Mississauga, ON, L4X 1L4",
+    "slug": "mississauga-east"
+  },
+  {
+    "id_store": "3135",
+    "ville": "Brampton",
+    "adresse": "30 Coventry Rd, Brampton, ON, L6T 5P9",
+    "slug": "e-brampton-on"
+  },
+  {
+    "id_store": "3088",
+    "ville": "St. Catharines",
+    "adresse": "525 Welland Ave, LINCOLN MALL SC, St. Catharines, ON, L2M 6P3",
+    "slug": "e-st-catharines-lincoln"
+  },
+  {
+    "id_store": "3160",
+    "ville": "Niagara Falls",
+    "adresse": "7481 Oakwood Dr, Niagara Falls, ON, L2G 0J5",
+    "slug": "niagara-falls-ontario-relo-0403"
+  },
+  {
+    "id_store": "3649",
+    "ville": "Fort Erie",
+    "adresse": "750 Garrison Rd, Fort Erie, ON, L2A 1N7",
+    "slug": "fort-erie-on"
+  },
+  {
+    "id_store": "1120",
+    "ville": "Brampton",
+    "adresse": "5085 Mayfield Rd, Brampton, ON, L6R 3S9",
+    "slug": "brampton-ne"
+  },
+  {
+    "id_store": "3055",
+    "ville": "Mississauga",
+    "adresse": "100 City Centre Dr, SQ ONE SC, Mississauga, ON, L5B 2G7",
+    "slug": "mississauga-square-one-on"
+  },
+  {
+    "id_store": "1188",
+    "ville": "Brampton",
+    "adresse": "15 Resolution Dr, Brampton, ON, L6W 0A6",
+    "slug": "brampton-s"
+  },
+  {
+    "id_store": "1164",
+    "ville": "St. Catharines",
+    "adresse": "221 Glendale Ave,, St. Catharines, ON, L2T 2K9",
+    "slug": "st-catharines-c"
+  },
+  {
+    "id_store": "1039",
+    "ville": "Collingwood",
+    "adresse": "10 Cambridge St, Collingwood, ON, L9Y 0A1",
+    "slug": "collingwood-on"
+  },
+  {
+    "id_store": "3172",
+    "ville": "St. Catharines",
+    "adresse": "420 Vansickle Rd, St. Catharines, ON, L2S 0C7",
+    "slug": "w-st-catharines-on"
+  },
+  {
+    "id_store": "1061",
+    "ville": "Mississauga",
+    "adresse": "800 Matheson Blvd W, Mississauga, ON, L5V 2N6",
+    "slug": "heartland-mississauga-on"
+  },
+  {
+    "id_store": "3198",
+    "ville": "Rimouski",
+    "adresse": "415 Montee Industrielle-et-commerciale, Rimouski, QC, G5M 1Y1",
+    "slug": "rimouski-quebec"
+  },
+  {
+    "id_store": "3130",
+    "ville": "Brampton",
+    "adresse": "50 Quarry Edge Dr, Brampton, ON, L6V 4K2",
+    "slug": "n-brampton-on"
+  },
+  {
+    "id_store": "3654",
+    "ville": "Mississauga",
+    "adresse": "2160 Burnhamthorpe Rd W, Mississauga, ON, L5L 5Z5",
+    "slug": "erin-mills-miss-ont"
+  },
+  {
+    "id_store": "1211",
+    "ville": "Mississauga West",
+    "adresse": "5100 Erin Mills Pky, Mississauga West, ON, L5M 4Z5",
+    "slug": "mississauga-west-on"
+  },
+  {
+    "id_store": "1079",
+    "ville": "Brampton",
+    "adresse": "9455 Mississauga Rd, Brampton, ON, L6X 0Z8",
+    "slug": "brampton-on"
+  },
+  {
+    "id_store": "3110",
+    "ville": "Welland",
+    "adresse": "102 Primeway Dr, Welland, ON, L3B 0A1",
+    "slug": "welland-ontario"
+  },
+  {
+    "id_store": "3054",
+    "ville": "Meadowvale",
+    "adresse": "3155 Argentia Rd, Meadowvale, ON, L5N 8E1",
+    "slug": "meadowvale-ontario"
+  },
+  {
+    "id_store": "3064",
+    "ville": "Oakville",
+    "adresse": "234 Hays Blvd, Oakville, ON, L6H 6M4",
+    "slug": "oakville-ontario"
+  },
+  {
+    "id_store": "3142",
+    "ville": "Orangeville",
+    "adresse": "95 1st St, Orangeville, ON, L9W 2E8",
+    "slug": "orangeville-on"
+  },
+  {
+    "id_store": "3034",
+    "ville": "Georgetown",
+    "adresse": "300 Guelph St, Georgetown, ON, L7G 4B1",
+    "slug": "georgetown-ontario-relo-0408"
+  },
+  {
+    "id_store": "1000",
+    "ville": "Milton",
+    "adresse": "1280 Steeles Ave E, Milton, ON, L9T 6R1",
+    "slug": "milton-on"
+  },
+  {
+    "id_store": "3170",
+    "ville": "Burlington",
+    "adresse": "4515 Dundas St, RR 1, Burlington, ON, L7M 5B4",
+    "slug": "burlington-n-on"
+  },
+  {
+    "id_store": "3141",
+    "ville": "Burlington",
+    "adresse": "2065 Fairview St, Burlington, ON, L7R 0B4",
+    "slug": "burlington-s-on"
+  },
+  {
+    "id_store": "3096",
+    "ville": "Hamilton",
+    "adresse": "510 Centennial Pkwy N, Hamilton, ON, L8E 0G2",
+    "slug": "stoney-creek-on"
+  },
+  {
+    "id_store": "3097",
+    "ville": "Sudbury",
+    "adresse": "1349 Lasalle Blvd, Sudbury, ON, P3A 1Z2",
+    "slug": "sudbury-ontario"
+  },
+  {
+    "id_store": "1121",
+    "ville": "Hamilton",
+    "adresse": "1115 Barton St E, Hamilton, ON, L8H 2V2",
+    "slug": "hamilton-centre"
+  },
+  {
+    "id_store": "1107",
+    "ville": "Waterdown",
+    "adresse": "90 Dundas St E, Waterdown, ON, L9H 0C2",
+    "slug": "dundas-ontario"
+  },
+  {
+    "id_store": "1042",
+    "ville": "Hannon",
+    "adresse": "2190 Rymal Rd E, Hannon, ON, L0R 1P0",
+    "slug": "hamilton-se"
+  },
+  {
+    "id_store": "1105",
+    "ville": "Sudbury",
+    "adresse": "2416 Long Lake Rd, Sudbury, ON, P3E 0C5",
+    "slug": "sudbury-south-on"
+  },
+  {
+    "id_store": "3037",
+    "ville": "Hamilton",
+    "adresse": "675 Upper James St, HAMILTON MTN PLAZA, Hamilton, ON, L9C 2Z5",
+    "slug": "hamilton-ont-relo-0401"
+  },
+  {
+    "id_store": "1199",
+    "ville": "Guelph",
+    "adresse": "175 Stone Rd W, Guelph, ON, N1G 5L4",
+    "slug": "guelph-s"
+  },
+  {
+    "id_store": "1130",
+    "ville": "Fergus",
+    "adresse": "801 St David St N, Fergus, ON, N1M 2L1",
+    "slug": "fergus"
+  },
+  {
+    "id_store": "3144",
+    "ville": "Guelph",
+    "adresse": "11 Woodlawn Rd W, Guelph, ON, N1H 1G8",
+    "slug": "guelph-ontario"
+  },
+  {
+    "id_store": "3127",
+    "ville": "Ancaster",
+    "adresse": "1051 Garner Rd W, Ancaster, ON, L9G 3K9",
+    "slug": "ancaster-on"
+  },
+  {
+    "id_store": "3067",
+    "ville": "Owen Sound",
+    "adresse": "1555 18th Ave E, Owen Sound, ON, N4K 6Y3",
+    "slug": "owen-sound-ontario"
+  },
+  {
+    "id_store": "1007",
+    "ville": "Kitchener",
+    "adresse": "1400 Ottawa St S, UNIT E, Kitchener, ON, N2E 4E2",
+    "slug": "kitchener-w-on"
+  },
+  {
+    "id_store": "3152",
+    "ville": "Cambridge",
+    "adresse": "22 Pinebush Rd, Cambridge, ON, N1R 8K5",
+    "slug": "cambridge-ontario"
+  },
+  {
+    "id_store": "3032",
+    "ville": "Fredericton",
+    "adresse": "1399 Regent St, REGENT MALL, Fredericton, NB, E3C 1A3",
+    "slug": "fredericton-new-brunswick"
+  },
+  {
+    "id_store": "1067",
+    "ville": "Fredericton",
+    "adresse": "125 Two Nations Cross, Fredericton, NB, E3A 0T3",
+    "slug": "fredericton-north-nb"
+  },
+  {
+    "id_store": "3045",
+    "ville": "Kitchener",
+    "adresse": "2960 Kingsway Dr, FAIRVIEW PK SC, Kitchener, ON, N2C 1X1",
+    "slug": "kitchener-ontario"
+  },
+  {
+    "id_store": "3002",
+    "ville": "Baie-comeau",
+    "adresse": "630 Boul Lafleche, Baie-comeau, QC, G5C 2Y3",
+    "slug": "baie-comeau-quebec"
+  },
+  {
+    "id_store": "1156",
+    "ville": "Waterloo",
+    "adresse": "70 Bridgeport Rd E, Waterloo, ON, N2J 2J9",
+    "slug": "waterloo-centre"
+  },
+  {
+    "id_store": "3005",
+    "ville": "Brantford",
+    "adresse": "1-300 King George Rd, Brantford, ON, N3R 5L7",
+    "slug": "brantford-ontario"
+  },
+  {
+    "id_store": "3156",
+    "ville": "Waterloo",
+    "adresse": "335 Farmers Market Rd Unit 101, Waterloo, ON, N2V 0A4",
+    "slug": "waterloo-ontario"
+  },
+  {
+    "id_store": "3129",
+    "ville": "Hanover",
+    "adresse": "1100 10th St, Hanover, ON, N4N 3B8",
+    "slug": "hanover-on"
+  },
+  {
+    "id_store": "1111",
+    "ville": "Kitchener",
+    "adresse": "100 The Boardwalk, Kitchener, ON, N2N 0B1",
+    "slug": "waterloo-west-on"
+  },
+  {
+    "id_store": "1025",
+    "ville": "Matane",
+    "adresse": "150 Rue Piuze, Matane, QC, G4W 4T2",
+    "slug": "matane-qc"
+  },
+  {
+    "id_store": "1160",
+    "ville": "Listowel",
+    "adresse": "600 Mitchell Rd S, Listowel, ON, N4W 3T1",
+    "slug": "listowel"
+  },
+  {
+    "id_store": "5752",
+    "ville": "Simcoe",
+    "adresse": "160 Queensway E, Simcoe, ON, N3Y 0A8",
+    "slug": "simcoe-on"
+  },
+  {
+    "id_store": "1059",
+    "ville": "Port Elgin",
+    "adresse": "5122 On-21, Port Elgin, ON, N0H 2C0",
+    "slug": "port-elgin-on"
+  },
+  {
+    "id_store": "3737",
+    "ville": "Atholville",
+    "adresse": "4 Jagoe St, Atholville, NB, E3N 5C3",
+    "slug": "atholville-new-brunswick"
+  },
+  {
+    "id_store": "3120",
+    "ville": "Woodstock",
+    "adresse": "499 Norwich Ave, Woodstock, ON, N4S 9A2",
+    "slug": "woodstock-ontario"
+  },
+  {
+    "id_store": "1125",
+    "ville": "Stratford",
+    "adresse": "920 Ontario St, Stratford, ON, N5A 3K1",
+    "slug": "stratford"
+  },
+  {
+    "id_store": "1175",
+    "ville": "Saint John",
+    "adresse": "621 Fairville Blvd, Saint John, NB, E2M 4X5",
+    "slug": "saint-john-w"
+  },
+  {
+    "id_store": "3091",
+    "ville": "Saint John",
+    "adresse": "450 Westmorland Rd, Saint John, NB, E2J 4Z2",
+    "slug": "saint-john-new-brunswick"
+  },
+  {
+    "id_store": "3103",
+    "ville": "Tillsonburg",
+    "adresse": "170 Broadway, NORFOLK MALL, Tillsonburg, ON, N4G 5A8",
+    "slug": "tillsonburg-ontario-relo-0407"
+  },
+  {
+    "id_store": "3104",
+    "ville": "Timmins",
+    "adresse": "1870 Riverside Dr Rr 2, Timmins, ON, P4R 1N7",
+    "slug": "timmins-ontario"
+  },
+  {
+    "id_store": "3126",
+    "ville": "Goderich",
+    "adresse": "35400 Huron Rd Rr2, Goderich, ON, N7A 3X8",
+    "slug": "goderich-on"
+  },
+  {
+    "id_store": "3049",
+    "ville": "E. London",
+    "adresse": "330 Clarke Rd, E. London, ON, N5W 6G4",
+    "slug": "e-london-argyle-mall-on"
+  },
+  {
+    "id_store": "1157",
+    "ville": "London",
+    "adresse": "1275 Highbury Ave N, London, ON, N5Y 1A8",
+    "slug": "london-northland"
+  },
+  {
+    "id_store": "3051",
+    "ville": "London",
+    "adresse": "1105 Wellington Rd, London, ON, N6E 1V4",
+    "slug": "s-london-white-oaks-mall"
+  },
+  {
+    "id_store": "1052",
+    "ville": "Sussex",
+    "adresse": "80 Main St, Sussex, NB, E4E 1Y6",
+    "slug": "sussex-nb"
+  },
+  {
+    "id_store": "3050",
+    "ville": "London",
+    "adresse": "1280 Fanshawe Pk Rd W, London, ON, N6G 5B1",
+    "slug": "n-london-oakridge-mall-on"
+  },
+  {
+    "id_store": "1017",
+    "ville": "Digby",
+    "adresse": "492 Hwy 303 Post Box 2140, Digby, NS, B0V 1A0",
+    "slug": "digby-ns"
+  },
+  {
+    "id_store": "1016",
+    "ville": "Yarmouth",
+    "adresse": "108 Starrs Rd, Yarmouth, NS, B5A 2T5",
+    "slug": "yarmouth-ns"
+  },
+  {
+    "id_store": "3197",
+    "ville": "St. Thomas",
+    "adresse": "1063 Talbot St Unit # 60, St. Thomas, ON, N5P 1G4",
+    "slug": "st-thomas-on"
+  },
+  {
+    "id_store": "3003",
+    "ville": "Bathurst",
+    "adresse": "900 St Anne St, Bathurst, NB, E2A 6X2",
+    "slug": "bathurst"
+  },
+  {
+    "id_store": "5833",
+    "ville": "Miramichi",
+    "adresse": "200 Douglastown Blvd, Miramichi, NB, E1V 7T9",
+    "slug": "miramichi-nb"
+  },
+  {
+    "id_store": "1038",
+    "ville": "Strathroy",
+    "adresse": "150 Carroll St E Rr 1, Strathroy, ON, N7G 4G2",
+    "slug": "strathroy-on"
+  },
+  {
+    "id_store": "3659",
+    "ville": "Moncton",
+    "adresse": "25 Plaza Blvd, Moncton, NB, E1C 0G3",
+    "slug": "moncton-west-nb"
+  },
+  {
+    "id_store": "3056",
+    "ville": "Dieppe",
+    "adresse": "477 Paul St, Dieppe, NB, E1A 5B2",
+    "slug": "moncton-new-brunswick"
+  },
+  {
+    "id_store": "1177",
+    "ville": "Greenwood",
+    "adresse": "1065 Central Ave, Greenwood, NS, B0P 1N0",
+    "slug": "greenwood"
+  },
+  {
+    "id_store": "3082",
+    "ville": "Sarnia",
+    "adresse": "1444 Quinn Dr, Sarnia, ON, N7S 6M8",
+    "slug": "sarnia-ontario"
+  },
+  {
+    "id_store": "3041",
+    "ville": "Kapuskasing",
+    "adresse": "350 Government Rd E, Kapuskasing, ON, P5N 2X7",
+    "slug": "kapuskasing-ontario"
+  },
+  {
+    "id_store": "3085",
+    "ville": "Sept-iles",
+    "adresse": "1005 Boul Laure Unit 500, Sept-iles, QC, G4R 4S6",
+    "slug": "sept-iles-quebec"
+  },
+  {
+    "id_store": "3738",
+    "ville": "New Minas",
+    "adresse": "9121 Commercial St, New Minas, NS, B4N 3E7",
+    "slug": "new-minas-ns"
+  },
+  {
+    "id_store": "3016",
+    "ville": "Chatham",
+    "adresse": "881 St Clair St, Chatham, ON, N7L 0E9",
+    "slug": "chatham-on"
+  },
+  {
+    "id_store": "1064",
+    "ville": "Wallaceburg",
+    "adresse": "60 Mcnaughton Ave Unit # 16, Wallaceburg, ON, N8A 1R9",
+    "slug": "wallaceburg-on"
+  },
+  {
+    "id_store": "1003",
+    "ville": "Bridgewater",
+    "adresse": "60 Pine Grove Rd, Bridgewater, NS, B4V 4H2",
+    "slug": "bridgewater-ns"
+  },
+  {
+    "id_store": "5789",
+    "ville": "Amherst",
+    "adresse": "46 Robert Angus Dr, Amherst, NS, B4H 4R7",
+    "slug": "amherst-ns"
+  },
+  {
+    "id_store": "3644",
+    "ville": "Summerside",
+    "adresse": "511 Granville St, Summerside, PE, C1N 5J4",
+    "slug": "summerside-pei"
+  },
+  {
+    "id_store": "3155",
+    "ville": "Sault Ste. Marie",
+    "adresse": "446 Great Northern Rd, Sault Ste. Marie, ON, P6B 4Z9",
+    "slug": "sault-ste-marie-ontario"
+  },
+  {
+    "id_store": "3164",
+    "ville": "Leamington",
+    "adresse": "304 Erie St S, Leamington, ON, N8H 3C5",
+    "slug": "leamington-ontario"
+  },
+  {
+    "id_store": "3115",
+    "ville": "Windsor",
+    "adresse": "7100 Tecumseh Rd E, Windsor, ON, N8T 1E6",
+    "slug": "e-windsor-gateway-plaza-on"
+  },
+  {
+    "id_store": "3114",
+    "ville": "Windsor",
+    "adresse": "3120 Dougall Ave, GATEWAY PLAZA, Windsor, ON, N9E 1S7",
+    "slug": "s-windsor-gateway-plaza"
+  },
+  {
+    "id_store": "3138",
+    "ville": "Halifax",
+    "adresse": "220 Chain Lake Dr, Halifax, NS, B3S 1C5",
+    "slug": "halifax-nova-scotia"
+  },
+  {
+    "id_store": "3081",
+    "ville": "Bedford",
+    "adresse": "141 Damascus Rd, Bedford, NS, B4A 0C2",
+    "slug": "sackville-nova-scotia"
+  },
+  {
+    "id_store": "3636",
+    "ville": "Halifax",
+    "adresse": "6990 Mumford Rd, Halifax, NS, B3L 4W4",
+    "slug": "halifax-centre-ns"
+  },
+  {
+    "id_store": "3021",
+    "ville": "Dartmouth",
+    "adresse": "90 Lamont Terr, Dartmouth, NS, B3B 0B5",
+    "slug": "dartmouth-nova-scotia"
+  },
+  {
+    "id_store": "1176",
+    "ville": "Dartmouth",
+    "adresse": "900 Cole Harbour Rd, Dartmouth, NS, B2V 2J5",
+    "slug": "dartmouth-south"
+  },
+  {
+    "id_store": "3184",
+    "ville": "Truro",
+    "adresse": "140 Wade Rd, Truro, NS, B2N 7H3",
+    "slug": "truro-ns"
+  },
+  {
+    "id_store": "1072",
+    "ville": "Amherstburg",
+    "adresse": "400 Sandwich St S, Amherstburg, ON, N9V 3L4",
+    "slug": "amherstburg-on"
+  },
+  {
+    "id_store": "3162",
+    "ville": "Charlottetown",
+    "adresse": "80 Buchanan Dr, Charlottetown, PE, C1E 2E5",
+    "slug": "charlottetown-pei"
+  },
+  {
+    "id_store": "3061",
+    "ville": "New Glasgow",
+    "adresse": "713 Westville Rd, New Glasgow, NS, B2H 2J6",
+    "slug": "new-glasgow-nova-scotia"
+  },
+  {
+    "id_store": "1014",
+    "ville": "Antigonish",
+    "adresse": "# 50 Market St, Antigonish, NS, B2G 3B4",
+    "slug": "antigonish-ns"
+  },
+  {
+    "id_store": "1035",
+    "ville": "Labrador City",
+    "adresse": "500 Vanier Ave, UNIT # 1000, Labrador City, NL, A2V 2W7",
+    "slug": "labrador-city-nl"
+  },
+  {
+    "id_store": "3068",
+    "ville": "Port Hawkesbury",
+    "adresse": "47 Paint St Unit 17, Port Hawkesbury, NS, B9A 3J9",
+    "slug": "port-hawkesbury-ns"
+  },
+  {
+    "id_store": "1178",
+    "ville": "North Sydney",
+    "adresse": "116 King St, North Sydney, NS, B2A 3R7",
+    "slug": "north-sydney"
+  },
+  {
+    "id_store": "3100",
+    "ville": "Sydney",
+    "adresse": "65 Keltic Dr, Sydney, NS, B1S 1P4",
+    "slug": "sydney-nova-scotia"
+  },
+  {
+    "id_store": "3101",
+    "ville": "Sydney",
+    "adresse": "80 Sydney Port Access Rd, Sydney, NS, B1P 7H9",
+    "slug": "sydney-nova-scotia-3101"
+  },
+  {
+    "id_store": "3124",
+    "ville": "Thunder Bay",
+    "adresse": "777 Memorial Ave, Thunder Bay, ON, P7B 3Z7",
+    "slug": "thunder-bay-on"
+  },
+  {
+    "id_store": "1166",
+    "ville": "Thunder Bay",
+    "adresse": "1020 Dawson Rd, Thunder Bay, ON, P7B 1K6",
+    "slug": "thunder-bay-north"
+  },
+  {
+    "id_store": "1165",
+    "ville": "Thunder Bay",
+    "adresse": "1101 Arthur St W, Thunder Bay, ON, P7E 5S2",
+    "slug": "thunder-bay-s"
+  },
+  {
+    "id_store": "3095",
+    "ville": "Stephenville",
+    "adresse": "42 Queen St, STEPHENVILLE SC, Stephenville, NL, A2N 3A7",
+    "slug": "stephenville-newfoundland"
+  },
+  {
+    "id_store": "3185",
+    "ville": "Corner Brook",
+    "adresse": "16 Murphy Sq, Corner Brook, NL, A2H 1R4",
+    "slug": "corner-brook-newfoundland"
+  },
+  {
+    "id_store": "3036",
+    "ville": "Grand Falls-windsor",
+    "adresse": "19 Cromer Ave, EXPLOITS VALLEY MALL, Grand Falls-windsor, NL, A2A 1X3",
+    "slug": "grand-falls-newfoundland"
+  },
+  {
+    "id_store": "1026",
+    "ville": "Marystown",
+    "adresse": "272 Mcgettigan Blvd, PO BOX 40, Marystown, NL, A0E 2M0",
+    "slug": "marystown-nl"
+  },
+  {
+    "id_store": "3024",
+    "ville": "Dryden",
+    "adresse": "Hwy # 17 E, STATION MAIN HWY, Dryden, ON, P8N 2Z4",
+    "slug": "dryden-ontario"
+  },
+  {
+    "id_store": "5806",
+    "ville": "Fort Frances",
+    "adresse": "1250 King ' S Hwy, Fort Frances, ON, P9A 2X6",
+    "slug": "fort-frances-ont"
+  },
+  {
+    "id_store": "3033",
+    "ville": "Gander",
+    "adresse": "55 Roe Ave P O Box 448, Gander, NL, A1V 1W8",
+    "slug": "gander-newfoundland"
+  },
+  {
+    "id_store": "3018",
+    "ville": "Clarenville",
+    "adresse": "11 Shoal Harbour Dr, Clarenville, NL, A5A 2C3",
+    "slug": "clarenville-nl"
+  },
+  {
+    "id_store": "5854",
+    "ville": "Kenora",
+    "adresse": "24 Miikana Way Unit # 1, Kenora, ON, P9N 4J1",
+    "slug": "kenora-on"
+  },
+  {
+    "id_store": "3015",
+    "ville": "Carbonear",
+    "adresse": "120 Columbus Dr, TRINITY CONCEPTION SQUARE MALL, Carbonear, NL, A1Y 1B3",
+    "slug": "carbonear-nl"
+  },
+  {
+    "id_store": "3093",
+    "ville": "Mount Pearl",
+    "adresse": "60 Merchant Dr, Mount Pearl, NL, A1N 5J5",
+    "slug": "mount-pearl-nl"
+  },
+  {
+    "id_store": "3092",
+    "ville": "St. John's",
+    "adresse": "75 Kelsey Dr, ST. JOHN'S CENTRAL, St. John's, NL, A1B 0C7",
+    "slug": "c-st-john-s-nl"
+  },
+  {
+    "id_store": "3196",
+    "ville": "St. John's",
+    "adresse": "90 Aberdeen Ave, St. John's, NL, A1A 5N6",
+    "slug": "e-st-john-s-nl"
+  },
+  {
+    "id_store": "1141",
+    "ville": "Steinbach",
+    "adresse": "184 Pth 12 N, Steinbach, MB, R5G 0Y1",
+    "slug": "steinbach"
+  },
+  {
+    "id_store": "1027",
+    "ville": "Selkirk",
+    "adresse": "1016 Manitoba Ave, Selkirk, MB, R1A 4M1",
+    "slug": "selkirk-mb"
+  },
+  {
+    "id_store": "3107",
+    "ville": "Winnipeg",
+    "adresse": "1576 Regent Ave W, Winnipeg, MB, R2C 3B4",
+    "slug": "e-winnipeg-manitoba"
+  },
+  {
+    "id_store": "1204",
+    "ville": "Winnipeg",
+    "adresse": "35 Lakewood Blvd, Winnipeg, MB, R2J 2M8",
+    "slug": "winnipeg-se"
+  },
+  {
+    "id_store": "3119",
+    "ville": "Winnipeg",
+    "adresse": "# 54-1225 St Mary ' S Rd, ST VITAL CTR, Winnipeg, MB, R2M 5E6",
+    "slug": "s-winnipeg-st-vital-ctr"
+  },
+  {
+    "id_store": "1186",
+    "ville": "Winnipeg",
+    "adresse": "1000 Taylor Ave, Winnipeg, MB, R3M 1T6",
+    "slug": "winnipeg-grant-park"
+  },
+  {
+    "id_store": "3118",
+    "ville": "Winnipeg",
+    "adresse": "2370 Mcphillips St, Winnipeg, MB, R2V 4J6",
+    "slug": "n-winnipeg-garden-city"
+  },
+  {
+    "id_store": "3177",
+    "ville": "Winnipeg",
+    "adresse": "1665 Kenaston Blvd, Winnipeg, MB, R3P 2M4",
+    "slug": "sw-winnipg-manitoba"
+  },
+  {
+    "id_store": "3116",
+    "ville": "Winnipeg",
+    "adresse": "1001 Empress St, Winnipeg, MB, R3G 3P8",
+    "slug": "c-winnipeg-manitoba"
+  },
+  {
+    "id_store": "3117",
+    "ville": "Winnipeg",
+    "adresse": "3655 Portage Ave, UNICITY MALL, Winnipeg, MB, R3K 2G6",
+    "slug": "w-winnipeg-manitoba"
+  },
+  {
+    "id_store": "1022",
+    "ville": "Winkler",
+    "adresse": "1000 Navigator Rd Box 1720, Winkler, MB, R6W 0L8",
+    "slug": "winkler-mb"
+  },
+  {
+    "id_store": "3069",
+    "ville": "Portage La Prairie",
+    "adresse": "2348 Sissons Dr, Portage La Prairie, MB, R1N 0G5",
+    "slug": "portage-la-prairie-man"
+  },
+  {
+    "id_store": "3004",
+    "ville": "Brandon",
+    "adresse": "903 18th St N, Brandon, MB, R7A 7S1",
+    "slug": "brandon-manitoba"
+  },
+  {
+    "id_store": "3102",
+    "ville": "Thompson",
+    "adresse": "300 Mystery Lake Rd, Thompson, MB, R8N 0M2",
+    "slug": "thompson-manitoba"
+  },
+  {
+    "id_store": "3022",
+    "ville": "Dauphin",
+    "adresse": "1450 Main St S, Dauphin, MB, R7N 3H4",
+    "slug": "dauphin-manitoba"
+  },
+  {
+    "id_store": "3176",
+    "ville": "Yorkton",
+    "adresse": "240 Hamilton Rd, Yorkton, SK, S3N 4C6",
+    "slug": "yorkton-sk"
+  },
+  {
+    "id_store": "3660",
+    "ville": "Flin Flon",
+    "adresse": "200 Mb-10 Alt, Flin Flon, MB, R8A 0C6",
+    "slug": "flin-flon-manitoba"
+  },
+  {
+    "id_store": "3030",
+    "ville": "Estevan",
+    "adresse": "413 Kensington Ave Box 609, Estevan, SK, S4A 2A5",
+    "slug": "estevan-saskatchewan"
+  },
+  {
+    "id_store": "5790",
+    "ville": "Weyburn",
+    "adresse": "1000 Sims Ave, Weyburn, SK, S4H 3N9",
+    "slug": "weyburn-saskatchewan"
+  },
+  {
+    "id_store": "3179",
+    "ville": "Regina",
+    "adresse": "2150 Prince Of Wales Dr, Regina, SK, S4V 3A6",
+    "slug": "e-regina-sk"
+  },
+  {
+    "id_store": "3076",
+    "ville": "Regina",
+    "adresse": "3939 Rochdale Blvd, Regina, SK, S4X 4P7",
+    "slug": "n-regina-northgate-mall"
+  },
+  {
+    "id_store": "3077",
+    "ville": "Regina",
+    "adresse": "4500 Gordon Rd, Regina, SK, S4W 0B7",
+    "slug": "s-regina"
+  },
+  {
+    "id_store": "3173",
+    "ville": "Moose Jaw",
+    "adresse": "551 Thatcher Dr E, Moose Jaw, SK, S6J 1L8",
+    "slug": "moose-jaw-sk"
+  },
+  {
+    "id_store": "3073",
+    "ville": "Prince Albert",
+    "adresse": "800 15 St E, Prince Albert, SK, S6V 8E3",
+    "slug": "prince-albert-sk"
+  },
+  {
+    "id_store": "3084",
+    "ville": "Saskatoon",
+    "adresse": "1706 Preston Ave N, Saskatoon, SK, S7N 4Y1",
+    "slug": "saskatoon-n"
+  },
+  {
+    "id_store": "5878",
+    "ville": "Saskatoon",
+    "adresse": "3035 Clarence Ave S, Saskatoon, SK, S7T 0B6",
+    "slug": "saskatoon-south"
+  },
+  {
+    "id_store": "3083",
+    "ville": "Saskatoon",
+    "adresse": "225 Betts Ave, Saskatoon, SK, S7M 1L2",
+    "slug": "saskatoon-west"
+  },
+  {
+    "id_store": "3099",
+    "ville": "Swift Current",
+    "adresse": "1800 22nd Ave Ne, Swift Current, SK, S9H 0E5",
+    "slug": "swift-current-sk"
+  },
+  {
+    "id_store": "3058",
+    "ville": "North Battleford",
+    "adresse": "601 Carlton Trail, North Battleford, SK, S9A 4A9",
+    "slug": "n-battleford-sk"
+  },
+  {
+    "id_store": "1065",
+    "ville": "Kindersley",
+    "adresse": "710 11th Ave E Post Box 1296, Kindersley, SK, S0L 1S0",
+    "slug": "kindersley-sk"
+  },
+  {
+    "id_store": "3168",
+    "ville": "Lloydminster",
+    "adresse": "4210 70th Ave, Lloydminster, AB, T9V 2X3",
+    "slug": "lloydminster-ab"
+  },
+  {
+    "id_store": "3640",
+    "ville": "Cold Lake",
+    "adresse": "4702 43rd Ave, Cold Lake, AB, T9M 1M9",
+    "slug": "cold-lake-alberta"
+  },
+  {
+    "id_store": "3150",
+    "ville": "Medicine Hat",
+    "adresse": "2051 Strachan Rd S E, Medicine Hat, AB, T1B 0G4",
+    "slug": "medicine-hat-ab"
+  },
+  {
+    "id_store": "1062",
+    "ville": "Wainwright",
+    "adresse": "2901 13th Ave, Wainwright, AB, T9W 0A2",
+    "slug": "wainwright-ab"
+  },
+  {
+    "id_store": "3157",
+    "ville": "Fort Mcmurray",
+    "adresse": "# 2 Hospital St, Fort Mcmurray, AB, T9H 5E4",
+    "slug": "ft-mcmurray-alberta"
+  },
+  {
+    "id_store": "3658",
+    "ville": "Brooks",
+    "adresse": "917 3rd St W, Brooks, AB, T1R 1L5",
+    "slug": "brooks-alberta"
+  },
+  {
+    "id_store": "1071",
+    "ville": "Vegreville",
+    "adresse": "6809 Hwy 16a W, Vegreville, AB, T9C 0A2",
+    "slug": "vegrville-ab"
+  },
+  {
+    "id_store": "1046",
+    "ville": "Taber",
+    "adresse": "4500 64 St, Taber, AB, T1G 0A4",
+    "slug": "taber-ab"
+  },
+  {
+    "id_store": "1028",
+    "ville": "Drumheller",
+    "adresse": "1801 S Railway Ave Box 1960, Drumheller, AB, T0J 0Y0",
+    "slug": "drumheller-ab"
+  },
+  {
+    "id_store": "1034",
+    "ville": "Stettler",
+    "adresse": "4721 70 St, Stettler, AB, T0C 2L2",
+    "slug": "stettler-alberta"
+  },
+  {
+    "id_store": "3181",
+    "ville": "Camrose",
+    "adresse": "6800 48th Ave, #400, Camrose, AB, T4V 4T1",
+    "slug": "camrose-ab"
+  },
+  {
+    "id_store": "1078",
+    "ville": "Lethbridge",
+    "adresse": "3195 26th Ave N, Lethbridge, AB, T1H 5P3",
+    "slug": "lethbridge-north-ab"
+  },
+  {
+    "id_store": "3048",
+    "ville": "Lethbridge",
+    "adresse": "3700 Mayor Magrath Dr S, Lethbridge, AB, T1K 7T6",
+    "slug": "lethbridge-alberta"
+  },
+  {
+    "id_store": "5753",
+    "ville": "Fort Saskatchewan",
+    "adresse": "9551 87th Ave, Fort Saskatchewan, AB, T8L 4N3",
+    "slug": "fort-sask-alberta"
+  },
+  {
+    "id_store": "1123",
+    "ville": "Sherwood Park",
+    "adresse": "400-7000 Emerald Dr, Sherwood Park, AB, T8H 0P5",
+    "slug": "sherwood-park-n"
+  },
+  {
+    "id_store": "3154",
+    "ville": "Sherwood Park",
+    "adresse": "239 Wye Rd, Sherwood Park, AB, T8B 1N1",
+    "slug": "sherwood-park-ab"
+  },
+  {
+    "id_store": "1138",
+    "ville": "Edmonton",
+    "adresse": "775 Tamarack Way Nw, Edmonton, AB, T6T 0X2",
+    "slug": "edmonton-se"
+  },
+  {
+    "id_store": "3112",
+    "ville": "Wetaskiwin",
+    "adresse": "3600 56th St Suite 300, Wetaskiwin, AB, T9A 3T5",
+    "slug": "wetaskiwin-alberta"
+  },
+  {
+    "id_store": "3028",
+    "ville": "Edmonton",
+    "adresse": "13703 40th St N W, Edmonton, AB, T5Y 3B5",
+    "slug": "ne-edmonton-londonderry"
+  },
+  {
+    "id_store": "1187",
+    "ville": "Edmonton",
+    "adresse": "110 Watt Common Sw, Edmonton, AB, T6X 1X2",
+    "slug": "edmonton-sse"
+  },
+  {
+    "id_store": "3026",
+    "ville": "Edmonton",
+    "adresse": "5004 98 Ave Nw, SUITE 1, Edmonton, AB, T6A 0A1",
+    "slug": "e-edmonton-capilano-s-c"
+  },
+  {
+    "id_store": "3029",
+    "ville": "Edmonton",
+    "adresse": "1203 Parsons Rd N W, Edmonton, AB, T6N 0A9",
+    "slug": "s-edmonton-alberta"
+  },
+  {
+    "id_store": "1146",
+    "ville": "Edmonton",
+    "adresse": "9499 137 Ave Nw, NORTHGATE CENTRE, Edmonton, AB, T5E 5R8",
+    "slug": "edmonton-northgate"
+  },
+  {
+    "id_store": "1145",
+    "ville": "Edmonton",
+    "adresse": "3931 Calgary Trail Nw, Edmonton, AB, T6J 5M8",
+    "slug": "edmonton-south-park"
+  },
+  {
+    "id_store": "1049",
+    "ville": "Strathmore",
+    "adresse": "200 Ranch Market, Strathmore, AB, T1P 0A8",
+    "slug": "strathmore-ab"
+  },
+  {
+    "id_store": "1182",
+    "ville": "Edmonton",
+    "adresse": "1 Kingsway Gdn Mall, UNIT 101, Edmonton, AB, T5G 3A6",
+    "slug": "edmonton-kingsway"
+  },
+  {
+    "id_store": "1122",
+    "ville": "Edmonton",
+    "adresse": "16940 127 St Nw, Edmonton, AB, T6V 1J6",
+    "slug": "edmonton-nw-albany"
+  },
+  {
+    "id_store": "3657",
+    "ville": "Leduc",
+    "adresse": "5302 Discovery Way, Leduc, AB, T9E 8J7",
+    "slug": "leduc-alberta"
+  },
+  {
+    "id_store": "1149",
+    "ville": "Edmonton",
+    "adresse": "156 87 Ave Nw, Edmonton, AB, T5R 5X1",
+    "slug": "edmonton-meadowlark"
+  },
+  {
+    "id_store": "1094",
+    "ville": "Edmonton",
+    "adresse": "6110 Currents Dr Nw, Edmonton, AB, T6W 0L7",
+    "slug": "edmonton-ab"
+  },
+  {
+    "id_store": "3087",
+    "ville": "St. Albert",
+    "adresse": "700 St Albert Trail, St. Albert, AB, T8N 7A5",
+    "slug": "st-albert-alberta"
+  },
+  {
+    "id_store": "3027",
+    "ville": "Edmonton",
+    "adresse": "18521 Stony Plain Rd Nw, Edmonton, AB, T5S 2V9",
+    "slug": "w-edmonton-mayfield-com"
+  },
+  {
+    "id_store": "3075",
+    "ville": "Red Deer",
+    "adresse": "6375 50th Ave, Red Deer, AB, T4N 4C7",
+    "slug": "n-red-deer-parkland-mall"
+  },
+  {
+    "id_store": "3194",
+    "ville": "Red Deer",
+    "adresse": "2010 50th Ave, Red Deer, AB, T4R 3A2",
+    "slug": "s-red-deer-alberta"
+  },
+  {
+    "id_store": "3637",
+    "ville": "Spruce Grove",
+    "adresse": "90 Campsite Rd, Spruce Grove, AB, T7X 4H4",
+    "slug": "spruce-grove-ab"
+  },
+  {
+    "id_store": "1136",
+    "ville": "Calgary",
+    "adresse": "255 East Hills Blvd Se, Calgary, AB, T2A 4X7",
+    "slug": "calgary-east-hills"
+  },
+  {
+    "id_store": "1102",
+    "ville": "Sylvan Lake",
+    "adresse": "3420 47th Ave, Sylvan Lake, AB, T4S 0B6",
+    "slug": "sylvan-lake-ab"
+  },
+  {
+    "id_store": "3012",
+    "ville": "Calgary",
+    "adresse": "3800 Memorial Dr, UNIT 1100, Calgary, AB, T2A 2K2",
+    "slug": "e-calgary-marlborough"
+  },
+  {
+    "id_store": "1050",
+    "ville": "Airdrie",
+    "adresse": "2881 Main St Se, Airdrie, AB, T4B 3G5",
+    "slug": "airdrie-ab"
+  },
+  {
+    "id_store": "3650",
+    "ville": "Calgary",
+    "adresse": "4705 130 Ave Se, Calgary, AB, T2Z 4J2",
+    "slug": "calgary-south-east-ab"
+  },
+  {
+    "id_store": "5708",
+    "ville": "Okotoks",
+    "adresse": "500-201 Southridge Dr, Okotoks, AB, T1S 2C8",
+    "slug": "okotoks-ab"
+  },
+  {
+    "id_store": "3013",
+    "ville": "Calgary",
+    "adresse": "1110 57th Ave N E, Calgary, AB, T2E 9B7",
+    "slug": "n-calgary-deerfoot-mall"
+  },
+  {
+    "id_store": "1089",
+    "ville": "Calgary",
+    "adresse": "7979-11 St Se, Calgary, AB, T2H 0B8",
+    "slug": "calgary-deerfoot-ab"
+  },
+  {
+    "id_store": "1084",
+    "ville": "Olds",
+    "adresse": "Unit 400-6900 46th St, Olds, AB, T4H 0A2",
+    "slug": "olds-ab"
+  },
+  {
+    "id_store": "3151",
+    "ville": "Calgary",
+    "adresse": "100-310 Shawville Blvd S E, Calgary, AB, T2Y 3S4",
+    "slug": "s-calgary-alberta"
+  },
+  {
+    "id_store": "3010",
+    "ville": "Calgary",
+    "adresse": "9650 Macleod Trail Se, MACLEOD MALL SC, Calgary, AB, T2J 0P7",
+    "slug": "c-calgary-mcleod-mall"
+  },
+  {
+    "id_store": "1097",
+    "ville": "Calgary",
+    "adresse": "35 Sage Hill Gate Nw, Calgary, AB, T3R 0S4",
+    "slug": "calgary-sage-hill-ab"
+  },
+  {
+    "id_store": "3011",
+    "ville": "Calgary",
+    "adresse": "5005 Northland Dr N W, Calgary, AB, T2L 2K1",
+    "slug": "nw-calgary-northland"
+  },
+  {
+    "id_store": "3009",
+    "ville": "Calgary",
+    "adresse": "1212 37th St S W, WESTBROOK PLAZA, Calgary, AB, T3C 1S3",
+    "slug": "w-calgary-westbrook"
+  },
+  {
+    "id_store": "5726",
+    "ville": "Calgary",
+    "adresse": "8888 Country Hills Blvd Nw, # 200, Calgary, AB, T3G 5T4",
+    "slug": "calgary-alberta"
+  },
+  {
+    "id_store": "1070",
+    "ville": "Pincher Creek",
+    "adresse": "1100 Table Mountain St, Pincher Creek, AB, T0K 1W0",
+    "slug": "pincher-creek-ab"
+  },
+  {
+    "id_store": "1135",
+    "ville": "Cochrane",
+    "adresse": "15 Quarry Street West, Cochrane, AB, T4C 0W5",
+    "slug": "cochrane"
+  },
+  {
+    "id_store": "1030",
+    "ville": "Slave Lake",
+    "adresse": "1500 Main St, # 601, Slave Lake, AB, T0G 2A4",
+    "slug": "slave-lake-ab"
+  },
+  {
+    "id_store": "1008",
+    "ville": "Drayton Valley",
+    "adresse": "5217 Power Centre Blvd, Drayton Valley, AB, T7A 0A5",
+    "slug": "drayton-valley-ab"
+  },
+  {
+    "id_store": "1009",
+    "ville": "Whitecourt",
+    "adresse": "4215 -52 Avenue, Whitecourt, AB, T7S 1X6",
+    "slug": "whitecourt-ab"
+  },
+  {
+    "id_store": "3183",
+    "ville": "Cranbrook",
+    "adresse": "2100 Willowbrook Dr, Cranbrook, BC, V1C 7H2",
+    "slug": "cranbrook-bc"
+  },
+  {
+    "id_store": "1048",
+    "ville": "Edson",
+    "adresse": "5750 2nd Ave, Edson, AB, T7E 0A1",
+    "slug": "edson-ab"
+  },
+  {
+    "id_store": "3121",
+    "ville": "Yellowknife",
+    "adresse": "313 Old Airport Rd, Yellowknife, NT, X1A 3T3",
+    "slug": "yellowknife-nwt"
+  },
+  {
+    "id_store": "1068",
+    "ville": "Peace River",
+    "adresse": "9701-78 St, Peace River, AB, T8S 0A3",
+    "slug": "peace-river-ab"
+  },
+  {
+    "id_store": "3038",
+    "ville": "Hinton",
+    "adresse": "# 100 900 Carmichael Lane, PARKS W MALL, Hinton, AB, T7V 1Y6",
+    "slug": "hinton-alberta"
+  },
+  {
+    "id_store": "3060",
+    "ville": "Nelson",
+    "adresse": "1000 Lakeside Dr, Nelson, BC, V1L 5Z4",
+    "slug": "nelson-british-columbia"
+  },
+  {
+    "id_store": "1011",
+    "ville": "Trail",
+    "adresse": "1601 Marcolin Dr, Trail, BC, V1R 4Y1",
+    "slug": "trail-bc"
+  },
+  {
+    "id_store": "3147",
+    "ville": "Grand-prairie",
+    "adresse": "11050-103 Ave, Grand-prairie, AB, T8V 7H1",
+    "slug": "grande-prairie-ab"
+  },
+  {
+    "id_store": "1100",
+    "ville": "Salmon Arm",
+    "adresse": "2991 10 Ave  Sw, UNIT A, Salmon Arm, BC, V1E 3J9",
+    "slug": "salmon-arm"
+  },
+  {
+    "id_store": "3169",
+    "ville": "Vernon",
+    "adresse": "2200-58 Th Ave, Vernon, BC, V1T 9T2",
+    "slug": "vernon-b-c"
+  },
+  {
+    "id_store": "5776",
+    "ville": "Dawson Creek",
+    "adresse": "# 600 Hwy 2, Dawson Creek, BC, V1G 0A4",
+    "slug": "dawson-creek-bc"
+  },
+  {
+    "id_store": "3042",
+    "ville": "Kelowna",
+    "adresse": "1555 Banks Rd, Kelowna, BC, V1X 7Y8",
+    "slug": "kelowna-british-columbia"
+  },
+  {
+    "id_store": "1093",
+    "ville": "Westbank",
+    "adresse": "2170 Louie Dr, Westbank, BC, V4T 3E5",
+    "slug": "westbank-bc"
+  },
+  {
+    "id_store": "3070",
+    "ville": "Penticton",
+    "adresse": "275 Green Ave W, Penticton, BC, V2A 7J2",
+    "slug": "penticton-bc"
+  },
+  {
+    "id_store": "3661",
+    "ville": "Fort St. John",
+    "adresse": "9007 96a St, Fort St. John, BC, V1J 7B6",
+    "slug": "fort-st-john-bc"
+  },
+  {
+    "id_store": "3040",
+    "ville": "Kamloops",
+    "adresse": "1055 Hillside Dr Unit # 100, Kamloops, BC, V2E 2S5",
+    "slug": "kamloops-british-columbia"
+  },
+  {
+    "id_store": "1036",
+    "ville": "Merritt",
+    "adresse": "100-3900 Crawford Ave, Merritt, BC, V1K 0A4",
+    "slug": "merritt-bc"
+  },
+  {
+    "id_store": "1106",
+    "ville": "Williams Lake",
+    "adresse": "1205 Prosperity Way, Williams Lake, BC, V2G 0A6",
+    "slug": "williams-lake-bc"
+  },
+  {
+    "id_store": "3199",
+    "ville": "Quesnel",
+    "adresse": "890 Rita Rd, Quesnel, BC, V2J 7J3",
+    "slug": "quesnel-b-c"
+  },
+  {
+    "id_store": "3651",
+    "ville": "Prince George",
+    "adresse": "6565 Southridge Ave, Prince George, BC, V2N 6Z4",
+    "slug": "prince-george-bc"
+  },
+  {
+    "id_store": "3167",
+    "ville": "Chilliwack",
+    "adresse": "8249 Eagle Landng Pkwy, Chilliwack, BC, V2R 0P9",
+    "slug": "chilliwack-bc"
+  },
+  {
+    "id_store": "3019",
+    "ville": "Abbotsford",
+    "adresse": "1812 Vedder Way, Abbotsford, BC, V2S 8K1",
+    "slug": "abbotsford-east"
+  },
+  {
+    "id_store": "1119",
+    "ville": "Mission",
+    "adresse": "31956 Lougheed Hwy, Mission, BC, V2V 0C6",
+    "slug": "mission"
+  },
+  {
+    "id_store": "1113",
+    "ville": "Abbotsford",
+    "adresse": "3122 Mt Lehman Rd, Abbotsford, BC, V2T 0C5",
+    "slug": "abbotsford-w-bc"
+  },
+  {
+    "id_store": "1206",
+    "ville": "Maple Ridge",
+    "adresse": "11850 224 St, Maple Ridge, BC, V2X 8S1",
+    "slug": "maple-ridge"
+  },
+  {
+    "id_store": "3158",
+    "ville": "Langley",
+    "adresse": "20202 66th Ave, Langley, BC, V2Y 1P3",
+    "slug": "langley-bc"
+  },
+  {
+    "id_store": "1112",
+    "ville": "Port Coquitlam",
+    "adresse": "2150 Hawkins St, Port Coquitlam, BC, V3B 0G6",
+    "slug": "port-coquitlam-bc"
+  },
+  {
+    "id_store": "1208",
+    "ville": "Coquitlam",
+    "adresse": "2929 Barnet Hwy, # 3010, Coquitlam, BC, V3B 5R5",
+    "slug": "coquitlam"
+  },
+  {
+    "id_store": "3098",
+    "ville": "Surrey",
+    "adresse": "10355 152 St, UNIT 1000, Surrey, BC, V3R 7C1",
+    "slug": "e-surry-bc-guildford-relo-0404"
+  },
+  {
+    "id_store": "5853",
+    "ville": "Surrey",
+    "adresse": "2355-160 St, Surrey, BC, V3Z 9N6",
+    "slug": "surrey-bc"
+  },
+  {
+    "id_store": "1205",
+    "ville": "Surrey",
+    "adresse": "2151-10153 King George Blvd, Surrey, BC, V3T 2W3",
+    "slug": "surrey-downtown"
+  },
+  {
+    "id_store": "3008",
+    "ville": "Burnaby",
+    "adresse": "9855 Austin Rd, SUITE 300, Burnaby, BC, V3J 1N5",
+    "slug": "burnaby-british-columbia"
+  },
+  {
+    "id_store": "5838",
+    "ville": "Surrey",
+    "adresse": "12451 88 Ave, Surrey, BC, V3W 1P8",
+    "slug": "surrey-west-bc"
+  },
+  {
+    "id_store": "1207",
+    "ville": "Delta",
+    "adresse": "7155 120 St, Delta, BC, V4E 2B1",
+    "slug": "surrey-sw"
+  },
+  {
+    "id_store": "1192",
+    "ville": "New Westminster",
+    "adresse": "610 Sixth St, New Westminster, BC, V3L 3C2",
+    "slug": "new-westminster-c"
+  },
+  {
+    "id_store": "5777",
+    "ville": "New Westminster",
+    "adresse": "805 Boyd St, New Westminster, BC, V3M 5X2",
+    "slug": "new-westminster-bc"
+  },
+  {
+    "id_store": "1015",
+    "ville": "Squamish",
+    "adresse": "39210 Discovery Way, Squamish, BC, V8B 0N1",
+    "slug": "squamish-bc"
+  },
+  {
+    "id_store": "1213",
+    "ville": "Burnaby",
+    "adresse": "4545 Central Blvd, Burnaby, BC, V5H 4J1",
+    "slug": "burnaby-sw"
+  },
+  {
+    "id_store": "1104",
+    "ville": "Vancouver",
+    "adresse": "3585 Grandview Hwy, Vancouver, BC, V5M 2G7",
+    "slug": "vancouver-bc"
+  },
+  {
+    "id_store": "3057",
+    "ville": "North Vancouver",
+    "adresse": "925 Marine Dr, North Vancouver, BC, V7P 1S2",
+    "slug": "n-vancouver-b-c"
+  },
+  {
+    "id_store": "3652",
+    "ville": "Richmond",
+    "adresse": "9251 Alderbridge Way, Richmond, BC, V6X 0N1",
+    "slug": "richmond-n-bc"
+  },
+  {
+    "id_store": "1181",
+    "ville": "Tsawwassen",
+    "adresse": "5143 Canoe Pass Way, Tsawwassen, BC, V4M 0B2",
+    "slug": "tsawwassen"
+  },
+  {
+    "id_store": "1214",
+    "ville": "Victoria",
+    "adresse": "1644 Hillside Ave, Victoria, BC, V8T 2C5",
+    "slug": "victoria-e-hillside-mall"
+  },
+  {
+    "id_store": "3109",
+    "ville": "Victoria",
+    "adresse": "3460 Saanich Rd, Victoria, BC, V8Z 0B9",
+    "slug": "victoria-b-c-relo-0400"
+  },
+  {
+    "id_store": "3188",
+    "ville": "Langford",
+    "adresse": "860 Langford Pkwy, Langford, BC, V9B 2P3",
+    "slug": "langford-bc"
+  },
+  {
+    "id_store": "3025",
+    "ville": "Duncan",
+    "adresse": "3020 Drinkwater Rd, Duncan, BC, V9L 6C6",
+    "slug": "duncan-bc"
+  },
+  {
+    "id_store": "3059",
+    "ville": "Nanaimo",
+    "adresse": "6801 Island Hwy N, Nanaimo, BC, V9T 6N8",
+    "slug": "nanaimo-british-columbia"
+  },
+  {
+    "id_store": "3072",
+    "ville": "Powell River",
+    "adresse": "7100 Alberni St, TOWN CTR MALL, Powell River, BC, V8A 5K9",
+    "slug": "powell-river-bc"
+  },
+  {
+    "id_store": "1018",
+    "ville": "Port Alberni",
+    "adresse": "3355 Johnston Rd (hwy 4), Port Alberni, BC, V9Y 8K1",
+    "slug": "port-alberni-bc"
+  },
+  {
+    "id_store": "3163",
+    "ville": "Courtenay",
+    "adresse": "3199 Cliffe Ave, Courtenay, BC, V9N 2L9",
+    "slug": "courtenay-bc"
+  },
+  {
+    "id_store": "1077",
+    "ville": "Campbell River",
+    "adresse": "1477 Island Hwy, Campbell River, BC, V9W 8E5",
+    "slug": "campbell-river-bc"
+  },
+  {
+    "id_store": "5834",
+    "ville": "Terrace",
+    "adresse": "4427 Hwy 16 W, Terrace, BC, V8G 5L5",
+    "slug": "terrace-bc"
+  },
+  {
+    "id_store": "1143",
+    "ville": "Prince Rupert",
+    "adresse": "500 2nd Ave W, Prince Rupert, BC, V8J 3T6",
+    "slug": "prince-rupert"
+  },
+  {
+    "id_store": "7124",
+    "ville": "Laval",
+    "adresse": "1400 Le Corbusier Blvd., Laval, QC, H7N 6J5",
+    "slug": "laval"
+  }
+]

--- a/incoming/walmart_stores_raw.tsv
+++ b/incoming/walmart_stores_raw.tsv
@@ -1,0 +1,403 @@
+7146<a href="https://www.walmart.ca/en/stores-near-me/7146" target="_blanc">MONTREAL (L'ACADIE)</a>1000, rue Sauve Ouest, Montreal, QC, H4N 3L5
+7147<a href="https://www.walmart.ca/en/stores-near-me/7147" target="_blanc">ST JEROME, QC</a>1045 boul du grand heron, St. Jerome, QC, J7Y 3P2
+1185<a href="https://www.walmart.ca/en/stores-near-me/1185" target="_blanc">BLAINVILLE</a>1333 Michele-bohec Blvd, Blainville, QC, J7C 0M4
+3080<a href="https://www.walmart.ca/en/stores-near-me/3080" target="_blanc">ROSEMERE, QUEBEC</a>401 Boul Labelle, Rosemere, QC, J7A 3T2
+3089<a href="https://www.walmart.ca/en/stores-near-me/3089" target="_blanc">ST EUSTACHE, QUEBEC</a>764 Arthur Sauve Boul, Saint-eustache, QC, J7R 4K3
+3132<a href="https://www.walmart.ca/en/stores-near-me/3132" target="_blanc">LACHUTE QUEBEC</a>480 Av Bethany, Lachute, QC, J8H 4H5
+3149<a href="https://www.walmart.ca/en/stores-near-me/3149" target="_blanc">Mascouche Supercentre</a>155 Montee Masson, Mascouche, QC, J7K 3B4
+1032<a href="https://www.walmart.ca/en/stores-near-me/1032" target="_blanc">LAVAL, QC</a>5205 Blvd Robert Bourassa, Laval, QC, H7E 0A3
+1020<a href="https://www.walmart.ca/en/stores-near-me/1020" target="_blanc">SAINTE-AGATHE-DES-MONTS,</a>400 Rue Laverdure, Sainte-agathe-des-monts, QC, J8C 0A2
+3047<a href="https://www.walmart.ca/en/stores-near-me/3047" target="_blanc">C. LAVAL, CENTRE LAVAL QC</a>2075 Boul Chomedey, Laval, QC, H7T 0G5
+3189<a href="https://www.walmart.ca/en/stores-near-me/3189" target="_blanc">W. LAVAL, QUEBEC</a>700 Autoroute Chomedey Ouest, Laval, QC, H7X 3S9
+3656<a href="https://www.walmart.ca/en/stores-near-me/3656" target="_blanc">MONTREAL NORTH, QUEBEC</a>6140 Boul Henri-bourassa E, Montreal-nord, QC, H1G 5X3
+1085<a href="https://www.walmart.ca/en/stores-near-me/1085" target="_blanc">LACHENAIE, QC</a>1001 Rue Des Migrateurs, Terrebonne, QC, J6V 0A8
+1202<a href="https://www.walmart.ca/en/stores-near-me/1202" target="_blanc">POINTE-CLAIRE</a>195 Boul Hymus, Pointe-claire, QC, H9R 1E9
+3044<a href="https://www.walmart.ca/en/stores-near-me/3044" target="_blanc">KIRKLAND, QUEBEC</a>17000 Rte Transcanadienne, Kirkland, QC, H9J 2M5
+1183<a href="https://www.walmart.ca/en/stores-near-me/1183" target="_blanc">ST-LEONARD (W)</a>7600 Boul Viau, RC 101, Saint-leonard, QC, H1S 2P3
+3094<a href="https://www.walmart.ca/en/stores-near-me/3094" target="_blanc">ST LEONARD, QUEBEC</a>7445 Boul Langelier, Saint-leonard, QC, H1S 1V6
+1189<a href="https://www.walmart.ca/en/stores-near-me/1189" target="_blanc">MONTREAL (ST-LAURENT)</a>3820 De La Cote Vertu Blvd, St-laurent, QC, H4R 1P8
+1169<a href="https://www.walmart.ca/en/stores-near-me/1169" target="_blanc">Pointe-Aux-Trembles</a>12675 Rue Sherbrooke E, Pointe-aux-trembles, QC, H1A 3W7
+3079<a href="https://www.walmart.ca/en/stores-near-me/3079" target="_blanc">REPENTIGNY, QUEBEC</a>100 Boul Brien, SUITE 66, Repentigny, QC, J6A 5N4
+1168<a href="https://www.walmart.ca/en/stores-near-me/1168" target="_blanc">Montreal (Hochelaga)</a>3121 Ave De Granby, Montreal, QC, H1N 2Z7
+3165<a href="https://www.walmart.ca/en/stores-near-me/3165" target="_blanc">COTE-ST-LUC QC</a>5400 Rue Jean-talon O, Montreal, QC, H4P 2T5
+1170<a href="https://www.walmart.ca/en/stores-near-me/1170" target="_blanc">Montreal (Cote-des-Neiges)</a>6700 Ch De La Cote-des-neiges, Montreal, QC, H3S 2B2
+1140<a href="https://www.walmart.ca/en/stores-near-me/1140" target="_blanc">Montreal (Dorval)</a>400 Dorval Ave, Dorval, QC, H9S 3H7
+1057<a href="https://www.walmart.ca/en/stores-near-me/1057" target="_blanc">VAUDREUIL, QC</a>3050 Boul De La Gare, Vaudreuil-dorion, QC, J7V 0H1
+3046<a href="https://www.walmart.ca/en/stores-near-me/3046" target="_blanc">LASALLE, QUEBEC</a>6797 Blvd Newman, Lasalle, QC, H8N 3E4
+3052<a href="https://www.walmart.ca/en/stores-near-me/3052" target="_blanc">LONGUEUIL, QUEBEC</a>1999 Boul Roland-therrien, Longueuil, QC, J4N 1A3
+1159<a href="https://www.walmart.ca/en/stores-near-me/1159" target="_blanc">Hawkesbury</a>1550 Cameron St, Hawkesbury, ON, K6A 3S5
+3039<a href="https://www.walmart.ca/en/stores-near-me/3039" target="_blanc">JOLIETTE, QUEBEC</a>1505 Boul Firestone, Joliette, QC, J6E 9E5
+1167<a href="https://www.walmart.ca/en/stores-near-me/1167" target="_blanc">LONGUEUIL (S)</a>2877 Ch De Chambly, Longueuil, QC, J4L 1M8
+1132<a href="https://www.walmart.ca/en/stores-near-me/1132" target="_blanc">Chateauguay</a>250 Boul Briseboise, Chateauguay, QC, J6K 0H5
+3642<a href="https://www.walmart.ca/en/stores-near-me/3642" target="_blanc">ST. CONSTANTS, QUEBEC</a>500 Voie De La Desserte De La Route 132, Saint-constant, QC, J5A 2S5
+3140<a href="https://www.walmart.ca/en/stores-near-me/3140" target="_blanc">ST.BRUNO, QUEBEC</a>1475 Boul St Bruno, Saint-bruno, QC, J3V 6J1
+3007<a href="https://www.walmart.ca/en/stores-near-me/3007" target="_blanc">BROSSARD, QUEBEC</a>9000 Blvd Leduc, Brossard, QC, J4Y 0E6
+3639<a href="https://www.walmart.ca/en/stores-near-me/3639" target="_blanc">VALLEYFIELD, QC</a>2050 Boul Monseigneur Langlois, Salaberry-de-valleyfield, QC, J6S 5R1
+1203<a href="https://www.walmart.ca/en/stores-near-me/1203" target="_blanc">CANDIAC</a>201 Rue Strasbourg, Candiac, QC, J5R 0B4
+1174<a href="https://www.walmart.ca/en/stores-near-me/1174" target="_blanc">Sorel Tracy</a>450 Boul Poliquin, Sorel-tracy, QC, J3P 7R5
+3090<a href="https://www.walmart.ca/en/stores-near-me/3090" target="_blanc">ST JEAN, QUEBEC</a>100 Boul Omer-marcil, St-jean-sur-richelieu, QC, J2W 2X2
+3137<a href="https://www.walmart.ca/en/stores-near-me/3137" target="_blanc">STE HYACINTHE</a>5950 Rue Martineau, Saint-hyacinthe, QC, J2R 2H6
+3020<a href="https://www.walmart.ca/en/stores-near-me/3020" target="_blanc">CORNWALL, ONTARIO</a>420 Ninth St W, Cornwall, ON, K6J 0B3
+1060<a href="https://www.walmart.ca/en/stores-near-me/1060" target="_blanc">ROCKLAND, ON</a>3001 Richelieu St, Rockland, ON, K4K 0B5
+3035<a href="https://www.walmart.ca/en/stores-near-me/3035" target="_blanc">GRANBY, QUEBEC</a>75 Simonds St N, Granby, QC, J2J 2S3
+3023<a href="https://www.walmart.ca/en/stores-near-me/3023" target="_blanc">DRUMMONDVILLE, QUEBEC</a>1205 Boul Rene-levesque, Drummondville, QC, J2C 7V4
+5839<a href="https://www.walmart.ca/en/stores-near-me/5839" target="_blanc">COWANSVILLE, QUEBEC</a>1770 Rue Du Sud, Cowansville, QC, J2K 3G8
+3065<a href="https://www.walmart.ca/en/stores-near-me/3065" target="_blanc">ORLEANS, OTTAWA, ON</a>3900 Innes Rd, Orleans, ON, K1W 1K9
+3108<a href="https://www.walmart.ca/en/stores-near-me/3108" target="_blanc">TROIS RIVERES, QUEBEC</a>4520 Boul Des Recollets, SUITE 820, Trois-rivieres, QC, G9A 4N2
+3647<a href="https://www.walmart.ca/en/stores-near-me/3647" target="_blanc">SHAWINIGAN, QC</a>1600 Blvd Royal, Shawinigan, QC, G9N 8S8
+3014<a href="https://www.walmart.ca/en/stores-near-me/3014" target="_blanc">CAP DE LA MADELEINE, QC</a>300 Rue Barkoff, Cap-de-la-madeleine, QC, G8T 2A3
+1158<a href="https://www.walmart.ca/en/stores-near-me/1158" target="_blanc">GLOUCESTER</a>1980 Ogilvie Rd, GLOUCESTER CENTRE, Gloucester, ON, K1J 9L3
+3125<a href="https://www.walmart.ca/en/stores-near-me/3125" target="_blanc">GATINEAU, QC</a>640 Blvd Maloney W, Gatineau, QC, J8T 8K7
+1031<a href="https://www.walmart.ca/en/stores-near-me/1031" target="_blanc">OTTAWA EAST, ON</a>450 Terminal Ave, Ottawa, ON, K1G 0Z3
+3131<a href="https://www.walmart.ca/en/stores-near-me/3131" target="_blanc">S. OTTAWA, ON</a>2210 Bank St, Ottawa, ON, K1V 1J5
+1200<a href="https://www.walmart.ca/en/stores-near-me/1200" target="_blanc">OTTAWA (C)</a>2277 Riverside Dr, Ottawa, ON, K1H 7X6
+1086<a href="https://www.walmart.ca/en/stores-near-me/1086" target="_blanc">GATINEAU WEST, QC</a>51 De La Gappe Blvd, Gatineau, QC, J8T 0B5
+1190<a href="https://www.walmart.ca/en/stores-near-me/1190" target="_blanc">HULL E.</a>1-425 Boul Saint Joseph, Hull, QC, J8Y 3Z9
+3143<a href="https://www.walmart.ca/en/stores-near-me/3143" target="_blanc">HULL, QC</a>35 Boul Du Plateau, Hull, QC, J9A 3G1
+1110<a href="https://www.walmart.ca/en/stores-near-me/1110" target="_blanc">OTTAWA SW., ON</a>1375 Baseline Rd, Ottawa, ON, K2C 3G1
+3638<a href="https://www.walmart.ca/en/stores-near-me/3638" target="_blanc">BARRHAVEN, ONT</a>3651 Strandherd Dr, Barrhaven, ON, K2J 4G8
+3066<a href="https://www.walmart.ca/en/stores-near-me/3066" target="_blanc">BAYSHORE SHOPPING CENTRE, OTTAWA</a>100 Bayshore Dr, UNIT 10, Ottawa, ON, K2B 8C1
+1047<a href="https://www.walmart.ca/en/stores-near-me/1047" target="_blanc">KEMPTVILLE, ON</a>340 Colonnade Dr, Kemptville, ON, K0G 1J0
+1118<a href="https://www.walmart.ca/en/stores-near-me/1118" target="_blanc">KANATA SOUTH, ON</a>5357 Fernbank Rd, Stittsville, ON, K2S 0T7
+3134<a href="https://www.walmart.ca/en/stores-near-me/3134" target="_blanc">KANATA,ONTARIO</a>500 Earl Grey Dr, Kanata, ON, K2T 1B6
+1076<a href="https://www.walmart.ca/en/stores-near-me/1076" target="_blanc">MAGOG, QC</a>1935 Sherbrooke St, Magog, QC, J1X 2T5
+3739<a href="https://www.walmart.ca/en/stores-near-me/3739" target="_blanc">VICTORIAVILLE, QUEBEC</a>110 Blvd Arthabaska O, Victoriaville, QC, G6S 0P2
+3086<a href="https://www.walmart.ca/en/stores-near-me/3086" target="_blanc">SHERBROOKE, QUEBEC</a>4050 Boul Josaphat-rancourt, Sherbrooke, QC, J1L 3C6
+1172<a href="https://www.walmart.ca/en/stores-near-me/1172" target="_blanc">Sherbrooke (E)</a>940 13e Av N, Sherbrooke, QC, J1E 3J7
+1075<a href="https://www.walmart.ca/en/stores-near-me/1075" target="_blanc">CARLETON PLACE, ON</a>450 Mcneely Ave, Carleton Place, ON, K7C 0A6
+3006<a href="https://www.walmart.ca/en/stores-near-me/3006" target="_blanc">BROCKVILLE, ONTARIO</a>1942 Parkedale Ave, Brockville, ON, K6V 7N4
+5811<a href="https://www.walmart.ca/en/stores-near-me/5811" target="_blanc">SMITHS FALLS, ONT</a>114 Lombard St, Smiths Falls, ON, K7A 5B8
+3078<a href="https://www.walmart.ca/en/stores-near-me/3078" target="_blanc">RENFREW, ONTARIO</a>980 O'brien Rd, Renfrew, ON, K7V 0B4
+5832<a href="https://www.walmart.ca/en/stores-near-me/5832" target="_blanc">THETFORD MINES, QUEBEC</a>1025 Boul Frontenac E, Thetford Mines, QC, G6G 6S7
+3146<a href="https://www.walmart.ca/en/stores-near-me/3146" target="_blanc">ST. FOY, QC</a>1470 Av Jules-verne, Sainte-foy, QC, G2G 2R5
+1045<a href="https://www.walmart.ca/en/stores-near-me/1045" target="_blanc">ST. ROMUALD, QC</a>700 Rue De La Concorde, Saint-romuald, QC, G6W 8A8
+1212<a href="https://www.walmart.ca/en/stores-near-me/1212" target="_blanc">QUEBEC CITY (DOWNTOWN)</a>2700 Boul Laurier, Quebec City, QC, G1V 2L8
+3074<a href="https://www.walmart.ca/en/stores-near-me/3074" target="_blanc">QUEBEC CITY, CAPITALE</a>1700 Boul Lebourgneuf, Quebec City, QC, G2K 2M4
+3171<a href="https://www.walmart.ca/en/stores-near-me/3171" target="_blanc">PEMBROKE, ON</a>1108 Pembroke St E, Pembroke, ON, K8A 8P7
+1201<a href="https://www.walmart.ca/en/stores-near-me/1201" target="_blanc">QUEBEC CITY (E)</a>550 Boul Wilfrid-hamel, Quebec City, QC, G1M 2S6
+1019<a href="https://www.walmart.ca/en/stores-near-me/1019" target="_blanc">LAC-MEGANTIC, QC</a>3130 Rue Laval, Lac-megantic, QC, G6B 1A4
+3148<a href="https://www.walmart.ca/en/stores-near-me/3148" target="_blanc">LEVIS, QC</a>1200 Boul Alphonse-desjardins, Levis, QC, G6V 6Y8
+3646<a href="https://www.walmart.ca/en/stores-near-me/3646" target="_blanc">BEAUPORT, QC</a>224 Joseph Casavant Ave, Quebec City, QC, G1C 7Z3
+1040<a href="https://www.walmart.ca/en/stores-near-me/1040" target="_blanc">ST. GEORGES-DE-BEAUCE, QC</a>750 107e Rue, Saint-georges, QC, G5Y 0A1
+3043<a href="https://www.walmart.ca/en/stores-near-me/3043" target="_blanc">KINGSTON, ONTARIO</a>1130 Midland Ave, Kingston, ON, K7P 2X9
+1041<a href="https://www.walmart.ca/en/stores-near-me/1041" target="_blanc">NAPANEE, ON</a>89 Jim Kimmett Blvd, Napanee, ON, K7R 3L1
+3122<a href="https://www.walmart.ca/en/stores-near-me/3122" target="_blanc">BELLEVILLE, ON</a>274 Millennium Pky, Belleville, ON, K8N 4Z5
+3178<a href="https://www.walmart.ca/en/stores-near-me/3178" target="_blanc">TRENTON ON</a>470 2nd Dug Hill Rd, RR 4, Trenton, ON, K8V 5P7
+1173<a href="https://www.walmart.ca/en/stores-near-me/1173" target="_blanc">La Pocatiere</a>161 Route 230 Ouest Unit 400, UNIT 400, La Pocatiere, QC, G0R 1Z0
+5795<a href="https://www.walmart.ca/en/stores-near-me/5795" target="_blanc">ALMA, QC</a>1755 Ave Du Pont S, Alma, QC, G8B 7W7
+3017<a href="https://www.walmart.ca/en/stores-near-me/3017" target="_blanc">CHICOUTIMI, QUEBEC</a>1451 Boul Talbot, SUITE 1, Chicoutimi, QC, G7H 5N8
+3071<a href="https://www.walmart.ca/en/stores-near-me/3071" target="_blanc">PETERBOROUGH, ONTARIO</a>1002 Chemong Rd, Peterborough, ON, K9H 7E2
+1162<a href="https://www.walmart.ca/en/stores-near-me/1162" target="_blanc">PETERBOUROUGH (S)</a>950 Lansdowne St W, Peterborough, ON, K9J 1Z9
+3139<a href="https://www.walmart.ca/en/stores-near-me/3139" target="_blanc">VAL D'OR QUEBEC</a>1855 3e Av, Val-d'or, QC, J9P 7A9
+3133<a href="https://www.walmart.ca/en/stores-near-me/3133" target="_blanc">COBURG, ONTARIO</a>73 Strathy Rd, Cobourg, ON, K9A 5W8
+3655<a href="https://www.walmart.ca/en/stores-near-me/3655" target="_blanc">RIVIERE DU LOUP, QC</a>100 Rue Des Cerisiers, Riviere-du-loup, QC, G5R 6E8
+5743<a href="https://www.walmart.ca/en/stores-near-me/5743" target="_blanc">HUNTSVILLE, ONT</a>111 Howland Dr, Huntsville, ON, P1H 2P4
+1054<a href="https://www.walmart.ca/en/stores-near-me/1054" target="_blanc">BRACEBRIDGE, ON</a>40 Depot Dr Rr7, Bracebridge, ON, P1L 0H1
+3063<a href="https://www.walmart.ca/en/stores-near-me/3063" target="_blanc">NORTH BAY, ONTARIO</a>1500 Fisher St, UNIT 102, North Bay, ON, P1B 2H3
+1001<a href="https://www.walmart.ca/en/stores-near-me/1001" target="_blanc">BOWMANVILLE, ON</a>2320 Highway 2, Bowmanville, ON, L1C 3K7
+3161<a href="https://www.walmart.ca/en/stores-near-me/3161" target="_blanc">OSHAWA N, ON</a>1471 Harmony Rd N, Oshawa, ON, L1H 7K5
+1069<a href="https://www.walmart.ca/en/stores-near-me/1069" target="_blanc">PORT PERRY., ON</a>1535 Hwy 7a, BLDG A, Port Perry, ON, L9L 1B5
+1056<a href="https://www.walmart.ca/en/stores-near-me/1056" target="_blanc">OSHAWA EAST, ON</a>680 Laval Dr, Oshawa, ON, L1J 0B5
+3113<a href="https://www.walmart.ca/en/stores-near-me/3113" target="_blanc">WHITBY, ONTARIO</a>4100 Baldwin St S, Whitby, ON, L1R 3H8
+3153<a href="https://www.walmart.ca/en/stores-near-me/3153" target="_blanc">ORILLIA, ONTARIO</a>175 Murphy Rd, 8000 HWY # 12, Orillia, ON, L3V 0B5
+3653<a href="https://www.walmart.ca/en/stores-near-me/3653" target="_blanc">UXBRIDGE, ONTARIO</a>6 Welwood Dr, Uxbridge, ON, L9P 1Z7
+3001<a href="https://www.walmart.ca/en/stores-near-me/3001" target="_blanc">AJAX, ONTARIO</a>270 Kingston Rd E R R # 1, Ajax, ON, L1Z 1G1
+3186<a href="https://www.walmart.ca/en/stores-near-me/3186" target="_blanc">PICKERING, ONTARIO</a>1899 Brock Rd, Pickering, ON, L1V 4H7
+1012<a href="https://www.walmart.ca/en/stores-near-me/1012" target="_blanc">KESWICK</a>23550 Woodbine Ave, Keswick, ON, L4P 0E2
+1029<a href="https://www.walmart.ca/en/stores-near-me/1029" target="_blanc">STOUFFVILLE, ON</a>1050 Hoover Pk Dr, Stouffville, ON, L4A 0K2
+1109<a href="https://www.walmart.ca/en/stores-near-me/1109" target="_blanc">MARKHAM East</a>500 Copper Creek Dr, Markham, ON, L6B 0S1
+3111<a href="https://www.walmart.ca/en/stores-near-me/3111" target="_blanc">SCARBOROUGH EAST, ON</a>799 Milner Ave, Scarborough, ON, M1B 3C3
+1033<a href="https://www.walmart.ca/en/stores-near-me/1033" target="_blanc">EDMUNDSTON, NB</a>805 Victoria St, Edmundston, NB, E3V 3T3
+3136<a href="https://www.walmart.ca/en/stores-near-me/3136" target="_blanc">ROUYN NORANDA</a>275 Blvd Rideau, Rouyn-noranda, QC, J9X 5Y6
+1080<a href="https://www.walmart.ca/en/stores-near-me/1080" target="_blanc">SCARBOROUGH, ON</a>5995 Steeles Ave E, Scarborough, ON, M1V 5P7
+1161<a href="https://www.walmart.ca/en/stores-near-me/1161" target="_blanc">NEWMARKET EAST</a>1111 Davis Dr, Newmarket, ON, L3Y 8X2
+3053<a href="https://www.walmart.ca/en/stores-near-me/3053" target="_blanc">MARKHAM, ONTARIO</a>5000 Hwy 7, UNIT # Y006A, Markham, ON, L3R 4M9
+5778<a href="https://www.walmart.ca/en/stores-near-me/5778" target="_blanc">AURORA, ON</a>135 First Commerce Dr, Aurora, ON, L4G 0G2
+1023<a href="https://www.walmart.ca/en/stores-near-me/1023" target="_blanc">PARRY SOUND, ON</a>1 Pine Dr, Parry Sound, ON, P2A 3C3
+1117<a href="https://www.walmart.ca/en/stores-near-me/1117" target="_blanc">Scarborough South</a>3132 Eglinton Ave E, Scarborough, ON, M1J 2H1
+3635<a href="https://www.walmart.ca/en/stores-near-me/3635" target="_blanc">C. SCARBOROUGH, ONTARIO</a>300 Borough Dr, Scarborough, ON, M1P 4P5
+3062<a href="https://www.walmart.ca/en/stores-near-me/3062" target="_blanc">NEWMARKET, ONTARIO</a>17940 Yonge St, Newmarket, ON, L3Y 8S4
+3128<a href="https://www.walmart.ca/en/stores-near-me/3128" target="_blanc">TEMISKAMING SHORES,ON</a>133 Hwy # 11, Temiskaming Shores, ON, P0J 1P0
+3166<a href="https://www.walmart.ca/en/stores-near-me/3166" target="_blanc">BARRIE NORTH ON</a>450 Bayfield St, Barrie, ON, L4M 5A2
+3000<a href="https://www.walmart.ca/en/stores-near-me/3000" target="_blanc">AGINCOURT, ONTARIO</a>3850 Sheppard Ave E, SUITE 360, Scarborough, ON, M1T 3L3
+3645<a href="https://www.walmart.ca/en/stores-near-me/3645" target="_blanc">MIDLAND, ONTARIO</a>16845 Hwy # 12, Midland, ON, L4R 0A9
+3123<a href="https://www.walmart.ca/en/stores-near-me/3123" target="_blanc">S. BARRIE, ON</a>35 Mapleview Dr W, Barrie, ON, L4N 9H5
+3195<a href="https://www.walmart.ca/en/stores-near-me/3195" target="_blanc">RICHMOND HILL, ON</a>1070 Major Mackenzie Dr E, UNIT A, Richmond Hill, ON, L4S 1P3
+3159<a href="https://www.walmart.ca/en/stores-near-me/3159" target="_blanc">W. SCARBOROUGH, ON</a>1900 Eglinton Ave E, Scarborough, ON, M1L 2L9
+1101<a href="https://www.walmart.ca/en/stores-near-me/1101" target="_blanc">BRADFORD,ON</a>545 Holland St W, Bradford, ON, L3Z 0C1
+1116<a href="https://www.walmart.ca/en/stores-near-me/1116" target="_blanc">RICHMOND HILL SOUTH</a>255 Silver Linden Dr, Richmond Hill, ON, L4B 4V5
+5831<a href="https://www.walmart.ca/en/stores-near-me/5831" target="_blanc">THORNHILL, ON</a>700 Centre St, Thornhill, ON, L4J 0A7
+1150<a href="https://www.walmart.ca/en/stores-near-me/1150" target="_blanc">Toronto DOWNTOWN (E)</a>1000 Gerrard St E, Toronto, ON, M4M 3G6
+1115<a href="https://www.walmart.ca/en/stores-near-me/1115" target="_blanc">VAUGHAN MAPLE, ON</a>1900 Major Mackenzie Dr, Vaughan, ON, L6A 4R9
+1095<a href="https://www.walmart.ca/en/stores-near-me/1095" target="_blanc">VAUGHAN NW, ON</a>3600 Major Mackenzie Dr W, Vaughan, ON, L4H 3T6
+1139<a href="https://www.walmart.ca/en/stores-near-me/1139" target="_blanc">Toronto Downsview</a>3757 Keele St, Toronto, ON, M3J 1N4
+3174<a href="https://www.walmart.ca/en/stores-near-me/3174" target="_blanc">VAUGHAN, ON</a>670 Applewood Crescent, Vaughan, ON, L4K 4B4
+3105<a href="https://www.walmart.ca/en/stores-near-me/3105" target="_blanc">TORONTO, NORTH PARK</a>1305 Lawrence Ave W, N PK SC, Toronto, ON, M6L 1A5
+3106<a href="https://www.walmart.ca/en/stores-near-me/3106" target="_blanc">TORONTO (DUFFERIN MALL)</a>900 Dufferin St, Toronto, ON, M6H 4A9
+1087<a href="https://www.walmart.ca/en/stores-near-me/1087" target="_blanc">WASAGA BEACH, ON</a>100 Stonebridge Blvd, Wasaga Beach, ON, L9Z 0C1
+1083<a href="https://www.walmart.ca/en/stores-near-me/1083" target="_blanc">ALLISTON, ON</a>30 Dunham Dr, Alliston, ON, L9R 0G1
+1151<a href="https://www.walmart.ca/en/stores-near-me/1151" target="_blanc">TORONTO (SHERIDAN)</a>2202 Jane St, North York, ON, M3M 1A4
+1004<a href="https://www.walmart.ca/en/stores-near-me/1004" target="_blanc">TORONTO (STOCKYARDS), ON</a>2525 St Clair Ave W, Toronto, ON, M6N 4Z5
+3740<a href="https://www.walmart.ca/en/stores-near-me/3740" target="_blanc">REXDALE, ON</a>2245 Islington Ave, Toronto, ON, M9W 3W6
+1081<a href="https://www.walmart.ca/en/stores-near-me/1081" target="_blanc">VAUGHAN (W), ON</a>8300 Hwy 27, Woodbridge, ON, L4H 0R9
+1043<a href="https://www.walmart.ca/en/stores-near-me/1043" target="_blanc">WOODSTOCK, NB</a>430 Connell St, Woodstock, NB, E7M 5R5
+5742<a href="https://www.walmart.ca/en/stores-near-me/5742" target="_blanc">BOLTON, ONT</a>150 Mcewan Dr E, Bolton, ON, L7E 2Y3
+1013<a href="https://www.walmart.ca/en/stores-near-me/1013" target="_blanc">GRAND FALLS, NB</a>494 Ch Madawaska, Grand Falls, NB, E3Y 1A3
+3031<a href="https://www.walmart.ca/en/stores-near-me/3031" target="_blanc">ETOBICOKE, ONTARIO</a>165 N Queen St, Etobicoke, ON, M9C 1A7
+1126<a href="https://www.walmart.ca/en/stores-near-me/1126" target="_blanc">MISSISSAUGA EAST</a>1500 Dundas St E, Mississauga, ON, L4X 1L4
+3135<a href="https://www.walmart.ca/en/stores-near-me/3135" target="_blanc">E. BRAMPTON, ON</a>30 Coventry Rd, Brampton, ON, L6T 5P9
+3088<a href="https://www.walmart.ca/en/stores-near-me/3088" target="_blanc">E ST. CATHARINES, LINCOLN</a>525 Welland Ave, LINCOLN MALL SC, St. Catharines, ON, L2M 6P3
+3160<a href="https://www.walmart.ca/en/stores-near-me/3160" target="_blanc">NIAGARA FALLS, ONTARIO / Relo 0403</a>7481 Oakwood Dr, Niagara Falls, ON, L2G 0J5
+3649<a href="https://www.walmart.ca/en/stores-near-me/3649" target="_blanc">FORT ERIE, ON</a>750 Garrison Rd, Fort Erie, ON, L2A 1N7
+1120<a href="https://www.walmart.ca/en/stores-near-me/1120" target="_blanc">Brampton NE</a>5085 Mayfield Rd, Brampton, ON, L6R 3S9
+3055<a href="https://www.walmart.ca/en/stores-near-me/3055" target="_blanc">MISSISSAUGA (SQUARE ONE), ON</a>100 City Centre Dr, SQ ONE SC, Mississauga, ON, L5B 2G7
+1188<a href="https://www.walmart.ca/en/stores-near-me/1188" target="_blanc">BRAMPTON (S)</a>15 Resolution Dr, Brampton, ON, L6W 0A6
+1164<a href="https://www.walmart.ca/en/stores-near-me/1164" target="_blanc">ST. CATHARINES (C)</a>221 Glendale Ave,, St. Catharines, ON, L2T 2K9
+1039<a href="https://www.walmart.ca/en/stores-near-me/1039" target="_blanc">COLLINGWOOD, ON</a>10 Cambridge St, Collingwood, ON, L9Y 0A1
+3172<a href="https://www.walmart.ca/en/stores-near-me/3172" target="_blanc">W ST. CATHARINES, ON</a>420 Vansickle Rd, St. Catharines, ON, L2S 0C7
+1061<a href="https://www.walmart.ca/en/stores-near-me/1061" target="_blanc">HEARTLAND, MISSISSAUGA,ON</a>800 Matheson Blvd W, Mississauga, ON, L5V 2N6
+3198<a href="https://www.walmart.ca/en/stores-near-me/3198" target="_blanc">RIMOUSKI, QUEBEC</a>415 Montee Industrielle-et-commerciale, Rimouski, QC, G5M 1Y1
+3130<a href="https://www.walmart.ca/en/stores-near-me/3130" target="_blanc">N. BRAMPTON, ON</a>50 Quarry Edge Dr, Brampton, ON, L6V 4K2
+3654<a href="https://www.walmart.ca/en/stores-near-me/3654" target="_blanc">ERIN MILLS MISS. ONT</a>2160 Burnhamthorpe Rd W, Mississauga, ON, L5L 5Z5
+1211<a href="https://www.walmart.ca/en/stores-near-me/1211" target="_blanc">MISSISSAUGA (WEST), ON</a>5100 Erin Mills Pky, Mississauga West, ON, L5M 4Z5
+1079<a href="https://www.walmart.ca/en/stores-near-me/1079" target="_blanc">BRAMPTON, ON</a>9455 Mississauga Rd, Brampton, ON, L6X 0Z8
+3110<a href="https://www.walmart.ca/en/stores-near-me/3110" target="_blanc">WELLAND, ONTARIO</a>102 Primeway Dr, Welland, ON, L3B 0A1
+3054<a href="https://www.walmart.ca/en/stores-near-me/3054" target="_blanc">MEADOWVALE, ONTARIO</a>3155 Argentia Rd, Meadowvale, ON, L5N 8E1
+3064<a href="https://www.walmart.ca/en/stores-near-me/3064" target="_blanc">OAKVILLE, ONTARIO</a>234 Hays Blvd, Oakville, ON, L6H 6M4
+3142<a href="https://www.walmart.ca/en/stores-near-me/3142" target="_blanc">ORANGEVILLE, ON</a>95 1st St, Orangeville, ON, L9W 2E8
+3034<a href="https://www.walmart.ca/en/stores-near-me/3034" target="_blanc">GEORGETOWN, ONTARIO, RELO 0408</a>300 Guelph St, Georgetown, ON, L7G 4B1
+1000<a href="https://www.walmart.ca/en/stores-near-me/1000" target="_blanc">MILTON, ON</a>1280 Steeles Ave E, Milton, ON, L9T 6R1
+3170<a href="https://www.walmart.ca/en/stores-near-me/3170" target="_blanc">BURLINGTON N., ON</a>4515 Dundas St, RR 1, Burlington, ON, L7M 5B4
+3141<a href="https://www.walmart.ca/en/stores-near-me/3141" target="_blanc">BURLINGTON, S, ON</a>2065 Fairview St, Burlington, ON, L7R 0B4
+3096<a href="https://www.walmart.ca/en/stores-near-me/3096" target="_blanc">STONEY CREEK, ON </a>510 Centennial Pkwy N, Hamilton, ON, L8E 0G2
+3097<a href="https://www.walmart.ca/en/stores-near-me/3097" target="_blanc">SUDBURY, ONTARIO</a>1349 Lasalle Blvd, Sudbury, ON, P3A 1Z2
+1121<a href="https://www.walmart.ca/en/stores-near-me/1121" target="_blanc">Hamilton Centre</a>1115 Barton St E, Hamilton, ON, L8H 2V2
+1107<a href="https://www.walmart.ca/en/stores-near-me/1107" target="_blanc">DUNDAS, ONTARIO</a>90 Dundas St E, Waterdown, ON, L9H 0C2
+1042<a href="https://www.walmart.ca/en/stores-near-me/1042" target="_blanc">HAMILTON SE</a>2190 Rymal Rd E, Hannon, ON, L0R 1P0
+1105<a href="https://www.walmart.ca/en/stores-near-me/1105" target="_blanc">SUDBURY SOUTH, ON</a>2416 Long Lake Rd, Sudbury, ON, P3E 0C5
+3037<a href="https://www.walmart.ca/en/stores-near-me/3037" target="_blanc">HAMILTON, ONT/RELO 0401</a>675 Upper James St, HAMILTON MTN PLAZA, Hamilton, ON, L9C 2Z5
+1199<a href="https://www.walmart.ca/en/stores-near-me/1199" target="_blanc">GUELPH (S)</a>175 Stone Rd W, Guelph, ON, N1G 5L4
+1130<a href="https://www.walmart.ca/en/stores-near-me/1130" target="_blanc">Fergus</a>801 St David St N, Fergus, ON, N1M 2L1
+3144<a href="https://www.walmart.ca/en/stores-near-me/3144" target="_blanc">GUELPH ONTARIO</a>11 Woodlawn Rd W, Guelph, ON, N1H 1G8
+3127<a href="https://www.walmart.ca/en/stores-near-me/3127" target="_blanc">ANCASTER, ON</a>1051 Garner Rd W, Ancaster, ON, L9G 3K9
+3067<a href="https://www.walmart.ca/en/stores-near-me/3067" target="_blanc">OWEN SOUND, ONTARIO</a>1555 18th Ave E, Owen Sound, ON, N4K 6Y3
+1007<a href="https://www.walmart.ca/en/stores-near-me/1007" target="_blanc">KITCHENER (W), ON</a>1400 Ottawa St S, UNIT E, Kitchener, ON, N2E 4E2
+3152<a href="https://www.walmart.ca/en/stores-near-me/3152" target="_blanc">CAMBRIDGE, ONTARIO</a>22 Pinebush Rd, Cambridge, ON, N1R 8K5
+3032<a href="https://www.walmart.ca/en/stores-near-me/3032" target="_blanc">FREDERICTON NEW BRUNSWICK</a>1399 Regent St, REGENT MALL, Fredericton, NB, E3C 1A3
+1067<a href="https://www.walmart.ca/en/stores-near-me/1067" target="_blanc">FREDERICTON NORTH, NB</a>125 Two Nations Cross, Fredericton, NB, E3A 0T3
+3045<a href="https://www.walmart.ca/en/stores-near-me/3045" target="_blanc">KITCHENER, ONTARIO</a>2960 Kingsway Dr, FAIRVIEW PK SC, Kitchener, ON, N2C 1X1
+3002<a href="https://www.walmart.ca/en/stores-near-me/3002" target="_blanc">BAIE COMEAU, QUEBEC</a>630 Boul Lafleche, Baie-comeau, QC, G5C 2Y3
+1156<a href="https://www.walmart.ca/en/stores-near-me/1156" target="_blanc">WATERLOO CENTRE</a>70 Bridgeport Rd E, Waterloo, ON, N2J 2J9
+3005<a href="https://www.walmart.ca/en/stores-near-me/3005" target="_blanc">BRANTFORD, ONTARIO</a>1-300 King George Rd, Brantford, ON, N3R 5L7
+3156<a href="https://www.walmart.ca/en/stores-near-me/3156" target="_blanc">WATERLOO, ONTARIO</a>335 Farmers Market Rd Unit 101, Waterloo, ON, N2V 0A4
+3129<a href="https://www.walmart.ca/en/stores-near-me/3129" target="_blanc">HANOVER, ON</a>1100 10th St, Hanover, ON, N4N 3B8
+1111<a href="https://www.walmart.ca/en/stores-near-me/1111" target="_blanc">WATERLOO WEST., ON</a>100 The Boardwalk, Kitchener, ON, N2N 0B1
+1025<a href="https://www.walmart.ca/en/stores-near-me/1025" target="_blanc">MATANE, QC</a>150 Rue Piuze, Matane, QC, G4W 4T2
+1160<a href="https://www.walmart.ca/en/stores-near-me/1160" target="_blanc">Listowel</a>600 Mitchell Rd S, Listowel, ON, N4W 3T1
+5752<a href="https://www.walmart.ca/en/stores-near-me/5752" target="_blanc">SIMCOE, ON</a>160 Queensway E, Simcoe, ON, N3Y 0A8
+1059<a href="https://www.walmart.ca/en/stores-near-me/1059" target="_blanc">PORT ELGIN, ON</a>5122 On-21, Port Elgin, ON, N0H 2C0
+3737<a href="https://www.walmart.ca/en/stores-near-me/3737" target="_blanc">ATHOLVILLE, NEW BRUNSWICK</a>4 Jagoe St, Atholville, NB, E3N 5C3
+3120<a href="https://www.walmart.ca/en/stores-near-me/3120" target="_blanc">WOODSTOCK, ONTARIO</a>499 Norwich Ave, Woodstock, ON, N4S 9A2
+1125<a href="https://www.walmart.ca/en/stores-near-me/1125" target="_blanc">Stratford</a>920 Ontario St, Stratford, ON, N5A 3K1
+1175<a href="https://www.walmart.ca/en/stores-near-me/1175" target="_blanc">SAINT JOHN (W)</a>621 Fairville Blvd, Saint John, NB, E2M 4X5
+3091<a href="https://www.walmart.ca/en/stores-near-me/3091" target="_blanc">SAINT JOHN NEW BRUNSWICK</a>450 Westmorland Rd, Saint John, NB, E2J 4Z2
+3103<a href="https://www.walmart.ca/en/stores-near-me/3103" target="_blanc">TILLSONBURG, ONTARIO /RELO 0407</a>170 Broadway, NORFOLK MALL, Tillsonburg, ON, N4G 5A8
+3104<a href="https://www.walmart.ca/en/stores-near-me/3104" target="_blanc">TIMMINS, ONTARIO</a>1870 Riverside Dr Rr 2, Timmins, ON, P4R 1N7
+3126<a href="https://www.walmart.ca/en/stores-near-me/3126" target="_blanc">GODERICH, ON</a>35400 Huron Rd Rr2, Goderich, ON, N7A 3X8
+3049<a href="https://www.walmart.ca/en/stores-near-me/3049" target="_blanc">E. LONDON, ARGYLE MALL, ON</a>330 Clarke Rd, E. London, ON, N5W 6G4
+1157<a href="https://www.walmart.ca/en/stores-near-me/1157" target="_blanc">London (Northland)</a>1275 Highbury Ave N, London, ON, N5Y 1A8
+3051<a href="https://www.walmart.ca/en/stores-near-me/3051" target="_blanc">S. LONDON,WHITE OAKS MALL</a>1105 Wellington Rd, London, ON, N6E 1V4
+1052<a href="https://www.walmart.ca/en/stores-near-me/1052" target="_blanc">SUSSEX, NB</a>80 Main St, Sussex, NB, E4E 1Y6
+3050<a href="https://www.walmart.ca/en/stores-near-me/3050" target="_blanc">N. LONDON, OAKRIDGE MALL, ON</a>1280 Fanshawe Pk Rd W, London, ON, N6G 5B1
+1017<a href="https://www.walmart.ca/en/stores-near-me/1017" target="_blanc">DIGBY, NS</a>492 Hwy 303 Post Box 2140, Digby, NS, B0V 1A0
+1016<a href="https://www.walmart.ca/en/stores-near-me/1016" target="_blanc">YARMOUTH, NS</a>108 Starrs Rd, Yarmouth, NS, B5A 2T5
+3197<a href="https://www.walmart.ca/en/stores-near-me/3197" target="_blanc">ST. THOMAS, ON</a>1063 Talbot St Unit # 60, St. Thomas, ON, N5P 1G4
+3003<a href="https://www.walmart.ca/en/stores-near-me/3003" target="_blanc">BATHURST</a>900 St Anne St, Bathurst, NB, E2A 6X2
+5833<a href="https://www.walmart.ca/en/stores-near-me/5833" target="_blanc">MIRAMICHI, NB</a>200 Douglastown Blvd, Miramichi, NB, E1V 7T9
+1038<a href="https://www.walmart.ca/en/stores-near-me/1038" target="_blanc">STRATHROY, ON</a>150 Carroll St E Rr 1, Strathroy, ON, N7G 4G2
+3659<a href="https://www.walmart.ca/en/stores-near-me/3659" target="_blanc">MONCTON WEST, NB</a>25 Plaza Blvd, Moncton, NB, E1C 0G3
+3056<a href="https://www.walmart.ca/en/stores-near-me/3056" target="_blanc">MONCTON NEW BRUNSWICK</a>477 Paul St, Dieppe, NB, E1A 5B2
+1177<a href="https://www.walmart.ca/en/stores-near-me/1177" target="_blanc">Greenwood</a>1065 Central Ave, Greenwood, NS, B0P 1N0
+3082<a href="https://www.walmart.ca/en/stores-near-me/3082" target="_blanc">SARNIA, ONTARIO</a>1444 Quinn Dr, Sarnia, ON, N7S 6M8
+3041<a href="https://www.walmart.ca/en/stores-near-me/3041" target="_blanc">KAPUSKASING, ONTARIO</a>350 Government Rd E, Kapuskasing, ON, P5N 2X7
+3085<a href="https://www.walmart.ca/en/stores-near-me/3085" target="_blanc">SEPT ILES, QUEBEC</a>1005 Boul Laure Unit 500, Sept-iles, QC, G4R 4S6
+3738<a href="https://www.walmart.ca/en/stores-near-me/3738" target="_blanc">NEW MINAS, NS</a>9121 Commercial St, New Minas, NS, B4N 3E7
+3016<a href="https://www.walmart.ca/en/stores-near-me/3016" target="_blanc">CHATHAM, ON</a>881 St Clair St, Chatham, ON, N7L 0E9
+1064<a href="https://www.walmart.ca/en/stores-near-me/1064" target="_blanc">WALLACEBURG, ON</a>60 Mcnaughton Ave Unit # 16, Wallaceburg, ON, N8A 1R9
+1003<a href="https://www.walmart.ca/en/stores-near-me/1003" target="_blanc">BRIDGEWATER, NS</a>60 Pine Grove Rd, Bridgewater, NS, B4V 4H2
+5789<a href="https://www.walmart.ca/en/stores-near-me/5789" target="_blanc">AMHERST, NS</a>46 Robert Angus Dr, Amherst, NS, B4H 4R7
+3644<a href="https://www.walmart.ca/en/stores-near-me/3644" target="_blanc">SUMMERSIDE, PEI</a>511 Granville St, Summerside, PE, C1N 5J4
+3155<a href="https://www.walmart.ca/en/stores-near-me/3155" target="_blanc">SAULT STE. MARIE, ONTARIO</a>446 Great Northern Rd, Sault Ste. Marie, ON, P6B 4Z9
+3164<a href="https://www.walmart.ca/en/stores-near-me/3164" target="_blanc">LEAMINGTON, ONTARIO</a>304 Erie St S, Leamington, ON, N8H 3C5
+3115<a href="https://www.walmart.ca/en/stores-near-me/3115" target="_blanc">E. WINDSOR GATEWAY PLAZA, ON</a>7100 Tecumseh Rd E, Windsor, ON, N8T 1E6
+3114<a href="https://www.walmart.ca/en/stores-near-me/3114" target="_blanc">S. WINDSOR GATEWAY PLAZA</a>3120 Dougall Ave, GATEWAY PLAZA, Windsor, ON, N9E 1S7
+3138<a href="https://www.walmart.ca/en/stores-near-me/3138" target="_blanc">HALIFAX, NOVA SCOTIA</a>220 Chain Lake Dr, Halifax, NS, B3S 1C5
+3081<a href="https://www.walmart.ca/en/stores-near-me/3081" target="_blanc">SACKVILLE NOVA SCOTIA</a>141 Damascus Rd, Bedford, NS, B4A 0C2
+3636<a href="https://www.walmart.ca/en/stores-near-me/3636" target="_blanc">HALIFAX CENTRE, NS</a>6990 Mumford Rd, Halifax, NS, B3L 4W4
+3021<a href="https://www.walmart.ca/en/stores-near-me/3021" target="_blanc">DARTMOUTH NOVA SCOTIA</a>90 Lamont Terr, Dartmouth, NS, B3B 0B5
+1176<a href="https://www.walmart.ca/en/stores-near-me/1176" target="_blanc">Dartmouth South</a>900 Cole Harbour Rd, Dartmouth, NS, B2V 2J5
+3184<a href="https://www.walmart.ca/en/stores-near-me/3184" target="_blanc">TRURO, NS</a>140 Wade Rd, Truro, NS, B2N 7H3
+1072<a href="https://www.walmart.ca/en/stores-near-me/1072" target="_blanc">AMHERSTBURG, ON</a>400 Sandwich St S, Amherstburg, ON, N9V 3L4
+3162<a href="https://www.walmart.ca/en/stores-near-me/3162" target="_blanc">CHARLOTTETOWN PEI</a>80 Buchanan Dr, Charlottetown, PE, C1E 2E5
+3061<a href="https://www.walmart.ca/en/stores-near-me/3061" target="_blanc">NEW GLASGOW NOVA SCOTIA</a>713 Westville Rd, New Glasgow, NS, B2H 2J6
+1014<a href="https://www.walmart.ca/en/stores-near-me/1014" target="_blanc">ANTIGONISH, NS</a># 50 Market St, Antigonish, NS, B2G 3B4
+1035<a href="https://www.walmart.ca/en/stores-near-me/1035" target="_blanc">LABRADOR CITY, NL</a>500 Vanier Ave, UNIT # 1000, Labrador City, NL, A2V 2W7
+3068<a href="https://www.walmart.ca/en/stores-near-me/3068" target="_blanc">PORT HAWKESBURY, NS</a>47 Paint St Unit 17, Port Hawkesbury, NS, B9A 3J9
+1178<a href="https://www.walmart.ca/en/stores-near-me/1178" target="_blanc">North Sydney</a>116 King St, North Sydney, NS, B2A 3R7
+3100<a href="https://www.walmart.ca/en/stores-near-me/3100" target="_blanc">SYDNEY NOVA SCOTIA</a>65 Keltic Dr, Sydney, NS, B1S 1P4
+3101<a href="https://www.walmart.ca/en/stores-near-me/3101" target="_blanc">SYDNEY NOVA SCOTIA</a>80 Sydney Port Access Rd, Sydney, NS, B1P 7H9
+3124<a href="https://www.walmart.ca/en/stores-near-me/3124" target="_blanc">THUNDER BAY, ON</a>777 Memorial Ave, Thunder Bay, ON, P7B 3Z7
+1166<a href="https://www.walmart.ca/en/stores-near-me/1166" target="_blanc">Thunder Bay North</a>1020 Dawson Rd, Thunder Bay, ON, P7B 1K6
+1165<a href="https://www.walmart.ca/en/stores-near-me/1165" target="_blanc">THUNDER BAY (S)</a>1101 Arthur St W, Thunder Bay, ON, P7E 5S2
+3095<a href="https://www.walmart.ca/en/stores-near-me/3095" target="_blanc">STEPHENVILLE NEWFOUNDLAND</a>42 Queen St, STEPHENVILLE SC, Stephenville, NL, A2N 3A7
+3185<a href="https://www.walmart.ca/en/stores-near-me/3185" target="_blanc">CORNER BROOK NEWFOUNDLAND</a>16 Murphy Sq, Corner Brook, NL, A2H 1R4
+3036<a href="https://www.walmart.ca/en/stores-near-me/3036" target="_blanc">GRAND FALLS NEWFOUNDLAND</a>19 Cromer Ave, EXPLOITS VALLEY MALL, Grand Falls-windsor, NL, A2A 1X3
+1026<a href="https://www.walmart.ca/en/stores-near-me/1026" target="_blanc">MARYSTOWN, NL</a>272 Mcgettigan Blvd, PO BOX 40, Marystown, NL, A0E 2M0
+3024<a href="https://www.walmart.ca/en/stores-near-me/3024" target="_blanc">DRYDEN, ONTARIO</a>Hwy # 17 E, STATION MAIN HWY, Dryden, ON, P8N 2Z4
+5806<a href="https://www.walmart.ca/en/stores-near-me/5806" target="_blanc">FORT FRANCES, ONT</a>1250 King ' S Hwy, Fort Frances, ON, P9A 2X6
+3033<a href="https://www.walmart.ca/en/stores-near-me/3033" target="_blanc">GANDER, NEWFOUNDLAND</a>55 Roe Ave P O Box 448, Gander, NL, A1V 1W8
+3018<a href="https://www.walmart.ca/en/stores-near-me/3018" target="_blanc">CLARENVILLE, NL</a>11 Shoal Harbour Dr, Clarenville, NL, A5A 2C3
+5854<a href="https://www.walmart.ca/en/stores-near-me/5854" target="_blanc">KENORA, ON</a>24 Miikana Way Unit # 1, Kenora, ON, P9N 4J1
+3015<a href="https://www.walmart.ca/en/stores-near-me/3015" target="_blanc">CARBONEAR, NL</a>120 Columbus Dr, TRINITY CONCEPTION SQUARE MALL, Carbonear, NL, A1Y 1B3
+3093<a href="https://www.walmart.ca/en/stores-near-me/3093" target="_blanc">MOUNT PEARL, NL</a>60 Merchant Dr, Mount Pearl, NL, A1N 5J5
+3092<a href="https://www.walmart.ca/en/stores-near-me/3092" target="_blanc">C. ST. JOHN'S, NL</a>75 Kelsey Dr, ST. JOHN'S CENTRAL, St. John's, NL, A1B 0C7
+3196<a href="https://www.walmart.ca/en/stores-near-me/3196" target="_blanc">E. ST. JOHN'S, NL</a>90 Aberdeen Ave, St. John's, NL, A1A 5N6
+1141<a href="https://www.walmart.ca/en/stores-near-me/1141" target="_blanc">Steinbach</a>184 Pth 12 N, Steinbach, MB, R5G 0Y1
+1027<a href="https://www.walmart.ca/en/stores-near-me/1027" target="_blanc">SELKIRK, MB</a>1016 Manitoba Ave, Selkirk, MB, R1A 4M1
+3107<a href="https://www.walmart.ca/en/stores-near-me/3107" target="_blanc">E. WINNIPEG, MANITOBA</a>1576 Regent Ave W, Winnipeg, MB, R2C 3B4
+1204<a href="https://www.walmart.ca/en/stores-near-me/1204" target="_blanc">WINNIPEG (SE)</a>35 Lakewood Blvd, Winnipeg, MB, R2J 2M8
+3119<a href="https://www.walmart.ca/en/stores-near-me/3119" target="_blanc">S. WINNIPEG, ST.VITAL CTR</a># 54-1225 St Mary ' S Rd, ST VITAL CTR, Winnipeg, MB, R2M 5E6
+1186<a href="https://www.walmart.ca/en/stores-near-me/1186" target="_blanc">WINNIPEG (GRANT PARK)</a>1000 Taylor Ave, Winnipeg, MB, R3M 1T6
+3118<a href="https://www.walmart.ca/en/stores-near-me/3118" target="_blanc">N. WINNIPEG, GARDEN CITY</a>2370 Mcphillips St, Winnipeg, MB, R2V 4J6
+3177<a href="https://www.walmart.ca/en/stores-near-me/3177" target="_blanc">SW. WINNIPG MANITOBA</a>1665 Kenaston Blvd, Winnipeg, MB, R3P 2M4
+3116<a href="https://www.walmart.ca/en/stores-near-me/3116" target="_blanc">C. WINNIPEG, MANITOBA</a>1001 Empress St, Winnipeg, MB, R3G 3P8
+3117<a href="https://www.walmart.ca/en/stores-near-me/3117" target="_blanc">W. WINNIPEG, MANITOBA</a>3655 Portage Ave, UNICITY MALL, Winnipeg, MB, R3K 2G6
+1022<a href="https://www.walmart.ca/en/stores-near-me/1022" target="_blanc">WINKLER, MB</a>1000 Navigator Rd Box 1720, Winkler, MB, R6W 0L8
+3069<a href="https://www.walmart.ca/en/stores-near-me/3069" target="_blanc">PORTAGE LA PRAIRIE, MAN.</a>2348 Sissons Dr, Portage La Prairie, MB, R1N 0G5
+3004<a href="https://www.walmart.ca/en/stores-near-me/3004" target="_blanc">BRANDON, MANITOBA</a>903 18th St N, Brandon, MB, R7A 7S1
+3102<a href="https://www.walmart.ca/en/stores-near-me/3102" target="_blanc">THOMPSON, MANITOBA</a>300 Mystery Lake Rd, Thompson, MB, R8N 0M2
+3022<a href="https://www.walmart.ca/en/stores-near-me/3022" target="_blanc">DAUPHIN, MANITOBA</a>1450 Main St S, Dauphin, MB, R7N 3H4
+3176<a href="https://www.walmart.ca/en/stores-near-me/3176" target="_blanc">YORKTON, SK</a>240 Hamilton Rd, Yorkton, SK, S3N 4C6
+3660<a href="https://www.walmart.ca/en/stores-near-me/3660" target="_blanc">FLIN FLON, MANITOBA</a>200 Mb-10 Alt, Flin Flon, MB, R8A 0C6
+3030<a href="https://www.walmart.ca/en/stores-near-me/3030" target="_blanc">ESTEVAN, SASKATCHEWAN</a>413 Kensington Ave Box 609, Estevan, SK, S4A 2A5
+5790<a href="https://www.walmart.ca/en/stores-near-me/5790" target="_blanc">WEYBURN SASKATCHEWAN</a>1000 Sims Ave, Weyburn, SK, S4H 3N9
+3179<a href="https://www.walmart.ca/en/stores-near-me/3179" target="_blanc">E. REGINA, SK</a>2150 Prince Of Wales Dr, Regina, SK, S4V 3A6
+3076<a href="https://www.walmart.ca/en/stores-near-me/3076" target="_blanc">N. REGINA, NORTHGATE MALL</a>3939 Rochdale Blvd, Regina, SK, S4X 4P7
+3077<a href="https://www.walmart.ca/en/stores-near-me/3077" target="_blanc">S. REGINA</a>4500 Gordon Rd, Regina, SK, S4W 0B7
+3173<a href="https://www.walmart.ca/en/stores-near-me/3173" target="_blanc">MOOSE JAW, SK</a>551 Thatcher Dr E, Moose Jaw, SK, S6J 1L8
+3073<a href="https://www.walmart.ca/en/stores-near-me/3073" target="_blanc">PRINCE ALBERT, SK</a>800 15 St E, Prince Albert, SK, S6V 8E3
+3084<a href="https://www.walmart.ca/en/stores-near-me/3084" target="_blanc">SASKATOON (N)</a>1706 Preston Ave N, Saskatoon, SK, S7N 4Y1
+5878<a href="https://www.walmart.ca/en/stores-near-me/5878" target="_blanc">SASKATOON SOUTH</a>3035 Clarence Ave S, Saskatoon, SK, S7T 0B6
+3083<a href="https://www.walmart.ca/en/stores-near-me/3083" target="_blanc">SASKATOON WEST</a>225 Betts Ave, Saskatoon, SK, S7M 1L2
+3099<a href="https://www.walmart.ca/en/stores-near-me/3099" target="_blanc">SWIFT CURRENT,SK</a>1800 22nd Ave Ne, Swift Current, SK, S9H 0E5
+3058<a href="https://www.walmart.ca/en/stores-near-me/3058" target="_blanc">N BATTLEFORD, SK</a>601 Carlton Trail, North Battleford, SK, S9A 4A9
+1065<a href="https://www.walmart.ca/en/stores-near-me/1065" target="_blanc">KINDERSLEY, SK</a>710 11th Ave E Post Box 1296, Kindersley, SK, S0L 1S0
+3168<a href="https://www.walmart.ca/en/stores-near-me/3168" target="_blanc">LLOYDMINSTER AB</a>4210 70th Ave, Lloydminster, AB, T9V 2X3
+3640<a href="https://www.walmart.ca/en/stores-near-me/3640" target="_blanc">COLD LAKE, ALBERTA</a>4702 43rd Ave, Cold Lake, AB, T9M 1M9
+3150<a href="https://www.walmart.ca/en/stores-near-me/3150" target="_blanc">MEDICINE HAT, AB</a>2051 Strachan Rd S E, Medicine Hat, AB, T1B 0G4
+1062<a href="https://www.walmart.ca/en/stores-near-me/1062" target="_blanc">WAINWRIGHT, AB</a>2901 13th Ave, Wainwright, AB, T9W 0A2
+3157<a href="https://www.walmart.ca/en/stores-near-me/3157" target="_blanc">FT. MCMURRAY, ALBERTA</a># 2 Hospital St, Fort Mcmurray, AB, T9H 5E4
+3658<a href="https://www.walmart.ca/en/stores-near-me/3658" target="_blanc">BROOKS ALBERTA</a>917 3rd St W, Brooks, AB, T1R 1L5
+1071<a href="https://www.walmart.ca/en/stores-near-me/1071" target="_blanc">VEGRVILLE, AB</a>6809 Hwy 16a W, Vegreville, AB, T9C 0A2
+1046<a href="https://www.walmart.ca/en/stores-near-me/1046" target="_blanc">TABER, AB</a>4500 64 St, Taber, AB, T1G 0A4
+1028<a href="https://www.walmart.ca/en/stores-near-me/1028" target="_blanc">DRUMHELLER, AB</a>1801 S Railway Ave Box 1960, Drumheller, AB, T0J 0Y0
+1034<a href="https://www.walmart.ca/en/stores-near-me/1034" target="_blanc">STETTLER, ALBERTA</a>4721 70 St, Stettler, AB, T0C 2L2
+3181<a href="https://www.walmart.ca/en/stores-near-me/3181" target="_blanc">CAMROSE, AB</a>6800 48th Ave, #400, Camrose, AB, T4V 4T1
+1078<a href="https://www.walmart.ca/en/stores-near-me/1078" target="_blanc">LETHBRIDGE NORTH, AB</a>3195 26th Ave N, Lethbridge, AB, T1H 5P3
+3048<a href="https://www.walmart.ca/en/stores-near-me/3048" target="_blanc">LETHBRIDGE, ALBERTA</a>3700 Mayor Magrath Dr S, Lethbridge, AB, T1K 7T6
+5753<a href="https://www.walmart.ca/en/stores-near-me/5753" target="_blanc">FORT SASK. ALBERTA</a>9551 87th Ave, Fort Saskatchewan, AB, T8L 4N3
+1123<a href="https://www.walmart.ca/en/stores-near-me/1123" target="_blanc">Sherwood Park N</a>400-7000 Emerald Dr, Sherwood Park, AB, T8H 0P5
+3154<a href="https://www.walmart.ca/en/stores-near-me/3154" target="_blanc">SHERWOOD PARK,AB</a>239 Wye Rd, Sherwood Park, AB, T8B 1N1
+1138<a href="https://www.walmart.ca/en/stores-near-me/1138" target="_blanc">EDMONTON SE</a>775 Tamarack Way Nw, Edmonton, AB, T6T 0X2
+3112<a href="https://www.walmart.ca/en/stores-near-me/3112" target="_blanc">WETASKIWIN, ALBERTA</a>3600 56th St Suite 300, Wetaskiwin, AB, T9A 3T5
+3028<a href="https://www.walmart.ca/en/stores-near-me/3028" target="_blanc">NE EDMONTON, LONDONDERRY</a>13703 40th St N W, Edmonton, AB, T5Y 3B5
+1187<a href="https://www.walmart.ca/en/stores-near-me/1187" target="_blanc">EDMONTON (SSE)</a>110 Watt Common Sw, Edmonton, AB, T6X 1X2
+3026<a href="https://www.walmart.ca/en/stores-near-me/3026" target="_blanc">E. EDMONTON, CAPILANO S.C</a>5004 98 Ave Nw, SUITE 1, Edmonton, AB, T6A 0A1
+3029<a href="https://www.walmart.ca/en/stores-near-me/3029" target="_blanc">S. EDMONTON, ALBERTA</a>1203 Parsons Rd N W, Edmonton, AB, T6N 0A9
+1146<a href="https://www.walmart.ca/en/stores-near-me/1146" target="_blanc">EDMONTON (NORTHGATE)</a>9499 137 Ave Nw, NORTHGATE CENTRE, Edmonton, AB, T5E 5R8
+1145<a href="https://www.walmart.ca/en/stores-near-me/1145" target="_blanc">EDMONTON (SOUTH PARK)</a>3931 Calgary Trail Nw, Edmonton, AB, T6J 5M8
+1049<a href="https://www.walmart.ca/en/stores-near-me/1049" target="_blanc">STRATHMORE AB</a>200 Ranch Market, Strathmore, AB, T1P 0A8
+1182<a href="https://www.walmart.ca/en/stores-near-me/1182" target="_blanc">EDMONTON KINGSWAY</a>1 Kingsway Gdn Mall, UNIT 101, Edmonton, AB, T5G 3A6
+1122<a href="https://www.walmart.ca/en/stores-near-me/1122" target="_blanc">EDMONTON NW ALBANY</a>16940 127 St Nw, Edmonton, AB, T6V 1J6
+3657<a href="https://www.walmart.ca/en/stores-near-me/3657" target="_blanc">LEDUC, ALBERTA</a>5302 Discovery Way, Leduc, AB, T9E 8J7
+1149<a href="https://www.walmart.ca/en/stores-near-me/1149" target="_blanc">EDMONTON (MEADOWLARK)</a>156 87 Ave Nw, Edmonton, AB, T5R 5X1
+1094<a href="https://www.walmart.ca/en/stores-near-me/1094" target="_blanc">EDMONTON, AB</a>6110 Currents Dr Nw, Edmonton, AB, T6W 0L7
+3087<a href="https://www.walmart.ca/en/stores-near-me/3087" target="_blanc">ST ALBERT, ALBERTA</a>700 St Albert Trail, St. Albert, AB, T8N 7A5
+3027<a href="https://www.walmart.ca/en/stores-near-me/3027" target="_blanc">W. EDMONTON, MAYFIELD COM</a>18521 Stony Plain Rd Nw, Edmonton, AB, T5S 2V9
+3075<a href="https://www.walmart.ca/en/stores-near-me/3075" target="_blanc">N RED DEER, PARKLAND MALL</a>6375 50th Ave, Red Deer, AB, T4N 4C7
+3194<a href="https://www.walmart.ca/en/stores-near-me/3194" target="_blanc">S. RED DEER, ALBERTA</a>2010 50th Ave, Red Deer, AB, T4R 3A2
+3637<a href="https://www.walmart.ca/en/stores-near-me/3637" target="_blanc">SPRUCE GROVE, AB</a>90 Campsite Rd, Spruce Grove, AB, T7X 4H4
+1136<a href="https://www.walmart.ca/en/stores-near-me/1136" target="_blanc">CALGARY EAST HILLS</a>255 East Hills Blvd Se, Calgary, AB, T2A 4X7
+1102<a href="https://www.walmart.ca/en/stores-near-me/1102" target="_blanc">SYLVAN LAKE, AB</a>3420 47th Ave, Sylvan Lake, AB, T4S 0B6
+3012<a href="https://www.walmart.ca/en/stores-near-me/3012" target="_blanc">E. CALGARY, MARLBOROUGH</a>3800 Memorial Dr, UNIT 1100, Calgary, AB, T2A 2K2
+1050<a href="https://www.walmart.ca/en/stores-near-me/1050" target="_blanc">AIRDRIE, AB</a>2881 Main St Se, Airdrie, AB, T4B 3G5
+3650<a href="https://www.walmart.ca/en/stores-near-me/3650" target="_blanc">CALGARY SOUTH EAST, AB</a>4705 130 Ave Se, Calgary, AB, T2Z 4J2
+5708<a href="https://www.walmart.ca/en/stores-near-me/5708" target="_blanc">OKOTOKS, AB</a>500-201 Southridge Dr, Okotoks, AB, T1S 2C8
+3013<a href="https://www.walmart.ca/en/stores-near-me/3013" target="_blanc">N. CALGARY, DEERFOOT MALL</a>1110 57th Ave N E, Calgary, AB, T2E 9B7
+1089<a href="https://www.walmart.ca/en/stores-near-me/1089" target="_blanc">CALGARY DEERFOOT, AB</a>7979-11 St Se, Calgary, AB, T2H 0B8
+1084<a href="https://www.walmart.ca/en/stores-near-me/1084" target="_blanc">OLDS, AB</a>Unit 400-6900 46th St, Olds, AB, T4H 0A2
+3151<a href="https://www.walmart.ca/en/stores-near-me/3151" target="_blanc">S. CALGARY, ALBERTA</a>100-310 Shawville Blvd S E, Calgary, AB, T2Y 3S4
+3010<a href="https://www.walmart.ca/en/stores-near-me/3010" target="_blanc">C. CALGARY, MCLEOD MALL</a>9650 Macleod Trail Se, MACLEOD MALL SC, Calgary, AB, T2J 0P7
+1097<a href="https://www.walmart.ca/en/stores-near-me/1097" target="_blanc">CALGARY, SAGE-HILL., AB</a>35 Sage Hill Gate Nw, Calgary, AB, T3R 0S4
+3011<a href="https://www.walmart.ca/en/stores-near-me/3011" target="_blanc">NW. CALGARY, NORTHLAND</a>5005 Northland Dr N W, Calgary, AB, T2L 2K1
+3009<a href="https://www.walmart.ca/en/stores-near-me/3009" target="_blanc">W. CALGARY, WESTBROOK</a>1212 37th St S W, WESTBROOK PLAZA, Calgary, AB, T3C 1S3
+5726<a href="https://www.walmart.ca/en/stores-near-me/5726" target="_blanc">CALGARY, ALBERTA</a>8888 Country Hills Blvd Nw, # 200, Calgary, AB, T3G 5T4
+1070<a href="https://www.walmart.ca/en/stores-near-me/1070" target="_blanc">PINCHER CREEK, AB</a>1100 Table Mountain St, Pincher Creek, AB, T0K 1W0
+1135<a href="https://www.walmart.ca/en/stores-near-me/1135" target="_blanc">Cochrane</a>15 Quarry Street West, Cochrane, AB, T4C 0W5
+1030<a href="https://www.walmart.ca/en/stores-near-me/1030" target="_blanc">SLAVE LAKE, AB</a>1500 Main St, # 601, Slave Lake, AB, T0G 2A4
+1008<a href="https://www.walmart.ca/en/stores-near-me/1008" target="_blanc">DRAYTON VALLEY, AB</a>5217 Power Centre Blvd, Drayton Valley, AB, T7A 0A5
+1009<a href="https://www.walmart.ca/en/stores-near-me/1009" target="_blanc">WHITECOURT, AB</a>4215 -52 Avenue, Whitecourt, AB, T7S 1X6
+3183<a href="https://www.walmart.ca/en/stores-near-me/3183" target="_blanc">CRANBROOK, BC</a>2100 Willowbrook Dr, Cranbrook, BC, V1C 7H2
+1048<a href="https://www.walmart.ca/en/stores-near-me/1048" target="_blanc">EDSON AB</a>5750 2nd Ave, Edson, AB, T7E 0A1
+3121<a href="https://www.walmart.ca/en/stores-near-me/3121" target="_blanc">YELLOWKNIFE, NWT</a>313 Old Airport Rd, Yellowknife, NT, X1A 3T3
+1068<a href="https://www.walmart.ca/en/stores-near-me/1068" target="_blanc">PEACE RIVER, AB</a>9701-78 St, Peace River, AB, T8S 0A3
+3038<a href="https://www.walmart.ca/en/stores-near-me/3038" target="_blanc">HINTON, ALBERTA</a># 100 900 Carmichael Lane, PARKS W MALL, Hinton, AB, T7V 1Y6
+3060<a href="https://www.walmart.ca/en/stores-near-me/3060" target="_blanc">NELSON, BRITISH COLUMBIA</a>1000 Lakeside Dr, Nelson, BC, V1L 5Z4
+1011<a href="https://www.walmart.ca/en/stores-near-me/1011" target="_blanc">TRAIL, BC</a>1601 Marcolin Dr, Trail, BC, V1R 4Y1
+3147<a href="https://www.walmart.ca/en/stores-near-me/3147" target="_blanc">GRANDE PRAIRIE, AB</a>11050-103 Ave, Grand-prairie, AB, T8V 7H1
+1100<a href="https://www.walmart.ca/en/stores-near-me/1100" target="_blanc">Salmon Arm</a>2991 10 Ave  Sw, UNIT A, Salmon Arm, BC, V1E 3J9
+3169<a href="https://www.walmart.ca/en/stores-near-me/3169" target="_blanc">VERNON, B.C.</a>2200-58 Th Ave, Vernon, BC, V1T 9T2
+5776<a href="https://www.walmart.ca/en/stores-near-me/5776" target="_blanc">DAWSON CREEK, BC</a># 600 Hwy 2, Dawson Creek, BC, V1G 0A4
+3042<a href="https://www.walmart.ca/en/stores-near-me/3042" target="_blanc">KELOWNA BRITISH COLUMBIA</a>1555 Banks Rd, Kelowna, BC, V1X 7Y8
+1093<a href="https://www.walmart.ca/en/stores-near-me/1093" target="_blanc">WESTBANK, BC</a>2170 Louie Dr, Westbank, BC, V4T 3E5
+3070<a href="https://www.walmart.ca/en/stores-near-me/3070" target="_blanc">PENTICTON, BC</a>275 Green Ave W, Penticton, BC, V2A 7J2
+3661<a href="https://www.walmart.ca/en/stores-near-me/3661" target="_blanc">FORT ST JOHN, BC</a>9007 96a St, Fort St. John, BC, V1J 7B6
+3040<a href="https://www.walmart.ca/en/stores-near-me/3040" target="_blanc">KAMLOOPS BRITISH COLUMBIA</a>1055 Hillside Dr Unit # 100, Kamloops, BC, V2E 2S5
+1036<a href="https://www.walmart.ca/en/stores-near-me/1036" target="_blanc">MERRITT, BC</a>100-3900 Crawford Ave, Merritt, BC, V1K 0A4
+1106<a href="https://www.walmart.ca/en/stores-near-me/1106" target="_blanc">WILLIAMS LAKE, BC</a>1205 Prosperity Way, Williams Lake, BC, V2G 0A6
+3199<a href="https://www.walmart.ca/en/stores-near-me/3199" target="_blanc">QUESNEL, B.C.</a>890 Rita Rd, Quesnel, BC, V2J 7J3
+3651<a href="https://www.walmart.ca/en/stores-near-me/3651" target="_blanc">PRINCE GEORGE, BC</a>6565 Southridge Ave, Prince George, BC, V2N 6Z4
+3167<a href="https://www.walmart.ca/en/stores-near-me/3167" target="_blanc">CHILLIWACK, BC</a>8249 Eagle Landng Pkwy, Chilliwack, BC, V2R 0P9
+3019<a href="https://www.walmart.ca/en/stores-near-me/3019" target="_blanc">ABBOTSFORD EAST</a>1812 Vedder Way, Abbotsford, BC, V2S 8K1
+1119<a href="https://www.walmart.ca/en/stores-near-me/1119" target="_blanc">Mission</a>31956 Lougheed Hwy, Mission, BC, V2V 0C6
+1113<a href="https://www.walmart.ca/en/stores-near-me/1113" target="_blanc">ABBOTSFORD W, BC</a>3122 Mt Lehman Rd, Abbotsford, BC, V2T 0C5
+1206<a href="https://www.walmart.ca/en/stores-near-me/1206" target="_blanc">MAPLE RIDGE</a>11850 224 St, Maple Ridge, BC, V2X 8S1
+3158<a href="https://www.walmart.ca/en/stores-near-me/3158" target="_blanc">LANGLEY BC</a>20202 66th Ave, Langley, BC, V2Y 1P3
+1112<a href="https://www.walmart.ca/en/stores-near-me/1112" target="_blanc">PORT COQUITLAM., BC</a>2150 Hawkins St, Port Coquitlam, BC, V3B 0G6
+1208<a href="https://www.walmart.ca/en/stores-near-me/1208" target="_blanc">COQUITLAM</a>2929 Barnet Hwy, # 3010, Coquitlam, BC, V3B 5R5
+3098<a href="https://www.walmart.ca/en/stores-near-me/3098" target="_blanc">E. SURRY, BC, GUILDFORD / RELO 0404</a>10355 152 St, UNIT 1000, Surrey, BC, V3R 7C1
+5853<a href="https://www.walmart.ca/en/stores-near-me/5853" target="_blanc">SURREY, BC</a>2355-160 St, Surrey, BC, V3Z 9N6
+1205<a href="https://www.walmart.ca/en/stores-near-me/1205" target="_blanc">SURREY (DOWNTOWN)</a>2151-10153 King George Blvd, Surrey, BC, V3T 2W3
+3008<a href="https://www.walmart.ca/en/stores-near-me/3008" target="_blanc">BURNABY, BRITISH COLUMBIA</a>9855 Austin Rd, SUITE 300, Burnaby, BC, V3J 1N5
+5838<a href="https://www.walmart.ca/en/stores-near-me/5838" target="_blanc">SURREY WEST, BC</a>12451 88 Ave, Surrey, BC, V3W 1P8
+1207<a href="https://www.walmart.ca/en/stores-near-me/1207" target="_blanc">SURREY (SW)</a>7155 120 St, Delta, BC, V4E 2B1
+1192<a href="https://www.walmart.ca/en/stores-near-me/1192" target="_blanc">New Westminster(C)</a>610 Sixth St, New Westminster, BC, V3L 3C2
+5777<a href="https://www.walmart.ca/en/stores-near-me/5777" target="_blanc">NEW WESTMINSTER, BC</a>805 Boyd St, New Westminster, BC, V3M 5X2
+1015<a href="https://www.walmart.ca/en/stores-near-me/1015" target="_blanc">SQUAMISH, BC</a>39210 Discovery Way, Squamish, BC, V8B 0N1
+1213<a href="https://www.walmart.ca/en/stores-near-me/1213" target="_blanc">BURNABY SW</a>4545 Central Blvd, Burnaby, BC, V5H 4J1
+1104<a href="https://www.walmart.ca/en/stores-near-me/1104" target="_blanc">VANCOUVER, BC</a>3585 Grandview Hwy, Vancouver, BC, V5M 2G7
+3057<a href="https://www.walmart.ca/en/stores-near-me/3057" target="_blanc">N VANCOUVER, B. C.</a>925 Marine Dr, North Vancouver, BC, V7P 1S2
+3652<a href="https://www.walmart.ca/en/stores-near-me/3652" target="_blanc">RICHMOND (N), BC</a>9251 Alderbridge Way, Richmond, BC, V6X 0N1
+1181<a href="https://www.walmart.ca/en/stores-near-me/1181" target="_blanc">TSAWWASSEN</a>5143 Canoe Pass Way, Tsawwassen, BC, V4M 0B2
+1214<a href="https://www.walmart.ca/en/stores-near-me/1214" target="_blanc">VICTORIA E - HILLSIDE MALL</a>1644 Hillside Ave, Victoria, BC, V8T 2C5
+3109<a href="https://www.walmart.ca/en/stores-near-me/3109" target="_blanc">VICTORIA B C / Relo 0400</a>3460 Saanich Rd, Victoria, BC, V8Z 0B9
+3188<a href="https://www.walmart.ca/en/stores-near-me/3188" target="_blanc">LANGFORD, BC</a>860 Langford Pkwy, Langford, BC, V9B 2P3
+3025<a href="https://www.walmart.ca/en/stores-near-me/3025" target="_blanc">DUNCAN, BC</a>3020 Drinkwater Rd, Duncan, BC, V9L 6C6
+3059<a href="https://www.walmart.ca/en/stores-near-me/3059" target="_blanc">NANAIMO, BRITISH COLUMBIA</a>6801 Island Hwy N, Nanaimo, BC, V9T 6N8
+3072<a href="https://www.walmart.ca/en/stores-near-me/3072" target="_blanc">POWELL RIVER, BC</a>7100 Alberni St, TOWN CTR MALL, Powell River, BC, V8A 5K9
+1018<a href="https://www.walmart.ca/en/stores-near-me/1018" target="_blanc">PORT ALBERNI, BC</a>3355 Johnston Rd (hwy 4), Port Alberni, BC, V9Y 8K1
+3163<a href="https://www.walmart.ca/en/stores-near-me/3163" target="_blanc">COURTENAY, BC</a>3199 Cliffe Ave, Courtenay, BC, V9N 2L9
+1077<a href="https://www.walmart.ca/en/stores-near-me/1077" target="_blanc">CAMPBELL RIVER,BC</a>1477 Island Hwy, Campbell River, BC, V9W 8E5
+5834<a href="https://www.walmart.ca/en/stores-near-me/5834" target="_blanc">TERRACE, BC</a>4427 Hwy 16 W, Terrace, BC, V8G 5L5
+1143<a href="https://www.walmart.ca/en/stores-near-me/1143" target="_blanc">Prince Rupert</a>500 2nd Ave W, Prince Rupert, BC, V8J 3T6
+7124<a href="https://www.walmart.ca/en/stores-near-me/7124" target="_blanc">LAVAL, QC</a>1400 Le Corbusier Blvd., Laval, QC, H7N 6J5


### PR DESCRIPTION
## Summary
- add the generated `incoming/walmart_stores.json` dataset (403 stores) alongside its raw TSV source with the Saint-Jérôme/Laval/Montreal additions
- update `incoming/walmart_scraper.py` to rely on the JSON dataset, normalize entries, and guard against duplicate slugs
- refresh the README automation notes to point to the new data flow

## Testing
- python - <<'PY'
from incoming.walmart_scraper import load_stores
stores = load_stores()
print(len(stores))
print(next(store.slug for store in stores if store.id_store == '7147'))
print(next(store.slug for store in stores if store.id_store == '7124'))
print(next(store.slug for store in stores if store.id_store == '7146'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68e02529dbe8832e8ec700ecc8204b98