### PR TITLE
Add Best Buy clearance scraper

### DIFF
--- a/data/best-buy/README.md
+++ b/data/best-buy/README.md
@@ -1,4 +1,27 @@
 # Données Best Buy
 
-Ce dossier reçoit `liquidations.json`, que vous pouvez mettre à jour manuellement
-selon vos besoins.
+Ce dossier reçoit les fichiers JSON produits par le script `incoming/best_buy_scraper.py`.
+
+## Fichiers
+
+- `stores.json` – Liste des magasins québécois (identifiant Best Buy, ville, adresse).
+- `liquidations.json` – Agrégat global des aubaines en liquidation pour tous les magasins traités.
+- `<slug>.json` – Fichier par magasin généré lors d'une exécution du scraper.
+
+## Mise à jour
+
+```bash
+python incoming/best_buy_scraper.py --language fr
+```
+
+Vous pouvez cibler un ou plusieurs magasins précis :
+
+```bash
+python incoming/best_buy_scraper.py --store laval --store "Trois-Rivieres"
+```
+
+Le script accepte également `--language en`, `--output-dir`, `--aggregated-path`,
+`--max-retries`, `--timeout`, `--delay` et `--page-size`.
+
+Les fichiers générés remplacent ceux existants; assurez-vous d'effectuer un commit
+des résultats avant de pousser vers GitHub.

--- a/data/best-buy/stores.json
+++ b/data/best-buy/stores.json
@@ -1,0 +1,178 @@
+[
+  {
+    "label": "St. Jerome",
+    "slug": "st-jerome-658",
+    "city": "Saint-Jerome",
+    "address": "1040 Boul. du Grand-Heron, Saint-Jerome, QC",
+    "storeNumber": "658",
+    "hasData": false
+  },
+  {
+    "label": "Rosemere",
+    "slug": "rosemere-978",
+    "city": "Rosemere",
+    "address": "401 Boul. Labelle, Unit M-20, Rosemere, QC",
+    "storeNumber": "978",
+    "hasData": false
+  },
+  {
+    "label": "Mascouche",
+    "slug": "mascouche-663",
+    "city": "Mascouche",
+    "address": "113 Monte Masson, Bldg. C Unit 2, Mascouche, QC",
+    "storeNumber": "663",
+    "hasData": false
+  },
+  {
+    "label": "Laval",
+    "slug": "laval-968",
+    "city": "Laval",
+    "address": "1560 Boul. Le Corbusier, Laval, QC",
+    "storeNumber": "968",
+    "hasData": false
+  },
+  {
+    "label": "Pointe Claire",
+    "slug": "pointe-claire-970",
+    "city": "Pointe-Claire",
+    "address": "6815 Autoroute Transcanadienne, Local #Y009, Pointe-Claire, QC",
+    "storeNumber": "970",
+    "hasData": false
+  },
+  {
+    "label": "Marche Central",
+    "slug": "marche-central-962",
+    "city": "Montreal",
+    "address": "8871 Boul de L'acadie, Montreal, QC",
+    "storeNumber": "962",
+    "hasData": false
+  },
+  {
+    "label": "Anjou",
+    "slug": "anjou-84",
+    "city": "Anjou",
+    "address": "7400 Boul. des Roseraies, Anjou, QC",
+    "storeNumber": "84",
+    "hasData": false
+  },
+  {
+    "label": "Vaudreuil",
+    "slug": "vaudreuil-674",
+    "city": "Vaudreuil-Dorion",
+    "address": "3090 Boul. de la Gare, Vaudreuil-Dorion, QC",
+    "storeNumber": "674",
+    "hasData": false
+  },
+  {
+    "label": "Centreville",
+    "slug": "centreville-651",
+    "city": "Montreal",
+    "address": "470 Rue Ste. Catherine O, Montreal, QC",
+    "storeNumber": "651",
+    "hasData": false
+  },
+  {
+    "label": "LaSalle",
+    "slug": "lasalle-967",
+    "city": "LaSalle",
+    "address": "7077 Boul. Newman, LaSalle, QC",
+    "storeNumber": "967",
+    "hasData": false
+  },
+  {
+    "label": "Taschereau",
+    "slug": "taschereau-82",
+    "city": "Greenfield Park",
+    "address": "1800 Rue Auguste, Greenfield Park, QC",
+    "storeNumber": "82",
+    "hasData": false
+  },
+  {
+    "label": "Brossard",
+    "slug": "brossard-969",
+    "city": "Brossard",
+    "address": "8480 Boul. Leduc, Unit 100, Brossard, QC",
+    "storeNumber": "969",
+    "hasData": false
+  },
+  {
+    "label": "St. Bruno",
+    "slug": "st-bruno-971",
+    "city": "Saint-Bruno",
+    "address": "1235 Boul. des Promenades, Saint-Bruno, QC",
+    "storeNumber": "971",
+    "hasData": false
+  },
+  {
+    "label": "Saint Jean",
+    "slug": "saint-jean-681",
+    "city": "Saint-Jean-sur-Richelieu",
+    "address": "600 Rue Pierre-Caisse, Unit 4000, Saint-Jean-sur-Richelieu, QC",
+    "storeNumber": "681",
+    "hasData": false
+  },
+  {
+    "label": "Granby",
+    "slug": "granby-673",
+    "city": "Granby",
+    "address": "90 Rue Simonds N, Granby, QC",
+    "storeNumber": "673",
+    "hasData": false
+  },
+  {
+    "label": "Drummondville",
+    "slug": "drummondville-680",
+    "city": "Drummondville",
+    "address": "850 Rue Hains, Drummondville, QC",
+    "storeNumber": "680",
+    "hasData": false
+  },
+  {
+    "label": "Trois-Rivieres",
+    "slug": "trois-rivieres-668",
+    "city": "Trois-Rivieres",
+    "address": "4520 Boul. des Recollets, Unit 900A, Trois-Rivieres, QC",
+    "storeNumber": "668",
+    "hasData": false
+  },
+  {
+    "label": "Gatineau",
+    "slug": "gatineau-972",
+    "city": "Gatineau",
+    "address": "920 Maloney Blvd. W, Gatineau, QC",
+    "storeNumber": "972",
+    "hasData": false
+  },
+  {
+    "label": "Sherbrooke",
+    "slug": "sherbrooke-659",
+    "city": "Sherbrooke",
+    "address": "3450 Boul. de Portland, Sherbrooke, QC",
+    "storeNumber": "659",
+    "hasData": false
+  },
+  {
+    "label": "Place Laurier",
+    "slug": "place-laurier-906",
+    "city": "Quebec",
+    "address": "2700 Boul. Laurier, Unit 2290, Quebec, QC",
+    "storeNumber": "906",
+    "hasData": false
+  },
+  {
+    "label": "La Capitale",
+    "slug": "la-capitale-907",
+    "city": "Quebec",
+    "address": "5401 Boul. des Galeries, Quebec, QC",
+    "storeNumber": "907",
+    "hasData": false
+  },
+  {
+    "label": "Chicoutimi",
+    "slug": "chicoutimi-653",
+    "city": "Chicoutimi",
+    "address": "1401 Boul. Talbot, Chicoutimi, QC",
+    "storeNumber": "653",
+    "hasData": false
+  }
+]

