### PR TITLE
Remove automation references from marketing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,19 @@ Site statique bilingue (FR/EN) avec filtres Magasin/Ville et barre de % de rabai
 
 © 2025 EconoDeal
 
-## Automatisation du scraper Walmart
+## Exécution du scraper Walmart
 
-Le script asynchrone `incoming/walmart_scraper.py` peut tourner automatiquement via
-GitHub Actions :
+Le script asynchrone `incoming/walmart_scraper.py` peut être exécuté à la demande
+depuis ton poste de travail :
 
-1. Dans **Settings → Secrets and variables → Actions**, ajoute un secret
-   `WALMART_PROXIES` contenant ta liste JSON de proxies, par exemple :
+1. Crée un fichier `incoming/walmart_stores.json` ou complète la liste `magasins`
+   avec l'identifiant, la ville et l'adresse de chaque magasin.
+2. Lance le script avec `python incoming/walmart_scraper.py` après avoir défini la
+   variable d'environnement `WALMART_PROXIES` contenant ta liste JSON de proxies :
    `[
    "http://user:pass@proxy1:port", "http://user:pass@proxy2:port"
    ]`.
-2. Complète la liste `magasins` dans le script (ou crée un fichier
-   `incoming/walmart_stores.json`) avec l'identifiant, la ville et l'adresse de
-   chacun des magasins.
-3. Le workflow `.github/workflows/walmart-scraper.yml` s'exécute chaque jour à
-   **17 h (heure de l'Est)**, ce qui correspond à 21 h UTC.
-4. Pour lancer le scraper manuellement vers 16 h, ouvre l'onglet **Actions**,
-   sélectionne *Walmart liquidation scraper* puis clique sur **Run workflow**.
-   Tu peux ajouter une note facultative avant de déclencher l'exécution.
-
-Chaque exécution produit un fichier `liquidations_walmart_qc.json` et le met à
-disposition en tant qu'artéfact téléchargeable depuis l'interface des Actions.
-Les jeux de données par magasin sont également mis à jour dans `data/walmart/`
-(`data/walmart/laval.json`, `data/walmart/moncton.json`, etc.) afin d'être
-consommés directement par le site statique.
+3. Récupère les résultats dans `liquidations_walmart_qc.json` ainsi que dans les
+   fichiers par magasin présents dans `data/walmart/` (`data/walmart/laval.json`,
+   `data/walmart/moncton.json`, etc.). Ces jeux de données peuvent ensuite être
+   consommés directement par le site statique.

--- a/best-deals-de.html
+++ b/best-deals-de.html
@@ -111,7 +111,7 @@
       <div class="hero">
         <div class="badge">Nach jedem Crawl aktualisiert</div>
         <h2>Bestenliste der Restposten</h2>
-        <p class="muted" style="max-width:720px">Entdecke die attraktivsten Rabatte, die unsere Bots bei allen überwachten Händlern finden. Die Bestenliste aktualisiert sich automatisch nach jedem Crawl. Lade die Seite neu, um die neuesten Angebote zu sehen und die Top-100-Restposten nach Rabatt zu prüfen.</p>
+        <p class="muted" style="max-width:720px">Entdecke die attraktivsten Rabatte, die unsere Bots bei allen überwachten Händlern finden. Die Bestenliste wird nach jedem Crawl aktualisiert. Lade die Seite neu, um die neuesten Angebote zu sehen und die Top-100-Restposten nach Rabatt zu prüfen.</p>
         <div class="status-banner" id="statusBanner" role="status">
           <span id="statusText">Wir analysieren die neuesten Crawls ...</span>
         </div>

--- a/best-deals-en.html
+++ b/best-deals-en.html
@@ -111,7 +111,7 @@
       <div class="hero">
         <div class="badge">Updated after each crawl</div>
         <h2>Top clearance leaderboard</h2>
-        <p class="muted" style="max-width:720px">Discover the most aggressive discounts detected by our bots across every monitored retailer. The leaderboard refreshes automatically once each crawl ends. Reload the page to see the latest offers and review the top 100 clearance deals ranked by discount rate.</p>
+        <p class="muted" style="max-width:720px">Discover the most aggressive discounts detected by our bots across every monitored retailer. The leaderboard refreshes once each crawl ends. Reload the page to see the latest offers and review the top 100 clearance deals ranked by discount rate.</p>
         <div class="status-banner" id="statusBanner" role="status">
           <span id="statusText">Analysing the latest crawls...</span>
         </div>

--- a/best-deals-it.html
+++ b/best-deals-it.html
@@ -111,7 +111,7 @@
       <div class="hero">
         <div class="badge">Aggiornato dopo ogni crawl</div>
         <h2>Classifica delle migliori liquidazioni</h2>
-        <p class="muted" style="max-width:720px">Scopri gli sconti più aggressivi individuati dai nostri bot in tutti i rivenditori monitorati. La classifica si aggiorna automaticamente al termine di ogni crawl. Ricarica la pagina per vedere le offerte più recenti e rivedere le prime 100 liquidazioni ordinate per tasso di sconto.</p>
+        <p class="muted" style="max-width:720px">Scopri gli sconti più aggressivi individuati dai nostri bot in tutti i rivenditori monitorati. La classifica viene aggiornata al termine di ogni crawl. Ricarica la pagina per vedere le offerte più recenti e rivedere le prime 100 liquidazioni ordinate per tasso di sconto.</p>
         <div class="status-banner" id="statusBanner" role="status">
           <span id="statusText">Analisi degli ultimi crawl in corso...</span>
         </div>

--- a/best-deals.html
+++ b/best-deals.html
@@ -111,7 +111,7 @@
       <div class="hero">
         <div class="badge">Mise à jour après chaque collecte</div>
         <h2>Classement des meilleures liquidations</h2>
-        <p class="muted" style="max-width:720px">Découvrez les rabais les plus agressifs détectés par nos robots sur l'ensemble des détaillants surveillés. Le classement se rafraîchit automatiquement dès que les scrapers terminent leur collecte. Rechargez la page pour voir les dernières offres et consultez le top 100 des meilleures liquidations triées par pourcentage de rabais.</p>
+        <p class="muted" style="max-width:720px">Découvrez les rabais les plus agressifs détectés par nos robots sur l'ensemble des détaillants surveillés. Le classement se rafraîchit dès que les scrapers terminent leur collecte. Rechargez la page pour voir les dernières offres et consultez le top 100 des meilleures liquidations triées par pourcentage de rabais.</p>
         <div class="status-banner" id="statusBanner" role="status">
           <span id="statusText">Analyse des dernières collectes en cours...</span>
         </div>

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -43,19 +43,13 @@ python incoming/walmart_requests_scraper.py --store saint-jerome
 
 Les options (`--store`, `--output-dir`, `--aggregated-path`, etc.) sont identiques à la version Playwright. Ce scraper repose sur la disponibilité du JSON `__NEXT_DATA__` dans la page et peut échouer si Walmart modifie la structure. En contrepartie, il démarre en quelques secondes et nécessite moins de ressources.
 
-## Automatisation
+## Planification manuelle
 
-Une action GitHub (`.github/workflows/walmart-scraper.yml`) planifie l'exécution chaque jour à 21h UTC. Pour l'activer :
-
-1. Ajoutez un secret `WALMART_PROXIES` contenant une liste JSON de proxies résidentiels.
-2. Mettez à jour `incoming/walmart_stores.json` (via `incoming/walmart_stores_raw.tsv`).
-3. Déclenchez manuellement le workflow via l'onglet **Actions** si nécessaire (`Run workflow`).
-
-Chaque exécution met à jour les JSON par magasin dans `data/walmart/` et attache un artefact `liquidations_walmart_qc.json` téléchargeable depuis GitHub Actions.
+Pour exécuter le scraper à intervalles réguliers, créez votre propre planificateur (ex.: cron, tâche planifiée) qui appelle la commande `python incoming/walmart_scraper.py`. Assurez-vous que la variable `WALMART_PROXIES` est définie dans l'environnement d'exécution et que les fichiers de sortie sont synchronisés avec votre environnement de production.
 
 # Canadian Tire Clearance Scraper
 
-Le script `incoming/canadian_tire_scraper.py` automatise la récupération des produits en liquidation publiés par Canadian Tire. Il lit la liste des magasins depuis `data/canadian-tire/stores.json`, génère un fichier JSON par magasin dans `data/canadian-tire/` puis consolide l'ensemble dans un agrégat global.
+Le script `incoming/canadian_tire_scraper.py` gère la récupération des produits en liquidation publiés par Canadian Tire. Il lit la liste des magasins depuis `data/canadian-tire/stores.json`, génère un fichier JSON par magasin dans `data/canadian-tire/` puis consolide l'ensemble dans un agrégat global.
 
 ```bash
 python incoming/canadian_tire_scraper.py --store laval --store saint-jerome

--- a/index-de.html
+++ b/index-de.html
@@ -325,7 +325,7 @@
           <ul>
             <li><span class="value-metric">Über 4&nbsp;500 aktive Angebote</span>, gebündelt in einem einzigen arbitragebereiten Katalog.</li>
             <li><span class="value-metric">97&nbsp;% der Listings validiert</span> – ein Beleg für Datenqualität und verlässliche Amazon-Exporte.</li>
-            <li><span class="value-metric">12 Stunden wöchentlich eingespart</span> dank automatisiertem Sourcing.</li>
+            <li><span class="value-metric">12 Stunden wöchentlich eingespart</span> durch gebündeltes Sourcing.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -334,7 +334,7 @@
           <ul>
             <li><span class="value-metric">2,4&nbsp;Mio. überwachte ASINs</span> auf Amazon.ca, Amazon.com und Amazon EU.</li>
             <li>Durchschnittliche Erkennung von <span class="value-metric">18 Sekunden</span> zwischen einem neuen Rabatt und seiner Prioritätswarnung.</li>
-            <li>KI-Automatisierungen holen in überwachten Szenarien eine <span class="value-metric">median +32&nbsp;% Marge</span> zurück.</li>
+            <li>KI-Insights holen in überwachten Szenarien eine <span class="value-metric">median +32&nbsp;% Marge</span> zurück.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -417,9 +417,9 @@
           <span class="value-icon" aria-hidden="true">🛒</span>
           <h3>Auf Amazon-Händler:innen zugeschnitten</h3>
           <ul>
-            <li>Angeleitetes FBA-Onboarding, automatische Gebührenberechnung und integrierte FBM-Szenarien.</li>
+            <li>Angeleitetes FBA-Onboarding, vereinfachte Gebührenberechnung und integrierte FBM-Szenarien.</li>
             <li>Überwachung mehrerer Lieferanten (Best Buy, Walmart, Canadian Tire u.&nbsp;a.), um die Buy Box zu sichern.</li>
-            <li>Private Community und startklare Automatisierungen, um der Konkurrenz voraus zu sein.</li>
+            <li>Private Community, taktische Workshops und dedizierte Unterstützung, um der Konkurrenz voraus zu sein.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -428,7 +428,7 @@
           <ul>
             <li>Essential-Paket: schneller Zugriff auf Top-Restposten und wöchentliche Alerts.</li>
             <li>Advanced-Paket: Echtzeitwarnungen, Seller-Central-Exports und Teamzusammenarbeit.</li>
-            <li>Premium-Angebot: KI-Analysen, Trendprognosen und unbegrenzte Multichannel-Automatisierungen.</li>
+            <li>Premium-Angebot: KI-Analysen, Trendprognosen und unbegrenzte Multichannel-Betreuung.</li>
           </ul>
         </article>
       </div>
@@ -437,7 +437,7 @@
     <section class="amazon-section" id="amazon-sellers">
       <div>
         <h2>Ein Erlebnis speziell für Amazon-Händler:innen</h2>
-        <p class="amazon-intro">Nutze ein Sourcing-Hub, das für FBA- und FBM-Abläufe entwickelt wurde: Entdecke in Sekunden profitable Restposten, sichere deine Margen und automatisiere Sourcing-Routinen für Amazon.ca und Amazon.com.</p>
+        <p class="amazon-intro">Nutze ein Sourcing-Hub, das für FBA- und FBM-Abläufe entwickelt wurde: Entdecke in Sekunden profitable Restposten, sichere deine Margen und strukturiere Sourcing-Routinen für Amazon.ca und Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
@@ -473,8 +473,8 @@
           <p>Erhalte Zugang zu einer privaten Amazon-Reseller-Lounge, teile Repricing-Strategien und profitiere von community-validierten Produktvergleichen.</p>
         </article>
         <article class="seller-card">
-          <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Startklare Automatisierungen</h3>
+          <div class="seller-icon" aria-hidden="true">🧭</div>
+          <h3>Operatives Coaching</h3>
           <ul class="seller-list">
             <li><span aria-hidden="true">✔</span>Alerts, sobald die Buy Box unter dein Ziel fällt.</li>
             <li><span aria-hidden="true">✔</span>Seller-Central-optimierte Exporte und FBA-Analysetools.</li>
@@ -547,7 +547,7 @@
             <ul>
               <li>Erlebnis für zentrale europäische Märkte lokalisieren.</li>
               <li>Mehrsprachige KI-Empfehlungsengine aktivieren.</li>
-              <li>Preisstrategien mit kontinuierlichem Lernen automatisieren.</li>
+              <li>Preisstrategien mit kontinuierlichem Lernen verfeinern.</li>
             </ul>
           </article>
         </div>

--- a/index-en.html
+++ b/index-en.html
@@ -325,7 +325,7 @@
           <ul>
             <li><span class="value-metric">4,500+ active deals</span> consolidated in a single arbitrage-ready catalogue.</li>
             <li><span class="value-metric">97% of listings validated</span>, proving data quality and reliable Amazon exports.</li>
-            <li><span class="value-metric">12 hours saved</span> per week on average thanks to sourcing automation.</li>
+            <li><span class="value-metric">12 hours saved</span> per week on average by centralising sourcing workflows.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -334,7 +334,7 @@
           <ul>
             <li><span class="value-metric">2.4M ASINs tracked</span> across Amazon.ca, Amazon.com and Amazon EU.</li>
             <li>Average detection of <span class="value-metric">18 seconds</span> between a new discount and its priority alert.</li>
-            <li>AI automations recovering a <span class="value-metric">median +32% margin</span> on monitored scenarios.</li>
+            <li>AI insights recovering a <span class="value-metric">median +32% margin</span> on monitored scenarios.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -417,9 +417,9 @@
           <span class="value-icon" aria-hidden="true">🛒</span>
           <h3>Tailored to Amazon resellers</h3>
           <ul>
-            <li>Guided FBA onboarding, automatic fee calculation and FBM scenarios built in.</li>
+            <li>Guided FBA onboarding, streamlined fee calculation and FBM scenarios built in.</li>
             <li>Multi-supplier monitoring (Best Buy, Walmart, Canadian Tire, etc.) to secure the Buy Box.</li>
-            <li>Private community and ready-to-launch automations to stay ahead.</li>
+            <li>Private community, tactical workshops and dedicated assistance to stay ahead.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -428,7 +428,7 @@
           <ul>
             <li>Essential plan: fast access to top clearance deals and weekly alerts.</li>
             <li>Advanced plan: real-time alerts, Seller Central exports and team collaboration.</li>
-            <li>Premium offer: AI analysis, trend forecasts and unlimited multichannel automations.</li>
+            <li>Premium offer: AI analysis, trend forecasts and unlimited multichannel guidance.</li>
           </ul>
         </article>
       </div>
@@ -437,7 +437,7 @@
     <section class="amazon-section" id="amazon-sellers">
       <div>
         <h2>An experience designed for Amazon resellers</h2>
-        <p class="amazon-intro">Leverage a sourcing hub built for FBA and FBM operations: detect profitable clearance deals in seconds, protect your margins and automate sourcing routines for Amazon.ca and Amazon.com.</p>
+        <p class="amazon-intro">Leverage a sourcing hub built for FBA and FBM operations: detect profitable clearance deals in seconds, protect your margins and structure sourcing routines for Amazon.ca and Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
@@ -473,8 +473,8 @@
           <p>Access a private Amazon reseller lounge, share repricing strategies and benefit from community-validated product comparisons.</p>
         </article>
         <article class="seller-card">
-          <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Ready-to-launch automations</h3>
+          <div class="seller-icon" aria-hidden="true">🧭</div>
+          <h3>Operational coaching</h3>
           <ul class="seller-list">
             <li><span aria-hidden="true">✔</span>Alerts when the Buy Box drops below your target.</li>
             <li><span aria-hidden="true">✔</span>Seller Central-friendly exports and FBA analysis tools.</li>
@@ -547,7 +547,7 @@
             <ul>
               <li>Localise the experience for key European markets.</li>
               <li>Activate a multilingual AI recommendation engine.</li>
-              <li>Automate pricing strategies with continuous learning.</li>
+              <li>Refine pricing strategies with continuous learning.</li>
             </ul>
           </article>
         </div>

--- a/index-es.html
+++ b/index-es.html
@@ -325,7 +325,7 @@
           <ul>
             <li><span class="value-metric">Más de 4&nbsp;500 ofertas activas</span> consolidadas en un único catálogo listo para el arbitraje.</li>
             <li><span class="value-metric">97&nbsp;% de los listings validados</span>, demostrando la calidad de los datos y exportaciones fiables a Amazon.</li>
-            <li><span class="value-metric">12 horas ahorradas</span> por semana en promedio gracias a la automatización del abastecimiento.</li>
+            <li><span class="value-metric">12 horas ahorradas</span> por semana en promedio al centralizar el abastecimiento.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -334,7 +334,7 @@
           <ul>
             <li><span class="value-metric">2,4&nbsp;M de ASIN monitorizados</span> en Amazon.ca, Amazon.com y Amazon EU.</li>
             <li>Detección promedio de <span class="value-metric">18 segundos</span> entre un nuevo descuento y su alerta prioritaria.</li>
-            <li>Automatizaciones de IA que recuperan una <span class="value-metric">margen mediana de +32&nbsp;%</span> en los escenarios monitorizados.</li>
+            <li>Insights de IA que recuperan una <span class="value-metric">margen mediana de +32&nbsp;%</span> en los escenarios monitorizados.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -417,9 +417,9 @@
           <span class="value-icon" aria-hidden="true">🛒</span>
           <h3>Diseñado para revendedores de Amazon</h3>
           <ul>
-            <li>Onboarding guiado a FBA, cálculo automático de tarifas y escenarios FBM integrados.</li>
+            <li>Onboarding guiado a FBA, cálculo de tarifas simplificado y escenarios FBM integrados.</li>
             <li>Supervisión multiproveedor (Best Buy, Walmart, Canadian Tire, etc.) para asegurar la Buy Box.</li>
-            <li>Comunidad privada y automatizaciones listas para lanzar que mantienen la ventaja competitiva.</li>
+            <li>Comunidad privada, talleres tácticos y asistencia dedicada que mantienen la ventaja competitiva.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -428,7 +428,7 @@
           <ul>
             <li>Plan Essential: acceso rápido a las mejores liquidaciones y alertas semanales.</li>
             <li>Plan Advanced: alertas en tiempo real, exportaciones a Seller Central y colaboración entre equipos.</li>
-            <li>Oferta Premium: análisis con IA, pronósticos de tendencias y automatizaciones multicanal ilimitadas.</li>
+            <li>Oferta Premium: análisis con IA, pronósticos de tendencias y acompañamiento multicanal ilimitado.</li>
           </ul>
         </article>
       </div>
@@ -437,7 +437,7 @@
     <section class="amazon-section" id="amazon-sellers">
       <div>
         <h2>Una experiencia diseñada para revendedores de Amazon</h2>
-        <p class="amazon-intro">Aprovecha un hub de abastecimiento creado para operaciones FBA y FBM: detecta liquidaciones rentables en segundos, protege tus márgenes y automatiza las rutinas de sourcing para Amazon.ca y Amazon.com.</p>
+        <p class="amazon-intro">Aprovecha un hub de abastecimiento creado para operaciones FBA y FBM: detecta liquidaciones rentables en segundos, protege tus márgenes y estructura las rutinas de sourcing para Amazon.ca y Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
@@ -473,8 +473,8 @@
           <p>Accede a un lounge privado para revendedores de Amazon, comparte estrategias de repricing y aprovecha comparativas validadas por la comunidad.</p>
         </article>
         <article class="seller-card">
-          <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Automatizaciones listas para lanzar</h3>
+          <div class="seller-icon" aria-hidden="true">🧭</div>
+          <h3>Acompañamiento operativo</h3>
           <ul class="seller-list">
             <li><span aria-hidden="true">✔</span>Alertas cuando la Buy Box cae por debajo de tu objetivo.</li>
             <li><span aria-hidden="true">✔</span>Exportaciones compatibles con Seller Central y herramientas de análisis FBA.</li>
@@ -547,7 +547,7 @@
             <ul>
               <li>Localizar la experiencia para los principales mercados europeos.</li>
               <li>Activar un motor de recomendaciones de IA multilingüe.</li>
-              <li>Automatizar las estrategias de precios con aprendizaje continuo.</li>
+              <li>Perfeccionar las estrategias de precios con aprendizaje continuo.</li>
             </ul>
           </article>
         </div>

--- a/index-it.html
+++ b/index-it.html
@@ -325,7 +325,7 @@
           <ul>
             <li><span class="value-metric">Oltre 4&nbsp;500 offerte attive</span> consolidate in un unico catalogo pronto per l'arbitraggio.</li>
             <li><span class="value-metric">97&nbsp;% dei listing convalidato</span>, a prova della qualità dei dati e di esportazioni affidabili verso Amazon.</li>
-            <li><span class="value-metric">12 ore risparmiate</span> a settimana in media grazie all'automazione del sourcing.</li>
+            <li><span class="value-metric">12 ore risparmiate</span> a settimana in media grazie alla centralizzazione del sourcing.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -334,7 +334,7 @@
           <ul>
             <li><span class="value-metric">2,4&nbsp;M di ASIN monitorati</span> su Amazon.ca, Amazon.com e Amazon EU.</li>
             <li>Rilevamento medio di <span class="value-metric">18 secondi</span> tra un nuovo sconto e il relativo avviso prioritario.</li>
-            <li>Automazioni IA che recuperano un <span class="value-metric">margine mediano di +32&nbsp;%</span> negli scenari monitorati.</li>
+            <li>Approfondimenti IA che recuperano un <span class="value-metric">margine mediano di +32&nbsp;%</span> negli scenari monitorati.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -417,9 +417,9 @@
           <span class="value-icon" aria-hidden="true">🛒</span>
           <h3>Su misura per i reseller Amazon</h3>
           <ul>
-            <li>Onboarding FBA guidato, calcolo automatico delle commissioni e scenari FBM integrati.</li>
+            <li>Onboarding FBA guidato, calcolo delle commissioni semplificato e scenari FBM integrati.</li>
             <li>Monitoraggio multi-fornitore (Best Buy, Walmart, Canadian Tire, ecc.) per assicurarsi la Buy Box.</li>
-            <li>Community privata e automazioni pronte all'uso per restare avanti.</li>
+            <li>Community privata, workshop tattici e assistenza dedicata per restare avanti.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -428,7 +428,7 @@
           <ul>
             <li>Piano Essential: accesso rapido alle principali offerte in liquidazione e avvisi settimanali.</li>
             <li>Piano Advanced: avvisi in tempo reale, esportazioni Seller Central e collaborazione del team.</li>
-            <li>Offerta Premium: analisi IA, previsioni dei trend e automazioni multicanale illimitate.</li>
+            <li>Offerta Premium: analisi IA, previsioni dei trend e accompagnamento multicanale illimitato.</li>
           </ul>
         </article>
       </div>
@@ -437,7 +437,7 @@
     <section class="amazon-section" id="amazon-sellers">
       <div>
         <h2>Un'esperienza pensata per i reseller Amazon</h2>
-        <p class="amazon-intro">Sfrutta un hub di sourcing creato per le operazioni FBA e FBM: rileva in pochi secondi le offerte in liquidazione redditizie, proteggi i margini e automatizza le routine di sourcing per Amazon.ca e Amazon.com.</p>
+        <p class="amazon-intro">Sfrutta un hub di sourcing creato per le operazioni FBA e FBM: rileva in pochi secondi le offerte in liquidazione redditizie, proteggi i margini e struttura le routine di sourcing per Amazon.ca e Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
@@ -473,8 +473,8 @@
           <p>Accedi a una lounge privata per reseller Amazon, condividi strategie di repricing e approfitta di comparazioni prodotto validate dalla community.</p>
         </article>
         <article class="seller-card">
-          <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Automazioni pronte al lancio</h3>
+          <div class="seller-icon" aria-hidden="true">🧭</div>
+          <h3>Coaching operativo</h3>
           <ul class="seller-list">
             <li><span aria-hidden="true">✔</span>Avvisi quando la Buy Box scende sotto il tuo obiettivo.</li>
             <li><span aria-hidden="true">✔</span>Esportazioni compatibili con Seller Central e strumenti di analisi FBA.</li>
@@ -547,7 +547,7 @@
             <ul>
               <li>Localizzare l'esperienza per i principali mercati europei.</li>
               <li>Attivare un motore di raccomandazioni IA multilingue.</li>
-              <li>Automatizzare le strategie di pricing con apprendimento continuo.</li>
+              <li>Affinare le strategie di pricing con apprendimento continuo.</li>
             </ul>
           </article>
         </div>

--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
           <ul>
             <li><span class="value-metric">+4&nbsp;500 rabais actifs</span> consolidés dans un catalogue unique prêt pour l'arbitrage.</li>
             <li><span class="value-metric">97&nbsp;% de fiches validées</span> prouvant la qualité des données et la fiabilité des exports Amazon.</li>
-            <li><span class="value-metric">12&nbsp;h économisées</span> par semaine en moyenne grâce à l'automatisation du sourcing.</li>
+            <li><span class="value-metric">12&nbsp;h économisées</span> par semaine en moyenne en centralisant les opérations de sourcing.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -334,7 +334,7 @@
           <ul>
             <li><span class="value-metric">2,4&nbsp;M d'ASIN</span> suivis pour Amazon.ca, Amazon.com et l'Europe.</li>
             <li>Détection moyenne de <span class="value-metric">18&nbsp;secondes</span> entre un rabais et son alerte prioritaire.</li>
-            <li>Automations IA qui récupèrent une <span class="value-metric">marge médiane de +32&nbsp;%</span> sur les scénarios surveillés.</li>
+            <li>Analyses IA qui récupèrent une <span class="value-metric">marge médiane de +32&nbsp;%</span> sur les scénarios surveillés.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -417,9 +417,9 @@
           <span class="value-icon" aria-hidden="true">🛒</span>
           <h3>Offre adaptée aux revendeurs Amazon</h3>
           <ul>
-            <li>Onboarding FBA guidé, calcul automatique des frais et scénarios FBM intégrés.</li>
+            <li>Onboarding FBA guidé, calcul des frais simplifié et scénarios FBM intégrés.</li>
             <li>Veille multi-fournisseurs (Best Buy, Walmart, Canadian Tire, etc.) pour sécuriser la Buy Box.</li>
-            <li>Communauté privée et automations prêtes à lancer pour garder une longueur d'avance.</li>
+            <li>Communauté privée, ateliers tactiques et assistance dédiée pour garder une longueur d'avance.</li>
           </ul>
         </article>
         <article class="value-card">
@@ -428,7 +428,7 @@
           <ul>
             <li>Forfait Essentiel : accès rapide aux meilleures liquidations et alertes hebdomadaires.</li>
             <li>Forfait Avancé : alertes en temps réel, exports Seller Central et travail d'équipe.</li>
-            <li>Offre Premium : analyse IA, prévisions de tendances et automatisations multicanal illimitées.</li>
+            <li>Offre Premium : analyse IA, prévisions de tendances et accompagnement multicanal illimité.</li>
           </ul>
         </article>
       </div>
@@ -437,7 +437,7 @@
     <section class="amazon-section" id="amazon-sellers">
       <div>
         <h2>Une expérience pensée pour les revendeurs Amazon</h2>
-        <p class="amazon-intro">Profitez d'un hub d'approvisionnement bâti pour les opérations FBA et FBM&nbsp;: détectez les liquidations rentables en quelques secondes, sécurisez vos marges et automatisez vos routines de sourcing pour Amazon.ca et Amazon.com.</p>
+        <p class="amazon-intro">Profitez d'un hub d'approvisionnement bâti pour les opérations FBA et FBM&nbsp;: détectez les liquidations rentables en quelques secondes, sécurisez vos marges et structurez vos routines de sourcing pour Amazon.ca et Amazon.com.</p>
       </div>
       <div class="seller-metrics">
         <div class="seller-metric">
@@ -473,8 +473,8 @@
           <p>Accédez à un salon privé de revendeurs Amazon, partagez vos stratégies de repricing et bénéficiez de comparatifs de produits validés par la communauté.</p>
         </article>
         <article class="seller-card">
-          <div class="seller-icon" aria-hidden="true">⚙️</div>
-          <h3>Automations prêtes à lancer</h3>
+          <div class="seller-icon" aria-hidden="true">🧭</div>
+          <h3>Coaching opérationnel</h3>
           <ul class="seller-list">
             <li><span aria-hidden="true">✔</span>Alertes quand la Buy Box chute sous votre cible.</li>
             <li><span aria-hidden="true">✔</span>Exports compatibles Seller Central et outils d'analyse FBA.</li>
@@ -547,7 +547,7 @@
             <ul>
               <li>Localiser l'expérience pour les principaux marchés européens.</li>
               <li>Activer un moteur de recommandations IA multilingue.</li>
-              <li>Automatiser les stratégies de prix grâce à l'apprentissage continu.</li>
+              <li>Affiner les stratégies de prix grâce à l'apprentissage continu.</li>
             </ul>
           </article>
         </div>

--- a/pricing-de.html
+++ b/pricing-de.html
@@ -116,7 +116,7 @@
     </section>
     <section class="section value-section">
       <h3 style="margin:0">Eine geplante Werteskala</h3>
-      <p class="muted" style="margin:0;max-width:680px">Jede Preisstufe schaltet konkrete Funktionen frei, die das Wachstum deiner Amazon-Aktivitäten unterstützen – vom manuellen Sourcing bis zur vollständig KI-gestützten Automatisierung.</p>
+      <p class="muted" style="margin:0;max-width:680px">Jede Preisstufe schaltet konkrete Funktionen frei, die das Wachstum deiner Amazon-Aktivitäten unterstützen – vom manuellen Sourcing bis zur vollständig KI-gestützten Orchestrierung.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
@@ -136,7 +136,7 @@
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>KI-gestützte Automatisierung</h4>
+          <h4>Fortgeschrittene KI-Optimierung</h4>
           <ul>
             <li>Das Premium-Paket aktiviert KI-Szenarien, Trendprognosen und unbegrenzte Multichannel-Alerts.</li>
             <li>Fortgeschrittene FBA-Simulation, um Margen zu sichern und Nachschub zu planen.</li>

--- a/pricing-en.html
+++ b/pricing-en.html
@@ -116,7 +116,7 @@
     </section>
     <section class="section value-section">
       <h3 style="margin:0">A planned value ladder</h3>
-      <p class="muted" style="margin:0;max-width:680px">Each pricing tier unlocks concrete capabilities to support the growth of your Amazon operations, from manual sourcing to full AI-driven automation.</p>
+      <p class="muted" style="margin:0;max-width:680px">Each pricing tier unlocks concrete capabilities to support the growth of your Amazon operations, from manual sourcing to full AI-driven orchestration.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
@@ -136,7 +136,7 @@
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>AI-driven automation</h4>
+          <h4>Advanced AI optimisation</h4>
           <ul>
             <li>The Premium plan activates AI scenarios, trend forecasts and unlimited multichannel alerts.</li>
             <li>Advanced FBA simulation to secure margins and plan replenishment.</li>

--- a/pricing-es.html
+++ b/pricing-es.html
@@ -116,7 +116,7 @@
     </section>
     <section class="section value-section">
       <h3 style="margin:0">Una escalera de valor planificada</h3>
-      <p class="muted" style="margin:0;max-width:680px">Cada nivel desbloquea capacidades concretas para impulsar el crecimiento de tus operaciones en Amazon, desde el sourcing manual hasta la automatización completa impulsada por IA.</p>
+      <p class="muted" style="margin:0;max-width:680px">Cada nivel desbloquea capacidades concretas para impulsar el crecimiento de tus operaciones en Amazon, desde el sourcing manual hasta una orquestación completa impulsada por IA.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
@@ -136,7 +136,7 @@
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>Automatización impulsada por IA</h4>
+          <h4>Optimización avanzada con IA</h4>
           <ul>
             <li>El plan Premium activa escenarios de IA, pronósticos de tendencias y alertas multicanal ilimitadas.</li>
             <li>Simulación FBA avanzada para asegurar márgenes y planificar la reposición.</li>

--- a/pricing-it.html
+++ b/pricing-it.html
@@ -116,7 +116,7 @@
     </section>
     <section class="section value-section">
       <h3 style="margin:0">Una scala di valore pianificata</h3>
-      <p class="muted" style="margin:0;max-width:680px">Ogni fascia di prezzo sblocca funzionalità concrete per sostenere la crescita delle tue operazioni Amazon, dal sourcing manuale fino all'automazione completa guidata dall'IA.</p>
+      <p class="muted" style="margin:0;max-width:680px">Ogni fascia di prezzo sblocca funzionalità concrete per sostenere la crescita delle tue operazioni Amazon, dal sourcing manuale fino a un'orchestrazione completa guidata dall'IA.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
@@ -136,7 +136,7 @@
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>Automazione guidata dall'IA</h4>
+          <h4>Ottimizzazione IA avanzata</h4>
           <ul>
             <li>Il piano Premium attiva scenari IA, previsioni dei trend e avvisi multicanale illimitati.</li>
             <li>Simulazione FBA avanzata per proteggere i margini e pianificare i riordini.</li>

--- a/pricing.html
+++ b/pricing.html
@@ -116,7 +116,7 @@
     </section>
     <section class="section value-section">
       <h3 style="margin:0">Une montée en valeur planifiée</h3>
-      <p class="muted" style="margin:0;max-width:680px">Chaque palier tarifaire débloque des capacités concrètes supplémentaires pour soutenir la croissance des opérations Amazon, de la prospection manuelle à l'automatisation complète pilotée par l'IA.</p>
+      <p class="muted" style="margin:0;max-width:680px">Chaque palier tarifaire débloque des capacités concrètes supplémentaires pour soutenir la croissance des opérations Amazon, de la prospection manuelle à une orchestration complète pilotée par l'IA.</p>
       <div class="value-grid">
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🧭</span>
@@ -136,7 +136,7 @@
         </article>
         <article class="value-card">
           <span class="value-icon" aria-hidden="true">🤖</span>
-          <h4>Automatisation pilotée par l'IA</h4>
+          <h4>Optimisation IA avancée</h4>
           <ul>
             <li>Le plan Premium active les scénarios IA, les prévisions de tendances et les alertes multicanal illimitées.</li>
             <li>Simulation FBA avancée pour sécuriser la marge et planifier les réapprovisionnements.</li>

--- a/roadmap-de.html
+++ b/roadmap-de.html
@@ -97,7 +97,7 @@
             <ul>
               <li>Erlebnis für zentrale europäische Märkte lokalisieren.</li>
               <li>Mehrsprachige KI-Empfehlungsengine aktivieren.</li>
-              <li>Preisstrategien mit kontinuierlichem Lernen automatisieren.</li>
+              <li>Preisstrategien mit kontinuierlichem Lernen verfeinern.</li>
             </ul>
           </article>
         </div>

--- a/roadmap-en.html
+++ b/roadmap-en.html
@@ -97,7 +97,7 @@
             <ul>
               <li>Localise the experience for key European markets.</li>
               <li>Activate a multilingual AI recommendation engine.</li>
-              <li>Automate pricing strategies with continuous learning.</li>
+              <li>Refine pricing strategies with continuous learning.</li>
             </ul>
           </article>
         </div>

--- a/roadmap-es.html
+++ b/roadmap-es.html
@@ -97,7 +97,7 @@
             <ul>
               <li>Localizar la experiencia para los principales mercados europeos.</li>
               <li>Activar un motor de recomendaciones de IA multilingüe.</li>
-              <li>Automatizar las estrategias de precios con aprendizaje continuo.</li>
+              <li>Perfeccionar las estrategias de precios con aprendizaje continuo.</li>
             </ul>
           </article>
         </div>

--- a/roadmap-it.html
+++ b/roadmap-it.html
@@ -97,7 +97,7 @@
             <ul>
               <li>Localizzare l'esperienza per i principali mercati europei.</li>
               <li>Attivare un motore di raccomandazioni IA multilingue.</li>
-              <li>Automatizzare le strategie di pricing con apprendimento continuo.</li>
+              <li>Affinare le strategie di pricing con apprendimento continuo.</li>
             </ul>
           </article>
         </div>

--- a/roadmap.html
+++ b/roadmap.html
@@ -97,7 +97,7 @@
             <ul>
               <li>Localiser l'expérience pour les principaux marchés européens.</li>
               <li>Activer un moteur de recommandations IA multilingue.</li>
-              <li>Automatiser les stratégies de prix grâce à l'apprentissage continu.</li>
+              <li>Affiner les stratégies de prix grâce à l'apprentissage continu.</li>
             </ul>
           </article>
         </div>


### PR DESCRIPTION
## Summary
- remove mentions of automation from homepage, pricing, roadmap, and best-deals pages across all locales
- update documentation to describe manual scraper execution instead of automated workflows
- adjust incoming scraper README to focus on manual scheduling guidance

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e5b7e56658832eababc7d6b7ee1658