### PR TITLE
Localize Italian pages

### DIFF
--- a/best-deals-it.html
+++ b/best-deals-it.html
@@ -59,22 +59,22 @@
 <body class="overlay-active">
   <div id="registrationOverlay" role="dialog" aria-modal="true" aria-labelledby="registrationTitle">
     <div class="registration-card">
-      <h2 id="registrationTitle">Members-only access</h2>
-      <p class="muted" style="margin:0">Join <strong><span data-client-count>0</span></strong> deal hunters and unlock the top offers leaderboard.</p>
+      <h2 id="registrationTitle">Accesso riservato ai membri</h2>
+      <p class="muted" style="margin:0">Unisciti a <strong><span data-client-count>0</span></strong> cacciatori di offerte e sblocca la classifica delle migliori promozioni.</p>
       <form id="registrationForm">
         <div>
-          <label for="fullName">Full name</label>
-          <input id="fullName" name="fullName" type="text" placeholder="Enter your name" autocomplete="name" required />
+          <label for="fullName">Nome completo</label>
+          <input id="fullName" name="fullName" type="text" placeholder="Inserisci il tuo nome" autocomplete="name" required />
         </div>
         <div>
           <label for="email">Email</label>
-          <input id="email" name="email" type="email" placeholder="name@example.com" autocomplete="email" required />
+          <input id="email" name="email" type="email" placeholder="nome@esempio.com" autocomplete="email" required />
         </div>
         <div class="checkbox-row">
           <input id="regulationCheckbox" name="regulation" type="checkbox" required />
-          <label for="regulationCheckbox" style="margin:0">I confirm I have read and accepted the site usage guidelines.</label>
+          <label for="regulationCheckbox" style="margin:0">Confermo di aver letto e accettato le linee guida di utilizzo del sito.</label>
         </div>
-        <button id="registrationSubmit" type="submit" disabled>Sign up and unlock access</button>
+        <button id="registrationSubmit" type="submit" disabled>Registrati e sblocca l'accesso</button>
       </form>
     </div>
   </div>
@@ -82,25 +82,25 @@
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
         <a class="brand" href="index-it.html">
-          <img src="assets/logo.svg" alt="EconoDeal – reseller accelerator" />
+          <img src="assets/logo.svg" alt="EconoDeal – acceleratore per rivenditori" />
           <span class="brand-text">
             <span class="brand-title">EconoDeal</span>
-            <span class="brand-tagline">Winning reseller</span>
+            <span class="brand-tagline">Rivenditore vincente</span>
           </span>
         </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
-        <a class="nav-button current" href="best-deals-it.html" style="white-space:nowrap">Top deals</a>
-        <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Plans / pricing</a>
-        <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / vision</a>
-        <div class="lang-switch" aria-label="Language selector">
+        <a class="nav-button current" href="best-deals-it.html" style="white-space:nowrap">Migliori offerte</a>
+        <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Piani / prezzi</a>
+        <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / visione</a>
+        <div class="lang-switch" aria-label="Selettore lingua">
           <a href="best-deals.html">FR</a>
           <a href="best-deals-en.html">EN</a>
           <a href="best-deals-es.html">ES</a>
           <a href="best-deals-de.html">DE</a>
           <span class="active" aria-current="true">IT</span>
         </div>
-        <div class="muted" style="white-space:nowrap">Registered clients:&nbsp; <span data-client-count>0</span></div>
+        <div class="muted" style="white-space:nowrap">Clienti registrati:&nbsp; <span data-client-count>0</span></div>
         <div class="muted">© <span id="year"></span></div>
       </div>
     </div>
@@ -109,32 +109,32 @@
   <main class="container">
     <section class="section" style="padding-bottom:10px">
       <div class="hero">
-        <div class="badge">Updated after each crawl</div>
-        <h2>Top clearance leaderboard</h2>
-        <p class="muted" style="max-width:720px">Discover the most aggressive discounts detected by our bots across every monitored retailer. The leaderboard refreshes automatically once each crawl ends. Reload the page to see the latest offers and review the top 100 clearance deals ranked by discount rate.</p>
+        <div class="badge">Aggiornato dopo ogni crawl</div>
+        <h2>Classifica delle migliori liquidazioni</h2>
+        <p class="muted" style="max-width:720px">Scopri gli sconti più aggressivi individuati dai nostri bot in tutti i rivenditori monitorati. La classifica si aggiorna automaticamente al termine di ogni crawl. Ricarica la pagina per vedere le offerte più recenti e rivedere le prime 100 liquidazioni ordinate per tasso di sconto.</p>
         <div class="status-banner" id="statusBanner" role="status">
-          <span id="statusText">Analysing the latest crawls...</span>
+          <span id="statusText">Analisi degli ultimi crawl in corso...</span>
         </div>
         <div class="filters">
           <div>
-            <label for="storeFilter" class="muted" style="font-size:12px;display:block;margin-bottom:4px">Filter by retailer</label>
+            <label for="storeFilter" class="muted" style="font-size:12px;display:block;margin-bottom:4px">Filtra per rivenditore</label>
             <select id="storeFilter">
-              <option value="">All retailers</option>
+              <option value="">Tutti i rivenditori</option>
             </select>
           </div>
-          <div style="margin-left:auto" class="muted">Total:&nbsp;<span id="dealCount">0</span> deals</div>
+          <div style="margin-left:auto" class="muted">Totale:&nbsp;<span id="dealCount">0</span> offerte</div>
         </div>
       </div>
     </section>
 
     <section class="section" style="padding-top:12px">
       <div id="cards" class="grid" aria-live="polite"></div>