--- a/incoming/README.md
+++ b/incoming/README.md
@@ -66,3 +66,24 @@ Options principales :
 | `--max-retries`, `--timeout`, `--delay` | Ajustent la tolérance réseau. |
 
 Chaque exécution sauvegarde les aubaines dans `data/canadian-tire/<ville>.json` et regroupe l'ensemble dans `liquidations_canadian_tire_qc.json`.
+
+# Best Buy Clearance Scraper
+
+Le script `incoming/best_buy_scraper.py` automatise la récupération des offres en liquidation affichées dans les magasins Best Buy du Québec. Il produit un fichier JSON par magasin (dossier `data/best-buy/`) et un agrégat global (`liquidations.json`).
+
+```bash
+python incoming/best_buy_scraper.py --language fr
+```
+
+Options principales :
+
+| Option | Description |
+| --- | --- |
+| `--store laval` | Limite l'extraction à un magasin (ville, label, slug ou numéro). |
+| `--language en` | Retourne les données en anglais (`fr` par défaut). |
+| `--output-dir ./sorties` | Change le dossier cible pour les JSON individuels. |
+| `--aggregated-path ./sorties/liquidations.json` | Positionne l'agrégat global. |
+| `--page-size 200` | Ajuste le nombre de produits chargés par requête. |
+| `--max-retries`, `--timeout`, `--delay` | Affinent la résilience réseau. |
+
+⚠️ L'API Best Buy applique des mécanismes anti-robot. En cas d'erreur 403, augmentez les délais (`--delay 2 5`) et réduisez la fréquence d'exécution.

