### PR TITLE
Add scheduled workflow for Best Buy clearance scraper

### DIFF
--- a/.github/workflows/bestbuy-liquidations.yml
+++ b/.github/workflows/bestbuy-liquidations.yml
@@ -1,0 +1,35 @@
+name: Mise à jour des liquidations Best Buy
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    name: Télécharger les liquidations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Récupérer le dépôt
+        uses: actions/checkout@v4
+
+      - name: Configurer Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Lancer le scraper Best Buy
+        run: python incoming/bestbuy_clearance_scraper.py --output data/best-buy/liquidations.json
+
+      - name: Publier le jeu de données
+        uses: actions/upload-artifact@v4
+        with:
+          name: liquidations-best-buy
+          path: data/best-buy/liquidations.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the Best Buy clearance scraper every day at 03:00 UTC
- install the Python requirements and upload the resulting dataset as an artifact for download

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63e9aafd4832e90d74bca4c3b11f2