-      <div id="emptyState" class="empty" style="display:none">No clearance deals found right now. Please try again later!</div>
+      <div id="emptyState" class="empty" style="display:none">Nessuna offerta in liquidazione trovata al momento. Riprova più tardi!</div>
     </section>
   </main>
 
   <div class="container footer">
-    © <span id="yearFooter"></span> EconoDeal · All rights reserved
+    © <span id="yearFooter"></span> EconoDeal · Tutti i diritti riservati
   </div>
 
   <style>

--- a/index-it.html
+++ b/index-it.html
@@ -225,22 +225,22 @@
   </div>
   <div id="registrationOverlay" role="dialog" aria-modal="true" aria-labelledby="registrationTitle">
     <div class="registration-card">
-      <h2 id="registrationTitle">Members-only access</h2>
-      <p class="muted" style="margin:0">Join <strong><span data-client-count>0</span></strong> Amazon resellers and deal hunters, then unlock the full catalogue.</p>
+      <h2 id="registrationTitle">Accesso riservato ai membri</h2>
+      <p class="muted" style="margin:0">Unisciti a <strong><span data-client-count>0</span></strong> rivenditori Amazon e cacciatori di offerte, poi sblocca l'intero catalogo.</p>
       <form id="registrationForm">
         <div>
-          <label for="fullName">Full name</label>
-          <input id="fullName" name="fullName" type="text" placeholder="Enter your name" autocomplete="name" required />
+          <label for="fullName">Nome completo</label>
+          <input id="fullName" name="fullName" type="text" placeholder="Inserisci il tuo nome" autocomplete="name" required />
         </div>
         <div>
           <label for="email">Email</label>
-          <input id="email" name="email" type="email" placeholder="name@example.com" autocomplete="email" required />
+          <input id="email" name="email" type="email" placeholder="nome@esempio.com" autocomplete="email" required />
         </div>
         <div class="checkbox-row">
           <input id="regulationCheckbox" name="regulation" type="checkbox" required />
-          <label for="regulationCheckbox" style="margin:0">I confirm I have read and accepted the site usage guidelines.</label>
+          <label for="regulationCheckbox" style="margin:0">Confermo di aver letto e accettato le linee guida di utilizzo del sito.</label>
         </div>
-        <button id="registrationSubmit" type="submit" disabled>Sign up and unlock access</button>
+        <button id="registrationSubmit" type="submit" disabled>Registrati e sblocca l'accesso</button>
       </form>
     </div>
   </div>
@@ -249,31 +249,31 @@
       <div class="row header-top">
         <div class="row" style="gap:16px;align-items:center;flex-wrap:wrap">
           <a class="brand" href="index-it.html">
-            <img src="assets/logo.svg" alt="EconoDeal – Amazon sellers accelerator" />
+            <img src="assets/logo.svg" alt="EconoDeal – acceleratore per venditori Amazon" />
             <span class="brand-text">
               <span class="brand-title">EconoDeal</span>
-              <span class="brand-tagline">Your Amazon hub</span>
+              <span class="brand-tagline">Il tuo hub Amazon</span>
             </span>
           </a>
-          <div class="country-toggle country-toggle--header" role="group" aria-label="Select country">
+          <div class="country-toggle country-toggle--header" role="group" aria-label="Seleziona paese">
             <button type="button" class="country-button active" data-country="canada" aria-pressed="true">Canada</button>
-            <button type="button" class="country-button" data-country="usa" aria-pressed="false">United States</button>
-            <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europe</button>
+            <button type="button" class="country-button" data-country="usa" aria-pressed="false">Stati Uniti</button>
+            <button type="button" class="country-button" data-country="europe" aria-pressed="false">Europa</button>
           </div>
         </div>
         <div class="row" style="gap:12px;align-items:center">
-          <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Top deals</a>
-          <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Plans / pricing</a>
-          <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / vision</a>
-          <div class="lang-switch" aria-label="Language selector">
+          <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Migliori offerte</a>
+          <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Piani / prezzi</a>
+          <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / visione</a>
+          <div class="lang-switch" aria-label="Selettore lingua">
             <a href="index.html">FR</a>
             <a href="index-en.html">EN</a>
             <a href="index-es.html">ES</a>
             <a href="index-de.html">DE</a>
             <span class="active" aria-current="true">IT</span>
           </div>
-          <span class="header-region" data-exchange-indicator aria-live="polite" aria-label="Exchange rate 1 CAD to 1 CAD">1 CAD = 1 CAD</span>
-          <div class="muted" style="white-space:nowrap">Registered clients:&nbsp; <span data-client-count>0</span></div>
+          <span class="header-region" data-exchange-indicator aria-live="polite" aria-label="Tasso di cambio 1 CAD per 1 CAD">1 CAD = 1 CAD</span>
+          <div class="muted" style="white-space:nowrap">Clienti registrati:&nbsp; <span data-client-count>0</span></div>
           <div class="muted">© <span id="year"></span></div>
         </div>
       </div>
@@ -284,107 +284,107 @@
   <main class="container">
     <section class="hero" aria-labelledby="heroTitle">
       <div class="hero-content">
-        <span class="hero-kicker">Amazon arbitrage platform</span>
-        <h1 id="heroTitle">Unlock the best clearance deals to grow your listings</h1>
-        <p>Centralise your product sourcing, plug in key suppliers and let our AI signals surface the most profitable discounts for Amazon.ca, Amazon.com and Europe.</p>
+        <span class="hero-kicker">Piattaforma di arbitraggio Amazon</span>
+        <h1 id="heroTitle">Sblocca le migliori offerte in liquidazione per far crescere i tuoi listing</h1>
+        <p>Centralizza il sourcing dei prodotti, collega i fornitori chiave e lascia che i nostri segnali IA mettano in evidenza gli sconti più redditizi per Amazon.ca, Amazon.com e l'Europa.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="#search">Explore inventories</a>
-          <a class="btn btn-secondary" href="#amazon-sellers">See the benefits</a>
+          <a class="btn btn-primary" href="#search">Esplora gli inventari</a>
+          <a class="btn btn-secondary" href="#amazon-sellers">Scopri i vantaggi</a>
         </div>
         <ul class="hero-stats">