--- a/incoming/best_buy_scraper.py
+++ b/incoming/best_buy_scraper.py
@@ -1,0 +1,493 @@
+"""Scraper for Best Buy Canada in-store clearance offers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+from urllib.parse import urljoin
+
+import requests
+
+BASE_DOMAIN = "https://www.bestbuy.ca"
+CLEARANCE_ENDPOINT = f"{BASE_DOMAIN}/api/offers/v1/page/clearance"
+DEFAULT_LANGUAGE = "fr"
+LANGUAGE_ALIASES: Dict[str, str] = {
+    "fr": "fr-CA",
+    "en": "en-CA",
+}
+DEFAULT_TIMEOUT = 20
+DEFAULT_MAX_RETRIES = 6
+DEFAULT_DELAY_RANGE: Tuple[float, float] = (1.0, 2.5)
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_OUTPUT_DIR = Path("data/best-buy")
+DEFAULT_AGGREGATED_FILENAME = "liquidations.json"
+STORES_JSON = Path("data/best-buy/stores.json")
+
+USER_AGENTS: Tuple[str, ...] = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+    "(KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+)
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def slugify(value: str) -> str:
+    import re
+    import unicodedata
+
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = "".join(ch for ch in normalized if not unicodedata.combining(ch))
+    ascii_only = ascii_only.lower()
+    ascii_only = re.sub(r"[^a-z0-9]+", "-", ascii_only).strip("-")
+    return ascii_only or "store"
+
+
+def coerce_price(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        value = value.strip().replace("$", "").replace(",", "")
+        if not value:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def normalize_token(value: str) -> Set[str]:
+    token = slugify(value)
+    variants = {token}
+    variants.add(token.replace("-", ""))
+    variants.add(token.replace(" ", ""))
+    return {item for item in variants if item}
+
+
+def build_headers(language: str) -> Dict[str, str]:
+    lang_header = LANGUAGE_ALIASES.get(language, language)
+    return {
+        "User-Agent": random.choice(USER_AGENTS),
+        "Accept": "application/json",
+        "Accept-Language": f"{lang_header},fr;q=0.9,en;q=0.8",
+        "Cache-Control": "no-cache",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Store:
+    label: str
+    slug: str
+    city: str
+    address: str
+    store_number: str
+
+    def normalized_city(self) -> str:
+        base = (self.city or "").strip()
+        replacements = {
+            "St.": "Saint",
+            "Ste.": "Sainte",
+            "St ": "Saint ",
+            "Ste ": "Sainte ",
+            "St-": "Saint-",
+            "Ste-": "Sainte-",
+        }
+        for needle, replacement in replacements.items():
+            base = base.replace(needle, replacement)
+        return base or self.label
+
+    def output_stem(self) -> str:
+        candidates = [self.label, self.city, self.slug]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            slug = slugify(candidate)
+            if slug:
+                return slug
+        return slugify(self.store_number or "store")
+
+    def matches_filters(self, filters: Set[str]) -> bool:
+        if not filters:
+            return True
+        tokens: Set[str] = set()
+        for candidate in (self.label, self.slug, self.city, self.normalized_city(), self.store_number):
+            if candidate:
+                tokens.update(normalize_token(str(candidate)))
+        return any(token in filters for token in tokens)
+
+
+@dataclass(slots=True)
+class Deal:
+    title: str
+    price: float
+    sale_price: float
+    url: str
+    image: Optional[str]
+    sku: Optional[str]
+
+    def to_payload(self, store: Store) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "title": self.title,
+            "image": self.image or "",
+            "price": round(self.price, 2),
+            "salePrice": round(self.sale_price, 2),
+            "store": "Best Buy",
+            "city": store.normalized_city(),
+            "url": self.url,
+        }
+        if self.sku:
+            payload["sku"] = self.sku
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Store loading & filtering
+# ---------------------------------------------------------------------------
+
+
+def load_stores(path: Path = STORES_JSON) -> List[Store]:
+    if not path.exists():
+        raise FileNotFoundError(f"Stores manifest not found: {path}")
+
+    with path.open("r", encoding="utf-8") as handle:
+        raw: Sequence[Dict[str, Any]] = json.load(handle)
+
+    stores: List[Store] = []
+    for entry in raw:
+        label = str(entry.get("label") or "").strip()
+        slug = str(entry.get("slug") or "").strip()
+        city = str(entry.get("city") or "").strip()
+        address = str(entry.get("address") or "").strip()
+        store_number = str(entry.get("storeNumber") or entry.get("store_number") or "").strip()
+        if not store_number:
+            continue
+        stores.append(Store(label=label, slug=slug, city=city, address=address, store_number=store_number))
+    return stores
+
+
+# ---------------------------------------------------------------------------
+# Networking helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_json(
+    params: Dict[str, Any],
+    *,
+    max_retries: int,
+    timeout: int,
+    delay_range: Tuple[float, float],
+    language: str,
+) -> Dict[str, Any]:
+    last_error: Optional[Exception] = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.get(
+                CLEARANCE_ENDPOINT,
+                params=params,
+                headers=build_headers(language),
+                timeout=timeout,
+            )
+            if response.status_code == 404:
+                return {}
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            if attempt >= max_retries:
+                break
+            delay = random.uniform(*delay_range)
+            time.sleep(delay)
+    if last_error:
+        raise last_error
+    return {}
+
+
+def iter_products(
+    store: Store,
+    *,
+    language: str,
+    max_retries: int,
+    timeout: int,
+    delay_range: Tuple[float, float],
+    page_size: int,
+) -> Iterator[Dict[str, Any]]:
+    lang_code = LANGUAGE_ALIASES.get(language, language)
+    page = 1
+    total_pages: Optional[int] = None
+
+    while total_pages is None or page <= total_pages:
+        params = {
+            "storeId": store.store_number,
+            "page": page,
+            "pageSize": page_size,
+            "lang": lang_code,
+            "include": "facets,attributes,availability,offers",
+        }
+        payload = fetch_json(
+            params,
+            max_retries=max_retries,
+            timeout=timeout,
+            delay_range=delay_range,
+            language=language,
+        )
+        results = payload.get("results") if isinstance(payload, dict) else None
+        if not results:
+            break
+        products = results.get("products") or []
+        if not products:
+            break
+        for product in products:
+            if isinstance(product, dict):
+                yield product
+        pagination = results.get("pagination") if isinstance(results, dict) else None
+        if pagination:
+            total_pages = int(pagination.get("totalPages") or pagination.get("total_pages") or page)
+        else:
+            total_pages = page
+        page += 1
+
+
+def parse_product(product: Dict[str, Any], language: str) -> Optional[Deal]:
+    title = product.get("name") or product.get("title") or product.get("shortName")
+    if not title:
+        return None
+
+    prices = product.get("prices") if isinstance(product.get("prices"), dict) else {}
+    sale_price = coerce_price(product.get("salePrice"))
+    if not sale_price and isinstance(prices, dict):
+        sale_price = coerce_price(
+            prices.get("current")
+            or prices.get("sale")
+            or prices.get("value")
+            or prices.get("price")
+        )
+    regular_price = coerce_price(product.get("regularPrice"))
+    if not regular_price and isinstance(prices, dict):
+        regular_price = coerce_price(
+            prices.get("regular")
+            or prices.get("was")
+            or prices.get("base")
+            or prices.get("original")
+        )
+    if not regular_price:
+        regular_price = sale_price
+    if not sale_price or not regular_price:
+        return None
+
+    image = None
+    for key in ("thumbnailImage", "image", "imageUrl", "primaryImage"):
+        candidate = product.get(key)
+        if isinstance(candidate, str) and candidate:
+            image = candidate
+            break
+    if not image and isinstance(product.get("images"), dict):
+        images = product["images"]
+        for key in ("main", "primary", "thumbnail"):
+            candidate = images.get(key)
+            if isinstance(candidate, str) and candidate:
+                image = candidate
+                break
+        if not image and isinstance(images.get("gallery"), list):
+            for entry in images["gallery"]:
+                if isinstance(entry, str) and entry:
+                    image = entry
+                    break
+                if isinstance(entry, dict):
+                    candidate = entry.get("href") or entry.get("url")
+                    if isinstance(candidate, str) and candidate:
+                        image = candidate
+                        break
+            if not image and isinstance(images.get("thumbnails"), list):
+                for entry in images["thumbnails"]:
+                    if isinstance(entry, str) and entry:
+                        image = entry
+                        break
+
+    url = product.get("productUrl") or product.get("url") or product.get("link")
+    if isinstance(url, str) and url:
+        url = urljoin(BASE_DOMAIN, url)
+    else:
+        return None
+
+    sku = None
+    for key in ("sku", "skuId", "skuNumber", "code", "id"):
+        candidate = product.get(key)
+        if isinstance(candidate, (str, int)):
+            sku = str(candidate)
+            break
+
+    return Deal(
+        title=str(title).strip(),
+        price=float(regular_price),
+        sale_price=float(sale_price),
+        url=url,
+        image=image,
+        sku=sku,
+    )
+
+
+def scrape_store(
+    store: Store,
+    *,
+    language: str,
+    max_retries: int,
+    timeout: int,
+    delay_range: Tuple[float, float],
+    page_size: int,
+) -> List[Deal]:
+    deals: List[Deal] = []
+    seen_skus: Set[str] = set()
+    for product in iter_products(
+        store,
+        language=language,
+        max_retries=max_retries,
+        timeout=timeout,
+        delay_range=delay_range,
+        page_size=page_size,
+    ):
+        deal = parse_product(product, language)
+        if not deal:
+            continue
+        if deal.sku and deal.sku in seen_skus:
+            continue
+        if deal.sku:
+            seen_skus.add(deal.sku)
+        deals.append(deal)
+    return deals
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Extraction des aubaines en liquidation des magasins Best Buy au Québec.",
+    )
+    parser.add_argument(
+        "--store",
+        dest="stores",
+        action="append",
+        default=[],
+        help="Filtre les magasins (ville, identifiant ou slug).",
+    )
+    parser.add_argument(
+        "--language",
+        choices=sorted(LANGUAGE_ALIASES),
+        default=DEFAULT_LANGUAGE,
+        help="Langue des résultats (fr ou en).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Dossier de sortie pour les fichiers JSON individuels.",
+    )
+    parser.add_argument(
+        "--aggregated-path",
+        type=Path,
+        default=None,
+        help="Chemin du fichier d'agrégation global (défaut: data/best-buy/liquidations.json).",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=DEFAULT_PAGE_SIZE,
+        help="Nombre d'articles par page à demander (défaut: 100).",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help="Nombre maximal de tentatives HTTP par requête.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help="Délai d'attente (secondes) pour les requêtes HTTP.",
+    )
+    parser.add_argument(
+        "--delay",
+        nargs=2,
+        type=float,
+        metavar=("MIN", "MAX"),
+        default=None,
+        help="Intervalle (secondes) utilisé entre les tentatives.",
+    )
+    return parser
+
+
+def ensure_directory(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def save_deals(path: Path, deals: Iterable[Deal], store: Store) -> None:
+    ensure_directory(path)
+    payload = [deal.to_payload(store) for deal in deals]
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    stores = load_stores()
+    filters = set()
+    for token in args.stores:
+        filters.update(normalize_token(token))
+    selected = [store for store in stores if store.matches_filters(filters)]
+    if not selected:
+        parser.error("Aucun magasin ne correspond aux filtres fournis.")
+
+    delay_range = tuple(args.delay) if args.delay else DEFAULT_DELAY_RANGE
+    aggregated_path = args.aggregated_path or args.output_dir / DEFAULT_AGGREGATED_FILENAME
+
+    aggregated: List[Dict[str, Any]] = []
+
+    for store in selected:
+        print(f"→ Extraction pour {store.label} ({store.store_number})…")
+        deals = scrape_store(
+            store,
+            language=args.language,
+            max_retries=args.max_retries,
+            timeout=args.timeout,
+            delay_range=(float(delay_range[0]), float(delay_range[1])),
+            page_size=args.page_size,
+        )
+        deals.sort(key=lambda deal: (deal.sale_price, deal.price, deal.title))
+        output_path = args.output_dir / f"{store.output_stem()}.json"
+        save_deals(output_path, deals, store)
+        aggregated.extend(deal.to_payload(store) for deal in deals)
+        print(f"   {len(deals)} offre(s) sauvegardée(s) dans {output_path}.")
+
+    aggregated.sort(key=lambda entry: (entry.get("city", ""), entry.get("salePrice", 0.0)))
+    ensure_directory(aggregated_path)
+    with aggregated_path.open("w", encoding="utf-8") as handle:
+        json.dump(aggregated, handle, ensure_ascii=False, indent=2)
+    print(f"Fichier agrégé mis à jour: {aggregated_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a requests-based scraper for Best Buy clearance pages that outputs per-store and aggregate JSON files
- curate a Quebec store manifest for Best Buy locations
- document scraper usage in data and incoming README files

## Testing
- python -m compileall incoming/best_buy_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68e63bcd57c0832eacc2a47b2d22d7a8