-          <li class="hero-stat"><strong>+4 500</strong><span>Active deals</span></li>
-          <li class="hero-stat"><strong>97 %</strong><span>Validated Amazon listings</span></li>
-          <li class="hero-stat"><strong>12 h</strong><span>Hours saved each week</span></li>
+          <li class="hero-stat"><strong>+4 500</strong><span>Offerte attive</span></li>
+          <li class="hero-stat"><strong>97 %</strong><span>Listing Amazon convalidati</span></li>
+          <li class="hero-stat"><strong>12 h</strong><span>Ore risparmiate ogni settimana</span></li>
         </ul>
       </div>
       <div class="hero-preview" aria-hidden="true">
         <article class="hero-preview-card">
           <header>
-            <span>Snapshot</span>
-            <div class="badge" style="margin:0">Canada feed</div>
+            <span>Panoramica</span>
+            <div class="badge" style="margin:0">Feed Canada</div>
           </header>
-          <h2>Opportunities in focus</h2>
-          <p>Track actionable price gaps between your favourite retailers and the Amazon Buy Box in real time.</p>
+          <h2>Opportunità in evidenza</h2>
+          <p>Monitora in tempo reale gli scarti di prezzo azionabili tra i tuoi rivenditori preferiti e la Buy Box di Amazon.</p>
           <ul class="hero-preview-list">
-            <li class="hero-preview-item"><span>1</span> Priority alerts when margin exceeds 28%.</li>
-            <li class="hero-preview-item"><span>2</span> Consolidated stock statuses for Best Buy, Walmart and Canadian Tire.</li>
-            <li class="hero-preview-item"><span>3</span> Instant export to your FBA and FBM templates.</li>
+            <li class="hero-preview-item"><span>1</span> Avvisi prioritari quando il margine supera il 28%.</li>
+            <li class="hero-preview-item"><span>2</span> Stati di stock consolidati per Best Buy, Walmart e Canadian Tire.</li>
+            <li class="hero-preview-item"><span>3</span> Esportazione immediata verso i tuoi modelli FBA e FBM.</li>
           </ul>
         </article>
       </div>
     </section>
     <section class="section value-section" id="investors">
       <div class="value-header">
-        <h2>Signals that reassure investors</h2>
-        <p class="muted">EconoDeal blends tangible usage indicators with an ambitious AI roadmap that proves its ability to create recurring value across markets.</p>
+        <h2>Segnali che rassicurano gli investitori</h2>
+        <p class="muted">EconoDeal combina indicatori di utilizzo concreti con una roadmap IA ambiziosa che dimostra la capacità di generare valore ricorrente nei diversi mercati.</p>
       </div>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">📊</span>
-          <h3>Robust data-driven positioning</h3>
+          <h3>Posizionamento robusto basato sui dati</h3>
           <ul>
-            <li><span class="value-metric">4,500+ active deals</span> consolidated in a single arbitrage-ready catalogue.</li>
-            <li><span class="value-metric">97% of listings validated</span>, proving data quality and reliable Amazon exports.</li>
-            <li><span class="value-metric">12 hours saved</span> per week on average thanks to sourcing automation.</li>
+            <li><span class="value-metric">Oltre 4&nbsp;500 offerte attive</span> consolidate in un unico catalogo pronto per l'arbitraggio.</li>
+            <li><span class="value-metric">97&nbsp;% dei listing convalidato</span>, a prova della qualità dei dati e di esportazioni affidabili verso Amazon.</li>
+            <li><span class="value-metric">12 ore risparmiate</span> a settimana in media grazie all'automazione del sourcing.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🌐</span>
-          <h3>Scalable technology</h3>
+          <h3>Tecnologia scalabile</h3>
           <ul>
-            <li><span class="value-metric">2.4M ASINs tracked</span> across Amazon.ca, Amazon.com and Amazon EU.</li>
-            <li>Average detection of <span class="value-metric">18 seconds</span> between a new discount and its priority alert.</li>
-            <li>AI automations recovering a <span class="value-metric">median +32% margin</span> on monitored scenarios.</li>
+            <li><span class="value-metric">2,4&nbsp;M di ASIN monitorati</span> su Amazon.ca, Amazon.com e Amazon EU.</li>
+            <li>Rilevamento medio di <span class="value-metric">18 secondi</span> tra un nuovo sconto e il relativo avviso prioritario.</li>
+            <li>Automazioni IA che recuperano un <span class="value-metric">margine mediano di +32&nbsp;%</span> negli scenari monitorati.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🗺️</span>
-          <h3>Three-year growth vision</h3>
+          <h3>Visione di crescita triennale</h3>
           <ul>
-            <li>Sequenced expansion: Canada → United States → Europe with full localisation.</li>
-            <li>Rollout of real-time alerts, predictive analytics and a multilingual AI recommendation engine.</li>
-            <li>Progressive monetisation that adds Seller Central exports, AI scenarios and advanced market insights.</li>
+            <li>Espansione sequenziale: Canada → Stati Uniti → Europa con localizzazione completa.</li>
+            <li>Implementazione di avvisi in tempo reale, analisi predittiva e motore di raccomandazioni IA multilingue.</li>
+            <li>Monetizzazione progressiva che aggiunge esportazioni Seller Central, scenari IA e insight di mercato avanzati.</li>
           </ul>
         </article>
       </div>
     </section>
     <section class="section" id="search">
-      <h2 style="margin:0 0 10px">Find clearance inventory for your Amazon listings</h2>
-      <p class="muted">Files are loaded from <span class="kbd">data/&lt;store&gt;/&lt;city&gt;.json</span> to rapidly surface arbitrage opportunities.</p>
+      <h2 style="margin:0 0 10px">Trova inventario in liquidazione per i tuoi listing Amazon</h2>
+      <p class="muted">I file sono caricati da <span class="kbd">data/&lt;store&gt;/&lt;city&gt;.json</span> per mostrare rapidamente le opportunità di arbitraggio.</p>
 
       <!-- ✅ Les éléments requis existent et leurs IDs correspondent au script -->
       <div class="row" style="gap:12px;align-items:center;flex-wrap:wrap;margin-top:12px">
-        <span class="muted" data-country-label>Covered country: Canada · Currency: CAD</span>
+        <span class="muted" data-country-label>Paese coperto: Canada · Valuta: CAD</span>
       </div>
 
       <div class="filters" style="margin-top:12px">
         <div>
-          <label for="searchInput">Quick search</label>
-          <input id="searchInput" name="search" type="text" inputmode="search" placeholder="Ex. Nintendo Switch, Lego..." autocomplete="off" />
+          <label for="searchInput">Ricerca rapida</label>
+          <input id="searchInput" name="search" type="text" inputmode="search" placeholder="Es. Nintendo Switch, Lego..." autocomplete="off" />
         </div>
         <div>
-          <label for="storeSelect">Store</label>
+          <label for="storeSelect">Negozio</label>
           <select id="storeSelect">
-            <option value="">(All)</option>
+            <option value="">(Tutti)</option>
           </select>
         </div>
         <div>
-          <label for="citySelect">City</label>
+          <label for="citySelect">Città</label>
           <select id="citySelect">
-            <option value="">(All)</option>
+            <option value="">(Tutte)</option>
           </select>
         </div>
         <div>
-          <label for="postalInput">Postal code</label>
-          <input id="postalInput" name="postal" type="text" inputmode="text" placeholder="Ex. H2X 1Y4" autocomplete="postal-code" />
-          <p id="postalHelper" class="field-helper">Enter the first three characters of the postal code to find branches within 50 km (e.g. H2X).</p>
+          <label for="postalInput">Codice postale</label>
+          <input id="postalInput" name="postal" type="text" inputmode="text" placeholder="Es. H2X 1Y4" autocomplete="postal-code" />
+          <p id="postalHelper" class="field-helper">Inserisci i primi tre caratteri del codice postale per trovare filiali entro 50 km (es. H2X).</p>
         </div>
         <div>
-          <label for="discountRange">Minimum discount: <span id="discountValue" class="kbd">0%</span></label>
+          <label for="discountRange">Sconto minimo: <span id="discountValue" class="kbd">0%</span></label>
           <input id="discountRange" type="range" min="0" max="90" step="5" value="0" />
         </div>
         <div style="align-self:end">
-          <button id="btnClear">Reset filters</button>
+          <button id="btnClear">Reimposta filtri</button>
         </div>
       </div>
 
@@ -392,43 +392,43 @@
 
       <div class="section">
         <div class="row" style="justify-content:space-between;align-items:center">
-          <h3 style="margin:0">Results</h3>
-          <div class="muted"><span id="resultCount">0</span> items</div>
+          <h3 style="margin:0">Risultati</h3>
+          <div class="muted"><span id="resultCount">0</span> elementi</div>
         </div>
         <div id="cards" class="grid" style="margin-top:12px"></div>
       </div>
     </section>
     <section class="section value-section" id="client-value">
       <div class="value-header">
-        <h2>Why paying clients stick with us</h2>
-        <p class="muted">The platform reduces sourcing effort, aligns with Amazon resellers’ critical needs and scales coherently as operations become more complex.</p>
+        <h2>Perché i clienti paganti restano con noi</h2>
+        <p class="muted">La piattaforma riduce lo sforzo di sourcing, si allinea alle esigenze cruciali dei reseller Amazon e scala in modo coerente man mano che le operazioni si fanno più complesse.</p>
       </div>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">⚡</span>
-          <h3>Immediate operational efficiency</h3>
+          <h3>Efficienza operativa immediata</h3>
           <ul>
-            <li>Multi-criteria filters (store, city, postal code, discount threshold) to centralise product searches.</li>
-            <li>Consolidated stock view and actionable price gaps without spreadsheets.</li>
-            <li>Export-ready workflows for Seller Central in just a few clicks.</li>
+            <li>Filtri multi-criterio (negozio, città, codice postale, soglia di sconto) per centralizzare le ricerche prodotto.</li>
+            <li>Vista consolidata delle scorte e scarti di prezzo azionabili senza fogli di calcolo.</li>
+            <li>Flussi pronti per l'esportazione verso Seller Central in pochi clic.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🛒</span>
-          <h3>Tailored to Amazon resellers</h3>
+          <h3>Su misura per i reseller Amazon</h3>
           <ul>
-            <li>Guided FBA onboarding, automatic fee calculation and FBM scenarios built in.</li>
-            <li>Multi-supplier monitoring (Best Buy, Walmart, Canadian Tire, etc.) to secure the Buy Box.</li>
-            <li>Private community and ready-to-launch automations to stay ahead.</li>
+            <li>Onboarding FBA guidato, calcolo automatico delle commissioni e scenari FBM integrati.</li>
+            <li>Monitoraggio multi-fornitore (Best Buy, Walmart, Canadian Tire, ecc.) per assicurarsi la Buy Box.</li>
+            <li>Community privata e automazioni pronte all'uso per restare avanti.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">💡</span>
-          <h3>Clear, gradual monetisation</h3>
+          <h3>Monetizzazione chiara e graduale</h3>
           <ul>
-            <li>Essential plan: fast access to top clearance deals and weekly alerts.</li>
-            <li>Advanced plan: real-time alerts, Seller Central exports and team collaboration.</li>
-            <li>Premium offer: AI analysis, trend forecasts and unlimited multichannel automations.</li>
+            <li>Piano Essential: accesso rapido alle principali offerte in liquidazione e avvisi settimanali.</li>
+            <li>Piano Advanced: avvisi in tempo reale, esportazioni Seller Central e collaborazione del team.</li>
+            <li>Offerta Premium: analisi IA, previsioni dei trend e automazioni multicanale illimitate.</li>
           </ul>
         </article>
       </div>
@@ -436,118 +436,118 @@
 
     <section class="amazon-section" id="amazon-sellers">
       <div>
-        <h2>An experience designed for Amazon resellers</h2>
-        <p class="amazon-intro">Leverage a sourcing hub built for FBA and FBM operations: detect profitable clearance deals in seconds, protect your margins and automate sourcing routines for Amazon.ca and Amazon.com.</p>
+        <h2>Un'esperienza pensata per i reseller Amazon</h2>
+        <p class="amazon-intro">Sfrutta un hub di sourcing creato per le operazioni FBA e FBM: rileva in pochi secondi le offerte in liquidazione redditizie, proteggi i margini e automatizza le routine di sourcing per Amazon.ca e Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
           <strong>2,4&nbsp;M</strong>
-          <span>ASINs tracked</span>
-          <p>Dynamic mapping of Amazon.ca, Amazon.com and Amazon EU catalogues.</p>
+          <span>ASIN monitorati</span>
+          <p>Mappatura dinamica dei cataloghi Amazon.ca, Amazon.com e Amazon EU.</p>
         </div>
         <div class="seller-metric">
           <strong>18&nbsp;s</strong>
-          <span>Average detection time</span>
-          <p>Latency between importing a discount and alerting your team.</p>
+          <span>Tempo medio di rilevamento</span>
+          <p>Latenza tra l'importazione di uno sconto e l'avviso al tuo team.</p>
         </div>
         <div class="seller-metric">
           <strong>+32&nbsp;%</strong>
-          <span>Margin recovered</span>
-          <p>Median gain observed among sellers using our AI scenarios.</p>
+          <span>Margine recuperato</span>
+          <p>Guadagno mediano osservato tra i seller che utilizzano i nostri scenari IA.</p>
         </div>
       </div>
       <div class="seller-grid">
         <article class="seller-card">
           <div class="seller-icon" aria-hidden="true">🚀</div>
-          <h3>Simplified FBA onboarding</h3>
-          <p>Ready-to-use templates to calculate FBA fees, estimate rotation and sync your Amazon listings without complex spreadsheets.</p>
+          <h3>Onboarding FBA semplificato</h3>
+          <p>Template pronti all'uso per calcolare le commissioni FBA, stimare la rotazione e sincronizzare i tuoi listing Amazon senza fogli complicati.</p>
         </article>
         <article class="seller-card">
           <div class="seller-icon" aria-hidden="true">📦</div>
-          <h3>Multi-supplier stock monitoring</h3>
-          <p>Combine inventories from Best Buy, Walmart, Canadian Tire and more to spot exploitable price gaps before other Amazon sellers.</p>
+          <h3>Monitoraggio scorte multi-fornitore</h3>
+          <p>Combina gli inventari di Best Buy, Walmart, Canadian Tire e altri per individuare gli scarti di prezzo sfruttabili prima degli altri seller Amazon.</p>
         </article>
         <article class="seller-card">
           <div class="seller-icon" aria-hidden="true">🤝</div>
-          <h3>Dedicated community</h3>
-          <p>Access a private Amazon reseller lounge, share repricing strategies and benefit from community-validated product comparisons.</p>
+          <h3>Community dedicata</h3>
+          <p>Accedi a una lounge privata per reseller Amazon, condividi strategie di repricing e approfitta di comparazioni prodotto validate dalla community.</p>
         </article>
         <article class="seller-card">
           <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Ready-to-launch automations</h3>
+          <h3>Automazioni pronte al lancio</h3>
           <ul class="seller-list">
-            <li><span aria-hidden="true">✔</span>Alerts when the Buy Box drops below your target.</li>
-            <li><span aria-hidden="true">✔</span>Seller Central-friendly exports and FBA analysis tools.</li>
-            <li><span aria-hidden="true">✔</span>AI suggestions to repackage or arbitrage based on the season.</li>
+            <li><span aria-hidden="true">✔</span>Avvisi quando la Buy Box scende sotto il tuo obiettivo.</li>
+            <li><span aria-hidden="true">✔</span>Esportazioni compatibili con Seller Central e strumenti di analisi FBA.</li>
+            <li><span aria-hidden="true">✔</span>Suggerimenti IA per ripacchettare o fare arbitraggio in base alla stagione.</li>
           </ul>
         </article>
       </div>
     </section>
 
     <section class="section" id="pricing" style="padding-top:10px">
-      <h2 style="margin:0 0 10px">Plans tailored to your needs</h2>
-      <p class="muted" style="max-width:620px">Choose the option that best fits how you monitor discounts, feed your Amazon listings and protect your margins. Every plan includes a 7-day trial.</p>
+      <h2 style="margin:0 0 10px">Piani su misura per le tue esigenze</h2>
+      <p class="muted" style="max-width:620px">Scegli l'opzione che meglio si adatta a come monitori gli sconti, alimenti i tuoi listing Amazon e proteggi i margini. Ogni piano include una prova di 7 giorni.</p>
       <div class="pricing-grid">
         <article class="pricing-card">
           <div class="pricing-tag">Essential</div>
-          <h4>Core access</h4>
+          <h4>Accesso essenziale</h4>
           <div class="pricing-price">9,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Access to popular Amazon-ready clearance deals</li>
-            <li>3 email alerts per week</li>
-            <li>30-day price history</li>
+            <li>Accesso alle principali offerte in liquidazione pronte per Amazon</li>
+            <li>3 avvisi email alla settimana</li>
+            <li>Storico prezzi di 30 giorni</li>
           </ul>
         </article>
         <article class="pricing-card pricing-highlight">
-          <div class="pricing-tag">Most popular</div>
-          <h4>Advanced plan</h4>
+          <div class="pricing-tag">Più scelto</div>
+          <h4>Piano Advanced</h4>
           <div class="pricing-price">19,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Unlimited access to the Amazon-optimised catalogue</li>
-            <li>Real-time personalised alerts</li>
-            <li>Seller Central exports and shared team lists</li>
+            <li>Accesso illimitato al catalogo ottimizzato per Amazon</li>
+            <li>Avvisi personalizzati in tempo reale</li>
+            <li>Esportazioni Seller Central e liste condivise per il team</li>
           </ul>
         </article>
         <article class="pricing-card">
           <div class="pricing-tag">Premium</div>
-          <h4>Full AI analysis</h4>
+          <h4>Analisi IA completa</h4>
           <div class="pricing-price">29,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Unlimited multichannel alerts</li>
-            <li>AI-assisted pricing analysis for Amazon</li>
-            <li>Market trend forecasts and FBA simulation</li>
+            <li>Avvisi multicanale illimitati</li>
+            <li>Analisi dei prezzi assistita dall'IA per Amazon</li>
+            <li>Previsioni dei trend di mercato e simulazione FBA</li>
           </ul>
         </article>
       </div>
     </section>
 
     <section class="section" id="roadmap" style="padding-top:0">
-      <h2 style="margin:0 0 10px">Our roadmap</h2>
-      <p class="muted" style="max-width:640px">A three-year vision to propel EconoDeal internationally, progressively integrating artificial intelligence at the heart of our services.</p>
+      <h2 style="margin:0 0 10px">La nostra roadmap</h2>
+      <p class="muted" style="max-width:640px">Una visione triennale per spingere EconoDeal a livello internazionale, integrando progressivamente l'intelligenza artificiale al centro dei nostri servizi.</p>
       <div class="roadmap">
         <div class="roadmap-grid">
           <article class="roadmap-card">
-            <div class="roadmap-year"><strong>Year 1</strong> Canada</div>
+            <div class="roadmap-year"><strong>Anno 1</strong> Canada</div>
             <ul>
-              <li>Strengthen coverage of national retailers.</li>
-              <li>Optimise real-time discount alerts.</li>
-              <li>Launch bilingual regional dashboards.</li>
+              <li>Rafforzare la copertura dei rivenditori nazionali.</li>
+              <li>Ottimizzare gli avvisi di sconto in tempo reale.</li>
+              <li>Lanciare dashboard regionali bilingui.</li>
             </ul>
           </article>
           <article class="roadmap-card">
-            <div class="roadmap-year"><strong>Year 2</strong> United States</div>
+            <div class="roadmap-year"><strong>Anno 2</strong> Stati Uniti</div>
             <ul>
-              <li>Expand the catalogue to major US banners.</li>
-              <li>Deploy multi-state stock monitoring.</li>
-              <li>Introduce predictive analysis of purchase trends.</li>
+              <li>Ampliare il catalogo ai principali marchi statunitensi.</li>
+              <li>Implementare il monitoraggio delle scorte multi-stato.</li>
+              <li>Introdurre l'analisi predittiva delle tendenze d'acquisto.</li>
             </ul>
           </article>
           <article class="roadmap-card roadmap-ai">
-            <div class="roadmap-year"><strong>Year 3</strong> Europe</div>
+            <div class="roadmap-year"><strong>Anno 3</strong> Europa</div>
             <ul>
-              <li>Localise the experience for key European markets.</li>
-              <li>Activate a multilingual AI recommendation engine.</li>
-              <li>Automate pricing strategies with continuous learning.</li>
+              <li>Localizzare l'esperienza per i principali mercati europei.</li>
+              <li>Attivare un motore di raccomandazioni IA multilingue.</li>
+              <li>Automatizzare le strategie di pricing con apprendimento continuo.</li>
             </ul>
           </article>
         </div>
@@ -556,8 +556,8 @@
   </main>
 
   <div class="container footer">
-    <p style="margin:0 0 8px">EconoDeal is not responsible for the availability of displayed stock and does not store any personal information about visitors.</p>
-    <div>© <span id="yearFooter"></span> EconoDeal · All rights reserved</div>
+    <p style="margin:0 0 8px">EconoDeal non è responsabile della disponibilità delle scorte visualizzate e non archivia alcuna informazione personale dei visitatori.</p>
+    <div>© <span id="yearFooter"></span> EconoDeal · Tutti i diritti riservati</div>
   </div>
 
   <script>

--- a/pricing-it.html
+++ b/pricing-it.html
@@ -54,18 +54,18 @@
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
         <a class="brand" href="index-it.html">
-          <img src="assets/logo.svg" alt="EconoDeal – reseller accelerator" />
+          <img src="assets/logo.svg" alt="EconoDeal – acceleratore per rivenditori" />
           <span class="brand-text">
             <span class="brand-title">EconoDeal</span>
-            <span class="brand-tagline">Winning reseller</span>
+            <span class="brand-tagline">Rivenditore vincente</span>
           </span>
         </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
-        <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Top deals</a>
-        <a class="nav-button current" href="pricing-it.html" style="white-space:nowrap">Plans / pricing</a>
-        <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / vision</a>
-        <div class="lang-switch" aria-label="Language selector">
+        <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Migliori offerte</a>
+        <a class="nav-button current" href="pricing-it.html" style="white-space:nowrap">Piani / prezzi</a>
+        <a class="nav-button" href="roadmap-it.html" style="white-space:nowrap">Roadmap / visione</a>
+        <div class="lang-switch" aria-label="Selettore lingua">
           <a href="pricing.html">FR</a>
           <a href="pricing-en.html">EN</a>
           <a href="pricing-es.html">ES</a>
@@ -79,67 +79,67 @@
 
   <main class="container">
     <section class="section">
-      <h2 style="margin:0 0 10px">Plans tailored to your needs</h2>
-      <p class="muted" style="max-width:620px">Choose the option that best fits how you track discounts and clearance deals in Canada. Every plan includes a 7-day trial.</p>
+      <h2 style="margin:0 0 10px">Piani su misura per le tue esigenze</h2>
+      <p class="muted" style="max-width:620px">Scegli l'opzione che meglio si adatta a come monitori gli sconti e le liquidazioni in Canada. Ogni piano include una prova di 7 giorni.</p>
       <div class="pricing-grid">
         <article class="pricing-card">
           <div class="pricing-tag">Essential</div>
-          <h4>Core access</h4>
+          <h4>Accesso essenziale</h4>
           <div class="pricing-price">9,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Access to popular clearance deals</li>
-            <li>3 email alerts per week</li>
-            <li>30-day price history</li>
+            <li>Accesso alle principali offerte in liquidazione</li>
+            <li>3 avvisi email alla settimana</li>
+            <li>Storico prezzi di 30 giorni</li>
           </ul>
         </article>
         <article class="pricing-card pricing-highlight">
-          <div class="pricing-tag">Most popular</div>
-          <h4>Advanced plan</h4>
+          <div class="pricing-tag">Più scelto</div>
+          <h4>Piano Advanced</h4>
           <div class="pricing-price">19,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Unlimited catalogue access</li>
-            <li>Real-time personalised alerts</li>
-            <li>Shared lists for your team</li>
+            <li>Accesso illimitato al catalogo</li>
+            <li>Avvisi personalizzati in tempo reale</li>
+            <li>Liste condivise per il tuo team</li>
           </ul>
         </article>
         <article class="pricing-card">
           <div class="pricing-tag">Premium</div>
-          <h4>Full AI analysis</h4>
+          <h4>Analisi IA completa</h4>
           <div class="pricing-price">29,99&nbsp;$</div>
           <ul class="pricing-features">
-            <li>Unlimited multichannel alerts</li>
-            <li>AI-assisted pricing analysis</li>
-            <li>Market trend forecasts</li>
+            <li>Avvisi multicanale illimitati</li>
+            <li>Analisi dei prezzi assistita dall'IA</li>
+            <li>Previsioni dei trend di mercato</li>
           </ul>
         </article>
       </div>
     </section>
     <section class="section value-section">
-      <h3 style="margin:0">A planned value ladder</h3>
-      <p class="muted" style="margin:0;max-width:680px">Each pricing tier unlocks concrete capabilities to support the growth of your Amazon operations, from manual sourcing to full AI-driven automation.</p>
+      <h3 style="margin:0">Una scala di valore pianificata</h3>
+      <p class="muted" style="margin:0;max-width:680px">Ogni fascia di prezzo sblocca funzionalità concrete per sostenere la crescita delle tue operazioni Amazon, dal sourcing manuale fino all'automazione completa guidata dall'IA.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
-          <h4>Rapid start</h4>
+          <h4>Avvio rapido</h4>
           <ul>
-            <li>The Essential plan condenses top clearance deals, ideal to quickly validate the feed’s value.</li>
-            <li>Guided email alerts help you test sourcing routines without added complexity.</li>
+            <li>Il piano Essential concentra le migliori liquidazioni, ideale per convalidare rapidamente il valore del feed.</li>
+            <li>Gli avvisi email guidati ti aiutano a testare le routine di sourcing senza complessità aggiuntive.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤝</span>
-          <h4>Advanced collaboration</h4>
+          <h4>Collaborazione avanzata</h4>
           <ul>
-            <li>The Advanced plan adds Seller Central exports and shared lists to structure your team.</li>
-            <li>Real-time notifications to capture the Buy Box before competitors.</li>
+            <li>Il piano Advanced aggiunge esportazioni Seller Central e liste condivise per strutturare il tuo team.</li>
+            <li>Notifiche in tempo reale per conquistare la Buy Box prima dei concorrenti.</li>
           </ul>
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>AI-driven automation</h4>
+          <h4>Automazione guidata dall'IA</h4>
           <ul>
-            <li>The Premium plan activates AI scenarios, trend forecasts and unlimited multichannel alerts.</li>
-            <li>Advanced FBA simulation to secure margins and plan replenishment.</li>
+            <li>Il piano Premium attiva scenari IA, previsioni dei trend e avvisi multicanale illimitati.</li>
+            <li>Simulazione FBA avanzata per proteggere i margini e pianificare i riordini.</li>
           </ul>
         </article>
       </div>
@@ -147,7 +147,7 @@
   </main>
 
   <div class="container footer">
-    © <span id="yearFooter"></span> EconoDeal · All rights reserved
+    © <span id="yearFooter"></span> EconoDeal · Tutti i diritti riservati
   </div>
 
   <script>

--- a/roadmap-it.html
+++ b/roadmap-it.html
@@ -31,7 +31,7 @@
     .section{padding:36px 0}
     .muted{color:var(--muted)}
     .roadmap{background:linear-gradient(180deg,var(--panel),#101b2d);border:1px solid var(--border);border-radius:var(--radius);padding:22px;display:grid;gap:18px;margin-top:22px;position:relative;overflow:hidden}
-    .roadmap::before{content:"Strategic roadmap";position:absolute;top:16px;right:-80px;width:220px;text-align:center;transform:rotate(45deg);background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.35);color:#86efac;padding:6px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase}
+    .roadmap::before{content:"Roadmap strategica";position:absolute;top:16px;right:-80px;width:220px;text-align:center;transform:rotate(45deg);background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.35);color:#86efac;padding:6px 0;font-size:12px;letter-spacing:.08em;text-transform:uppercase}
     .roadmap-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
     .roadmap-card{background:var(--panel-2);border:1px solid var(--border);border-radius:12px;padding:18px;display:flex;flex-direction:column;gap:12px;position:relative;overflow:hidden}
     .roadmap-year{font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
@@ -47,18 +47,18 @@
     <div class="container row" style="justify-content:space-between">
       <div class="row" style="gap:10px;align-items:center">
         <a class="brand" href="index-it.html">
-          <img src="assets/logo.svg" alt="EconoDeal – reseller accelerator" />
+          <img src="assets/logo.svg" alt="EconoDeal – acceleratore per rivenditori" />
           <span class="brand-text">
             <span class="brand-title">EconoDeal</span>
-            <span class="brand-tagline">Winning reseller</span>
+            <span class="brand-tagline">Rivenditore vincente</span>
           </span>
         </a>
       </div>
       <div class="row" style="gap:12px;align-items:center">
-        <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Top deals</a>
-        <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Plans / pricing</a>
-        <a class="nav-button current" href="roadmap-it.html" style="white-space:nowrap">Roadmap / vision</a>
-        <div class="lang-switch" aria-label="Language selector">
+        <a class="nav-button" href="best-deals-it.html" style="white-space:nowrap">Migliori offerte</a>
+        <a class="nav-button" href="pricing-it.html" style="white-space:nowrap">Piani / prezzi</a>
+        <a class="nav-button current" href="roadmap-it.html" style="white-space:nowrap">Roadmap / visione</a>
+        <div class="lang-switch" aria-label="Selettore lingua">
           <a href="roadmap.html">FR</a>
           <a href="roadmap-en.html">EN</a>
           <a href="roadmap-es.html">ES</a>
@@ -72,32 +72,32 @@
 
   <main class="container">
     <section class="section">
-      <h2 style="margin:0 0 10px">Our roadmap</h2>
-      <p class="muted" style="max-width:640px">A three-year vision to propel EconoDeal internationally, progressively integrating artificial intelligence at the heart of our services.</p>
+      <h2 style="margin:0 0 10px">La nostra roadmap</h2>
+      <p class="muted" style="max-width:640px">Una visione triennale per spingere EconoDeal a livello internazionale, integrando progressivamente l'intelligenza artificiale al centro dei nostri servizi.</p>
       <div class="roadmap">
         <div class="roadmap-grid">
           <article class="roadmap-card">
-            <div class="roadmap-year"><strong>Year 1</strong> Canada</div>
+            <div class="roadmap-year"><strong>Anno 1</strong> Canada</div>
             <ul>
-              <li>Strengthen coverage of national retailers.</li>
-              <li>Optimise real-time discount alerts.</li>
-              <li>Launch bilingual regional dashboards.</li>
+              <li>Rafforzare la copertura dei rivenditori nazionali.</li>
+              <li>Ottimizzare gli avvisi di sconto in tempo reale.</li>
+              <li>Lanciare dashboard regionali bilingui.</li>
             </ul>
           </article>
           <article class="roadmap-card">
-            <div class="roadmap-year"><strong>Year 2</strong> United States</div>
+            <div class="roadmap-year"><strong>Anno 2</strong> Stati Uniti</div>
             <ul>
-              <li>Expand the catalogue to major US banners.</li>
-              <li>Deploy multi-state stock monitoring.</li>
-              <li>Introduce predictive analysis of purchase trends.</li>
+              <li>Ampliare il catalogo ai principali marchi statunitensi.</li>
+              <li>Implementare il monitoraggio delle scorte multi-stato.</li>
+              <li>Introdurre l'analisi predittiva delle tendenze d'acquisto.</li>
             </ul>
           </article>
           <article class="roadmap-card roadmap-ai">
-            <div class="roadmap-year"><strong>Year 3</strong> Europe</div>
+            <div class="roadmap-year"><strong>Anno 3</strong> Europa</div>
             <ul>
-              <li>Localise the experience for key European markets.</li>
-              <li>Activate a multilingual AI recommendation engine.</li>
-              <li>Automate pricing strategies with continuous learning.</li>
+              <li>Localizzare l'esperienza per i principali mercati europei.</li>
+              <li>Attivare un motore di raccomandazioni IA multilingue.</li>
+              <li>Automatizzare le strategie di pricing con apprendimento continuo.</li>
             </ul>
           </article>
         </div>
@@ -106,7 +106,7 @@
   </main>
 
   <div class="container footer">
-    © <span id="yearFooter"></span> EconoDeal · All rights reserved
+    © <span id="yearFooter"></span> EconoDeal · Tutti i diritti riservati
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- translate the Italian homepage copy, navigation, and feature sections into proper Italian wording
- localize the Italian best deals, pricing, and roadmap pages to match the updated terminology

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e41bb68bc8832ea1a4219361947cb1